### PR TITLE
Get list of networks from env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,5 @@ VERBOSE=true
 
 # Bun request timeout in seconds
 BUN_IDLE_REQUEST_TIMEOUT=60
+
+NETWORKS=mainnet,bsc,base,optimism,arbitrum-one

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": false,
+  "files.insertFinalNewline": false
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,7 @@ export const DEFAULT_MAX_AGE = 180;
 export const DEFAULT_PAGE = 1;
 export const DEFAULT_LIMIT = 10;
 export const DEFAULT_NETWORK_ID = "mainnet";
+export const DEFAULT_NETWORKS = DEFAULT_NETWORK_ID;
 
 // GitHub metadata
 const GIT_COMMIT = (process.env.GIT_COMMIT ?? await $`git rev-parse HEAD`.text()).replace(/\n/, "").slice(0, 7);
@@ -43,6 +44,8 @@ export const APP_NAME = pkg.name;
 export const APP_DESCRIPTION = pkg.description;
 export const APP_VERSION = `${GIT_APP.version}+${GIT_APP.commit} (${GIT_APP.date})`;
 
+export const DB_SUFFIX = "evm-tokens@v1.9.0:db_out";
+
 // parse command line options
 const opts = program
     .name(pkg.name)
@@ -57,6 +60,7 @@ const opts = program
     .addOption(new Option("--database <string>", "The database to use inside ClickHouse").env("DATABASE").default(DEFAULT_DATABASE))
     .addOption(new Option("--username <string>", "Database user for API").env("USERNAME").default(DEFAULT_USERNAME))
     .addOption(new Option("--password <string>", "Password associated with the specified API username").env("PASSWORD").default(DEFAULT_PASSWORD))
+    .addOption(new Option("--networks <string>", "Supported The Graph Network IDs").env("NETWORKS").default(DEFAULT_NETWORKS))
     .addOption(new Option("--mcp-username <string>", "Database user for MCP").env("MCP_USERNAME").default(DEFAULT_MCP_USERNAME))
     .addOption(new Option("--mcp-password <string>", "Password associated with the specified MCP username").env("MCP_PASSWORD").default(DEFAULT_MCP_PASSWORD))
     .addOption(new Option("--max-limit <number>", "Maximum LIMIT queries").env("MAX_LIMIT").default(DEFAULT_MAX_LIMIT))
