### PR TITLE
Use different DB user for MCP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ URL=http://127.0.0.1:8123
 DATABASE=default
 USERNAME=default
 PASSWORD=
+MCP_USERNAME=default
+MCP_PASSWORD=
 MAX_LIMIT=10000
 
 # Logging

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ URL=http://127.0.0.1:8123
 DATABASE=default
 USERNAME=default
 PASSWORD=
+MCP_USERNAME=default
+MCP_PASSWORD=
 MAX_LIMIT=10000
 
 # Logging

--- a/src/clickhouse/client.ts
+++ b/src/clickhouse/client.ts
@@ -1,11 +1,12 @@
 import { createClient } from "@clickhouse/client-web";
 import { APP_NAME, config } from "../config.js";
+import { WebClickHouseClientConfigOptions } from "@clickhouse/client-web/dist/config.js";
 
 // TODO: Check how to abort previous queries if haven't returned yet
-const client = (database?: string) => {
+const client = (custom_config?: WebClickHouseClientConfigOptions) => {
     const c = createClient({
         ...config,
-        database,
+        ...custom_config,
         clickhouse_settings: {
             allow_experimental_object_type: 1,
             output_format_json_quote_64bit_integers: 0,

--- a/src/clickhouse/makeQuery.ts
+++ b/src/clickhouse/makeQuery.ts
@@ -5,19 +5,19 @@ import { logger } from "../logger.js";
 
 import type { ResponseJSON } from "@clickhouse/client-web";
 import { isProgressRow, ProgressRow } from "@clickhouse/client";
-import { config } from "../config.js";
 import { Progress } from 'fastmcp';
+import { WebClickHouseClientConfigOptions } from '@clickhouse/client-web/dist/config.js';
 
 export async function makeQuery<T = unknown>(
     query: string,
     query_params?: Record<string, unknown>,
-    database?: string,
+    overwrite_config?: WebClickHouseClientConfigOptions,
     reportProgressMCP?: (progress: Progress) => Promise<void>
 ) {
     const query_id = crypto.randomUUID();
-    logger.trace({ query_id, database, query, query_params });
+    logger.trace({ query_id, overwrite_config, query, query_params });
 
-    const response = await client(database).query({ query, query_params, format: "JSONEachRowWithProgress", query_id });
+    const response = await client(overwrite_config).query({ query, query_params, format: "JSONEachRowWithProgress", query_id });
     const stream = response.stream<T>();
     const data: T[] = [];
     let rows_before_limit_at_least = 0;

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,8 @@ export const DEFAULT_URL = "http://localhost:8123";
 export const DEFAULT_DATABASE = "default";
 export const DEFAULT_USERNAME = "default";
 export const DEFAULT_PASSWORD = "";
+export const DEFAULT_MCP_USERNAME = "default";
+export const DEFAULT_MCP_PASSWORD = "";
 export const DEFAULT_MAX_LIMIT = 10000;
 export const DEFAULT_LARGE_QUERIES_ROWS_TRIGGER = 10_000_000; // 10M rows
 export const DEFAULT_LARGE_QUERIES_BYTES_TRIGGER = 1_000_000_000; // 1Gb
@@ -53,8 +55,10 @@ const opts = program
     .addOption(new Option("--sse-endpoint <string>", "Endpoint name for the MCP SSE server").env("SSE_ENDPOINT").default(DEFAULT_SSE_ENDPOINT))
     .addOption(new Option("--url <string>", "Database HTTP hostname").env("URL").default(DEFAULT_URL))
     .addOption(new Option("--database <string>", "The database to use inside ClickHouse").env("DATABASE").default(DEFAULT_DATABASE))
-    .addOption(new Option("--username <string>", "Database user").env("USERNAME").default(DEFAULT_USERNAME))
-    .addOption(new Option("--password <string>", "Password associated with the specified username").env("PASSWORD").default(DEFAULT_PASSWORD))
+    .addOption(new Option("--username <string>", "Database user for API").env("USERNAME").default(DEFAULT_USERNAME))
+    .addOption(new Option("--password <string>", "Password associated with the specified API username").env("PASSWORD").default(DEFAULT_PASSWORD))
+    .addOption(new Option("--mcp-username <string>", "Database user for MCP").env("MCP_USERNAME").default(DEFAULT_MCP_USERNAME))
+    .addOption(new Option("--mcp-password <string>", "Password associated with the specified MCP username").env("MCP_PASSWORD").default(DEFAULT_MCP_PASSWORD))
     .addOption(new Option("--max-limit <number>", "Maximum LIMIT queries").env("MAX_LIMIT").default(DEFAULT_MAX_LIMIT))
     .addOption(new Option("--max-rows-trigger <number>", "Queries returning rows above this treshold will be considered large queries for metrics").env("LARGE_QUERIES_ROWS_TRIGGER").default(DEFAULT_LARGE_QUERIES_ROWS_TRIGGER))
     .addOption(new Option("--max-bytes-trigger <number>", "Queries processing bytes above this treshold will be considered large queries for metrics").env("LARGE_QUERIES_BYTES_TRIGGER").default(DEFAULT_LARGE_QUERIES_BYTES_TRIGGER))
@@ -73,6 +77,8 @@ export const config = z.object({
     database: z.string(),
     username: z.string(),
     password: z.string(),
+    mcpUsername: z.string(),
+    mcpPassword: z.string(),
     maxLimit: z.coerce.number(),
     maxRowsTrigger: z.coerce.number(),
     maxBytesTrigger: z.coerce.number(),

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -3,11 +3,12 @@
 import { formatQueryParams } from "@clickhouse/client-common";
 import { Progress, UserError } from "fastmcp";
 import { makeQuery } from "../clickhouse/makeQuery.js";
+import { config } from "../config.js";
 
 export async function runSQLMCP(sql: string, reportProgress?: (progress: Progress) => Promise<void>): Promise<string> {
     let response;
     try {
-        response = await makeQuery(sql, {}, undefined, reportProgress);
+        response = await makeQuery(sql, {}, { username: config.mcpUsername, password: config.mcpPassword }, reportProgress);
     } catch (error) {
         throw new UserError(`Error while running SQL query: ${error}`);
     }

--- a/src/routes/networks.ts
+++ b/src/routes/networks.ts
@@ -1,5 +1,5 @@
-import { Hono } from 'hono'
-import { describeRoute } from 'hono-openapi'
+import { Hono } from 'hono';
+import { describeRoute } from 'hono-openapi';
 import { resolver } from 'hono-openapi/zod';
 import { NetworksRegistry } from "@pinax/graph-networks-registry";
 import { z } from 'zod';
@@ -36,15 +36,17 @@ const openapi = describeRoute({
         200: {
             description: 'Successful Response',
             content: {
-                'application/json': { schema: resolver(responseSchema), example: {
-                    networks: [
-                        getNetwork("mainnet"),
-                    ]
-                } },
+                'application/json': {
+                    schema: resolver(responseSchema), example: {
+                        networks: [
+                            getNetwork("mainnet"),
+                        ]
+                    }
+                },
             },
         },
     },
-})
+});
 
 export function getNetwork(id: string) {
     const network = registry.getNetworkById(id);
@@ -65,10 +67,10 @@ export function getNetwork(id: string) {
 
 export async function getNetworksIds() {
     const query = `SHOW DATABASES LIKE '%db_out'`;
-    const result = await client(config.database).query({ query, format: "JSONEachRow" });
+    const result = await client({ database: config.database }).query({ query, format: "JSONEachRow" });
     const network_ids = new Set<string>([DEFAULT_NETWORK_ID]);
 
-    for ( const row of await result.json<{name: string}>()) {
+    for (const row of await result.json<{ name: string; }>()) {
         const network_id = row.name.split(":")[0];
         if (network_id) network_ids.add(network_id);
     }
@@ -77,12 +79,12 @@ export async function getNetworksIds() {
 
 // store networks in memory
 // this is a workaround to avoid loading networks from the database on every request
-export const networks = await getNetworksIds()
+export const networks = await getNetworksIds();
 export const networkIdSchema = z.enum([networks.at(0) ?? DEFAULT_NETWORK_ID, ...networks.slice(1)]);
 logger.trace(`Supported networks:\n`, networks);
 
 route.get('/networks', openapi, async (c) => {
-    return c.json({networks: networks.map(id => getNetwork(id))});
+    return c.json({ networks: networks.map(id => getNetwork(id)) });
 });
 
 export default route;

--- a/src/routes/token/balances/evm.ts
+++ b/src/routes/token/balances/evm.ts
@@ -83,7 +83,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
     const query = sqlQueries['balances_for_account']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);
 
-    return makeUsageQuery(c, [query], { address, network_id, contract }, database);
+    return makeUsageQuery(c, [query], { address, network_id, contract }, { database });
 });
 
 export default route;

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -81,7 +81,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
     const query = sqlQueries['holders_for_contract']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);
 
-    return makeUsageQuery(c, [query], { contract, network_id }, database);
+    return makeUsageQuery(c, [query], { contract, network_id }, { database });
 });
 
 export default route;

--- a/src/routes/token/tokens/evm.ts
+++ b/src/routes/token/tokens/evm.ts
@@ -7,7 +7,7 @@ import { EVM_SUBSTREAMS_VERSION } from '../index.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { DEFAULT_NETWORK_ID } from '../../../config.js';
-import * as web3icons from "@web3icons/core"
+import * as web3icons from "@web3icons/core";
 import { networkIdSchema } from '../../networks.js';
 
 const route = new Hono();
@@ -87,17 +87,17 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
     const query = sqlQueries['tokens_for_contract']?.['evm'];
     if (!query) return c.json({ error: 'Query for tokens could not be loaded' }, 500);
 
-    type Data = {symbol: string, icon: {web3icon: string}}
-    const result = await makeUsageQueryJson<Data>(c, [query], { contract, network_id }, database);
+    type Data = { symbol: string, icon: { web3icon: string; }; };
+    const result = await makeUsageQueryJson<Data>(c, [query], { contract, network_id }, { database });
 
     // inject Web3 Icons
-    if ( 'data' in result ) {
+    if ('data' in result) {
         result.data.forEach((row: Data) => {
             const web3icon = findIcon(row.symbol);
             if (web3icon) {
                 row.icon = {
                     web3icon
-                }
+                };
             }
         });
         return c.json(result);
@@ -108,11 +108,11 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 function findIcon(symbol?: string) {
     if (!symbol) return null;
     for (const token in web3icons.svgs.tokens.mono) {
-        if ( token === symbol ) {
-            return token
+        if (token === symbol) {
+            return token;
         }
     }
-    return null
+    return null;
 }
 
 export default route;

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -89,7 +89,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
     const query = sqlQueries['transfers_for_account']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);
 
-    return makeUsageQuery(c, [query], { address, age, network_id, contract }, database);
+    return makeUsageQuery(c, [query], { address, age, network_id, contract }, { database });
 });
 
 export default route;


### PR DESCRIPTION
- Change `makeQuery` and `createClient` definitions to more broadly accept custom configuration
- New environment variable and CLI options:
  - `MCP_USERNAME` / `--mcp-username`
  - `MCP_PASSWORD` / `--mcp-password`
- `USERNAME` / `PASSWORD` not changed, still references the API DB user
- Update `.env` examples