@@ -77,6 +81,7 @@ export const config = z.object({
     database: z.string(),
     username: z.string(),
     password: z.string(),
+    networks: z.string().transform((networks) => networks.split(',')),
     mcpUsername: z.string(),
     mcpPassword: z.string(),
     maxLimit: z.coerce.number(),

--- a/src/inject/prices.ts
+++ b/src/inject/prices.ts
@@ -1,6 +1,6 @@
 import client from "../clickhouse/client.js";
+import { DB_SUFFIX } from "../config.js";
 import { logger } from "../logger.js";
-import { EVM_SUBSTREAMS_VERSION } from "../routes/token/index.js";
 import { ApiErrorResponse, ApiUsageResponse } from "../types/zod.js";
 
 interface Data {
@@ -35,7 +35,7 @@ interface ComputedPrice {
 const LOW_LIQUIDITY_CHECK = 10000; // $10K
 
 export async function injectPrices(response: ApiUsageResponse|ApiErrorResponse, network_id: string, contract?: string) {
-    const database = `${network_id}:${EVM_SUBSTREAMS_VERSION}`;
+    const database = `${network_id}:${DB_SUFFIX}`;
     const prices = await getPrices(database);
 
     // Native price

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { escapeSQL, runSQLMCP } from "./utils.js";
 import { Tool } from "fastmcp";
+import { DB_SUFFIX } from "../config.js";
 
 export default [
     {
@@ -8,7 +9,7 @@ export default [
         description: "List available databases",
         parameters: z.object({}), // Always needs a parameter (even if empty)
         execute: async ({ reportProgress }) => {
-            return runSQLMCP("SHOW DATABASES LIKE '%db_out'", reportProgress);
+            return runSQLMCP(`SHOW DATABASES LIKE '%${DB_SUFFIX}'`, reportProgress);
         },
     },
     {

--- a/src/routes/token/balances/evm.ts
+++ b/src/routes/token/balances/evm.ts
@@ -3,10 +3,9 @@ import { describeRoute } from 'hono-openapi';
 import { resolver, validator } from 'hono-openapi/zod';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { evmAddressSchema, paginationQuery, statisticsSchema, walletAddressSchema } from '../../../types/zod.js';
-import { EVM_SUBSTREAMS_VERSION } from '../index.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
-import { DEFAULT_NETWORK_ID } from '../../../config.js';
+import { DB_SUFFIX, DEFAULT_NETWORK_ID } from '../../../config.js';
 import { networkIdSchema } from '../../networks.js';
 import { injectSymbol } from '../../../inject/symbol.js';
 import { injectPrices } from '../../../inject/prices.js';
@@ -86,7 +85,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
 
     const address = parseAddress.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? DEFAULT_NETWORK_ID;
-    const database = `${network_id}:${EVM_SUBSTREAMS_VERSION}`;
+    const database = `${network_id}:${DB_SUFFIX}`;
 
     const contract = c.req.query("contract") ?? '';
 

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -3,7 +3,7 @@ import { describeRoute } from 'hono-openapi';
 import { resolver, validator } from 'hono-openapi/zod';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { evmAddressSchema, statisticsSchema, paginationQuery, orderBySchema, contractAddressSchema } from '../../../types/zod.js';
-import { EVM_SUBSTREAMS_VERSION } from '../index.js';
+import { DB_SUFFIX } from '../../../config.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { DEFAULT_NETWORK_ID } from '../../../config.js';
@@ -87,7 +87,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
     const contract = parseContract.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? DEFAULT_NETWORK_ID;
     const order_by = orderBySchema.safeParse(c.req.query("order_by")).data ?? "desc";
-    const database = `${network_id}:${EVM_SUBSTREAMS_VERSION}`;
+    const database = `${network_id}:${DB_SUFFIX}`;
 
     const query = sqlQueries['holders_for_contract']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);

--- a/src/routes/token/index.ts
+++ b/src/routes/token/index.ts
@@ -4,8 +4,6 @@ import transfers from "./transfers/index.js";
 import holders from "./holders/index.js";
 import tokens from "./tokens/index.js";
 
-export const EVM_SUBSTREAMS_VERSION = "evm-tokens@v1.9.0:db_out";
-
 const router = new Hono()
 
 router.route('/balances', balances)

--- a/src/routes/token/tokens/evm.ts
+++ b/src/routes/token/tokens/evm.ts
@@ -3,7 +3,7 @@ import { describeRoute } from 'hono-openapi';
 import { resolver, validator } from 'hono-openapi/zod';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { contractAddressSchema, evmAddressSchema, statisticsSchema } from '../../../types/zod.js';
-import { EVM_SUBSTREAMS_VERSION } from '../index.js';
+import { DB_SUFFIX } from '../../../config.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { DEFAULT_NETWORK_ID } from '../../../config.js';
@@ -100,7 +100,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 
     const contract = parseContract.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? DEFAULT_NETWORK_ID;
-    const database = `${network_id}:${EVM_SUBSTREAMS_VERSION}`;
+    const database = `${network_id}:${DB_SUFFIX}`;
 
     const query = sqlQueries['tokens_for_contract']?.['evm'];
     if (!query) return c.json({ error: 'Query for tokens could not be loaded' }, 500);

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -3,7 +3,7 @@ import { describeRoute } from 'hono-openapi';
 import { resolver, validator } from 'hono-openapi/zod';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { ageSchema, evmAddressSchema, statisticsSchema, paginationQuery, walletAddressSchema } from '../../../types/zod.js';
-import { EVM_SUBSTREAMS_VERSION } from '../index.js';
+import { DB_SUFFIX } from '../../../config.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { DEFAULT_AGE, DEFAULT_NETWORK_ID } from '../../../config.js';
@@ -96,7 +96,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
     const address = parseAddress.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? DEFAULT_NETWORK_ID;
     const age = ageSchema.safeParse(c.req.query("age")).data ?? DEFAULT_AGE;
-    const database = `${network_id}:${EVM_SUBSTREAMS_VERSION}`;
+    const database = `${network_id}:${DB_SUFFIX}`;
 
     const contract = c.req.query("contract") ?? '';
 


### PR DESCRIPTION
Auto-discovering networks from the database causes potential issues:
- When we start sinking new substreams package into `mainnet:evm-tokens@v1.10:db_out` for example we will have mutlitple "mainnet" databases and it will pick the first one which is wrong.
- while the database backfilling is still ongoing it will produce incomplete results 
- If new network support hasn't been officially announced yet we don't want people to auto-discover it while we are still working on it.

This PR returns "NETWORKS" env variable, i.e. `mainnet,bsc,base,arbitrum-one,optimism` and adds validation against database on start-up.