### PR TITLE
Update `.env` for OpenAPI Server & `DB_EVM_SUFFIX`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # API Server
 PORT=8000
 HOSTNAME=localhost
+IDLE_TIMEOUT=60
 
 # MCP Server
 SSE_PORT=8080
@@ -14,12 +15,14 @@ PASSWORD=
 MCP_USERNAME=default
 MCP_PASSWORD=
 MAX_LIMIT=10000
+NETWORKS=mainnet,bsc,base,optimism,arbitrum-one
+DB_EVM_SUFFIX=evm-tokens@v1.9.0:db_out
+DB_SVM_SUFFIX=svm-tokens@v1.0.0:db_out
+DB_ANTELOPE_SUFFIX=antelope-tokens@v1.0.0:db_out
+
+# OpenAPI
+DISABLE_OPENAPI_SERVERS=false
 
 # Logging
 PRETTY_LOGGING=true
 VERBOSE=true
-
-# Bun request timeout in seconds
-BUN_IDLE_REQUEST_TIMEOUT=60
-
-NETWORKS=mainnet,bsc,base,optimism,arbitrum-one

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ bun test
 # API Server
 PORT=8000
 HOSTNAME=localhost
+IDLE_TIMEOUT=60
 
 # MCP Server
 SSE_PORT=8080
@@ -99,6 +100,13 @@ PASSWORD=
 MCP_USERNAME=default
 MCP_PASSWORD=
 MAX_LIMIT=10000
+NETWORKS=mainnet,bsc,base,optimism,arbitrum-one
+DB_EVM_SUFFIX=evm-tokens@v1.9.0:db_out
+DB_SVM_SUFFIX=svm-tokens@v1.0.0:db_out
+DB_ANTELOPE_SUFFIX=antelope-tokens@v1.0.0:db_out
+
+# OpenAPI
+DISABLE_OPENAPI_SERVERS=false
 
 # Logging
 PRETTY_LOGGING=true

--- a/index.ts
+++ b/index.ts
@@ -32,7 +32,7 @@ app.get('/openapi', openAPISpecs(app, {
             version: APP_VERSION,
             description: 'Power your apps & AI agents with real-time token data.',
         },
-        servers: [
+        servers: config.disableOpenapiServers ? [] : [
             { url: `https://token-api.thegraph.com`, description: `${APP_DESCRIPTION} - Production` },
             { url: `http://localhost:${config.port}`, description: `${APP_DESCRIPTION} - Local` },
         ],
@@ -60,5 +60,5 @@ app.notFound((c: Context) => APIErrorResponse(c, 404, "route_not_found", `Path n
 
 export default {
     ...app,
-    idleTimeout: config.requestIdleTimeout
+    idleTimeout: config.idleTimeout
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "token-api",
     "description": "Token API",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "homepage": "https://github.com/pinax-network/token-api",
     "license": "Apache-2.0",
     "type": "module",

--- a/src/banner.ts
+++ b/src/banner.ts
@@ -1,5 +1,5 @@
 import pkg from "../package.json" with { type: "json" };
-import { APP_VERSION } from "./config.js";
+import { APP_VERSION, config } from "./config.js";
 
 export function banner() {
     let text = `
@@ -13,6 +13,9 @@ export function banner() {
 `;
     text += `                 Token API v${APP_VERSION}\n`
     text += `               ${pkg.homepage}\n`
+    text += `                      ${config.dbEvmSuffix}\n`
+    text += `                      ${config.dbSvmSuffix}\n`
+    text += `                    ${config.dbAntelopeSuffix}\n`
 
     return text;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,15 @@ export const DEFAULT_LIMIT = 10;
 export const DEFAULT_NETWORK_ID = "mainnet";
 export const DEFAULT_NETWORKS = DEFAULT_NETWORK_ID;
 export const DEFAULT_LOW_LIQUIDITY_CHECK = 10000; // $10K USD
+export const DEFAULT_DISABLE_OPENAPI_SERVERS = false;
+
+// Token Substreams
+// https://github.com/pinax-network/substreams-evm-tokens
+export const DEFAULT_DB_EVM_SUFFIX = "evm-tokens@v1.9.0:db_out";
+// https://github.com/pinax-network/substreams-svm-tokens
+export const DEFAULT_DB_SVM_SUFFIX = "svm-tokens@v1.0.0:db_out"; // NOT YET IMPLEMENTED
+// https://github.com/pinax-network/substreams-antelope-tokens
+export const DEFAULT_DB_ANTELOPE_SUFFIX = "antelope-tokens@v1.0.0:db_out"; // NOT YET IMPLEMENTED
 
 // GitHub metadata
 const GIT_COMMIT = (process.env.GIT_COMMIT ?? await $`git rev-parse HEAD`.text()).replace(/\n/, "").slice(0, 7);
@@ -44,8 +53,6 @@ export const GIT_APP = {
 export const APP_NAME = pkg.name;
 export const APP_DESCRIPTION = pkg.description;
 export const APP_VERSION = `${GIT_APP.version}+${GIT_APP.commit} (${GIT_APP.date})`;
-
-export const DB_SUFFIX = "evm-tokens@v1.9.0:db_out";
 
 // parse command line options
 const opts = program
@@ -62,12 +69,16 @@ const opts = program
     .addOption(new Option("--username <string>", "Database user for API").env("USERNAME").default(DEFAULT_USERNAME))
     .addOption(new Option("--password <string>", "Password associated with the specified API username").env("PASSWORD").default(DEFAULT_PASSWORD))
     .addOption(new Option("--networks <string>", "Supported The Graph Network IDs").env("NETWORKS").default(DEFAULT_NETWORKS))
+    .addOption(new Option("--db-evm-suffix <string>", "EVM Token Clickhouse database suffix").env("DB_EVM_SUFFIX").default(DEFAULT_DB_EVM_SUFFIX))
+    .addOption(new Option("--db-svm-suffix <string>", "SVM (Solana) Token Clickhouse database suffix").env("DB_SVM_SUFFIX").default(DEFAULT_DB_SVM_SUFFIX))
+    .addOption(new Option("--db-antelope-suffix <string>", "Antelope Token Clickhouse database suffix").env("DB_ANTELOPE_SUFFIX").default(DEFAULT_DB_ANTELOPE_SUFFIX))
     .addOption(new Option("--mcp-username <string>", "Database user for MCP").env("MCP_USERNAME").default(DEFAULT_MCP_USERNAME))
     .addOption(new Option("--mcp-password <string>", "Password associated with the specified MCP username").env("MCP_PASSWORD").default(DEFAULT_MCP_PASSWORD))
     .addOption(new Option("--max-limit <number>", "Maximum LIMIT queries").env("MAX_LIMIT").default(DEFAULT_MAX_LIMIT))
     .addOption(new Option("--max-rows-trigger <number>", "Queries returning rows above this treshold will be considered large queries for metrics").env("LARGE_QUERIES_ROWS_TRIGGER").default(DEFAULT_LARGE_QUERIES_ROWS_TRIGGER))
     .addOption(new Option("--max-bytes-trigger <number>", "Queries processing bytes above this treshold will be considered large queries for metrics").env("LARGE_QUERIES_BYTES_TRIGGER").default(DEFAULT_LARGE_QUERIES_BYTES_TRIGGER))
-    .addOption(new Option("--request-idle-timeout <number>", "Bun server request idle timeout (seconds)").env("BUN_IDLE_REQUEST_TIMEOUT").default(DEFAULT_IDLE_TIMEOUT))
+    .addOption(new Option("--idle-timeout <number>", "HTTP server request idle timeout (seconds)").env("IDLE_TIMEOUT").default(DEFAULT_IDLE_TIMEOUT))
+    .addOption(new Option("--disable-openapi-servers <boolean>", "Disable OpenAPI servers (used for local testing)").choices(["true", "false"]).env("DISABLE_OPENAPI_SERVERS").default(DEFAULT_DISABLE_OPENAPI_SERVERS))
     .addOption(new Option("--pretty-logging <boolean>", "Enable pretty logging (default JSON)").choices(["true", "false"]).env("PRETTY_LOGGING").default(DEFAULT_PRETTY_LOGGING))
     .addOption(new Option("-v, --verbose <boolean>", "Enable verbose logging").choices(["true", "false"]).env("VERBOSE").default(DEFAULT_VERBOSE))
     .parse()
@@ -83,13 +94,17 @@ export const config = z.object({
     username: z.string(),
     password: z.string(),
     networks: z.string().transform((networks) => networks.split(',')),
+    dbEvmSuffix: z.string(),
+    dbSvmSuffix: z.string(),
+    dbAntelopeSuffix: z.string(),
     mcpUsername: z.string(),
     mcpPassword: z.string(),
     maxLimit: z.coerce.number(),
     maxRowsTrigger: z.coerce.number(),
     maxBytesTrigger: z.coerce.number(),
-    requestIdleTimeout: z.coerce.number(),
+    idleTimeout: z.coerce.number(),
     // `z.coerce.boolean` doesn't parse boolean string values as expected (see https://github.com/colinhacks/zod/issues/1630)
     prettyLogging: z.coerce.string().transform((val) => val.toLowerCase() === "true"),
+    disableOpenapiServers: z.coerce.string().transform((val) => val.toLowerCase() === "true"),
     verbose: z.coerce.string().transform((val) => val.toLowerCase() === "true"),
 }).parse(opts);

--- a/src/inject/prices.ts
+++ b/src/inject/prices.ts
@@ -1,10 +1,7 @@
 import client from "../clickhouse/client.js";
-import { DB_SUFFIX } from "../config.js";
-import { DEFAULT_LOW_LIQUIDITY_CHECK } from "../config.js";
-import { logger } from "../logger.js";
+import { config, DEFAULT_LOW_LIQUIDITY_CHECK } from "../config.js";
 import { ApiErrorResponse, ApiUsageResponse } from "../types/zod.js";
 import { stables, natives } from "./prices.tokens.js";
-import * as symbols from "./symbol.tokens.js";
 
 interface Data {
     address?: string;
@@ -37,7 +34,7 @@ interface ComputedPrice {
 }
 
 export async function injectPrices(response: ApiUsageResponse|ApiErrorResponse, network_id: string, contract?: string) {
-    const database = `${network_id}:${DB_SUFFIX}`;
+    const database = `${network_id}:${config.dbEvmSuffix}`;
     const prices = await getPrices(database);
 
     // Native price

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { escapeSQL, runSQLMCP } from "./utils.js";
 import { Tool } from "fastmcp";
-import { DB_SUFFIX } from "../config.js";
+import { config } from "../config.js";
 
 export default [
     {
@@ -9,7 +9,7 @@ export default [
         description: "List available databases",
         parameters: z.object({}), // Always needs a parameter (even if empty)
         execute: async ({ reportProgress }) => {
-            return runSQLMCP(`SHOW DATABASES LIKE '%${DB_SUFFIX}'`, reportProgress);
+            return runSQLMCP(`SHOW DATABASES LIKE '%${config.dbEvmSuffix}'`, reportProgress);
         },
     },
     {

--- a/src/routes/networks.ts
+++ b/src/routes/networks.ts
@@ -5,7 +5,7 @@ import { NetworksRegistry } from "@pinax/graph-networks-registry";
 import { z } from 'zod';
 import client from '../clickhouse/client.js';
 import { logger } from '../logger.js';
-import { config, DB_SUFFIX, DEFAULT_NETWORK_ID } from '../config.js';
+import { config, DEFAULT_NETWORK_ID } from '../config.js';
 
 const registry = await NetworksRegistry.fromLatestVersion();
 
@@ -69,12 +69,12 @@ async function validateNetworks() {
     if (!config.networks.includes(DEFAULT_NETWORK_ID)) {
         throw new Error(`Default network ${DEFAULT_NETWORK_ID} not found`);
     }
-    const query = `SHOW DATABASES LIKE '%:${DB_SUFFIX}'`;
+    const query = `SHOW DATABASES LIKE '%:${config.dbEvmSuffix}'`;
     const result = await client({ database: config.database }).query({ query, format: "JSONEachRow" });
     const dbs = await result.json<{ name: string; }>();
     for (const network of config.networks) {
-        if (!dbs.find(db => db.name === `${network}:${DB_SUFFIX}`)) {
-            throw new Error(`Database ${network}:${DB_SUFFIX} not found`);
+        if (!dbs.find(db => db.name === `${network}:${config.dbEvmSuffix}`)) {
+            throw new Error(`Database ${network}:${config.dbEvmSuffix} not found`);
         }
     }
 }

--- a/src/routes/token/balances/evm.ts
+++ b/src/routes/token/balances/evm.ts
@@ -5,7 +5,7 @@ import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.
 import { evmAddressSchema, paginationQuery, statisticsSchema, walletAddressSchema, networkIdSchema } from '../../../types/zod.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
-import { DB_SUFFIX, DEFAULT_NETWORK_ID } from '../../../config.js';
+import { config, DEFAULT_NETWORK_ID } from '../../../config.js';
 import { injectSymbol } from '../../../inject/symbol.js';
 import { injectPrices } from '../../../inject/prices.js';
 
@@ -84,7 +84,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
 
     const address = parseAddress.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? DEFAULT_NETWORK_ID;
-    const database = `${network_id}:${DB_SUFFIX}`;
+    const database = `${network_id}:${config.dbEvmSuffix}`;
 
     const contract = c.req.query("contract") ?? '';
 

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -3,10 +3,9 @@ import { describeRoute } from 'hono-openapi';
 import { resolver, validator } from 'hono-openapi/zod';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { evmAddressSchema, statisticsSchema, paginationQuery, orderBySchema, contractAddressSchema, networkIdSchema } from '../../../types/zod.js';
-import { DB_SUFFIX } from '../../../config.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
-import { DEFAULT_NETWORK_ID } from '../../../config.js';
+import { config, DEFAULT_NETWORK_ID } from '../../../config.js';
 import { injectSymbol } from '../../../inject/symbol.js';
 import { injectPrices } from '../../../inject/prices.js';
 
@@ -86,7 +85,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
     const contract = parseContract.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? DEFAULT_NETWORK_ID;
     const order_by = orderBySchema.safeParse(c.req.query("order_by")).data ?? "desc";
-    const database = `${network_id}:${DB_SUFFIX}`;
+    const database = `${network_id}:${config.dbEvmSuffix}`;
 
     const query = sqlQueries['holders_for_contract']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);

--- a/src/routes/token/ohlc/prices/evm.ts
+++ b/src/routes/token/ohlc/prices/evm.ts
@@ -5,7 +5,7 @@ import { handleUsageQueryError, makeUsageQueryJson } from '../../../../handleQue
 import { evmAddressSchema, statisticsSchema, paginationQuery, contractAddressSchema, intervalSchema, timestampSchema, networkIdSchema } from '../../../../types/zod.js';
 import { sqlQueries } from '../../../../sql/index.js';
 import { z } from 'zod';
-import { DB_SUFFIX, DEFAULT_NETWORK_ID } from '../../../../config.js';
+import { config, DEFAULT_NETWORK_ID } from '../../../../config.js';
 import { stables } from '../../../../inject/prices.tokens.js';
 
 const route = new Hono();
@@ -69,7 +69,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 
     const contract = parseContract.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? DEFAULT_NETWORK_ID;
-    const database = `${network_id}:${DB_SUFFIX}`;
+    const database = `${network_id}:${config.dbEvmSuffix}`;
 
     const query = sqlQueries['ohlcv_prices_usd_for_contract']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for OHLCV prices could not be loaded' }, 500);

--- a/src/routes/token/tokens/evm.ts
+++ b/src/routes/token/tokens/evm.ts
@@ -3,10 +3,9 @@ import { describeRoute } from 'hono-openapi';
 import { resolver, validator } from 'hono-openapi/zod';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { contractAddressSchema, evmAddressSchema, statisticsSchema, networkIdSchema } from '../../../types/zod.js';
-import { DB_SUFFIX } from '../../../config.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
-import { DEFAULT_NETWORK_ID } from '../../../config.js';
+import { config, DEFAULT_NETWORK_ID } from '../../../config.js';
 import { injectIcons } from '../../../inject/icon.js';
 import { injectSymbol } from '../../../inject/symbol.js';
 import { injectPrices } from '../../../inject/prices.js';
@@ -99,7 +98,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 
     const contract = parseContract.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? DEFAULT_NETWORK_ID;
-    const database = `${network_id}:${DB_SUFFIX}`;
+    const database = `${network_id}:${config.dbEvmSuffix}`;
 
     const query = sqlQueries['tokens_for_contract']?.['evm'];
     if (!query) return c.json({ error: 'Query for tokens could not be loaded' }, 500);

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -3,10 +3,9 @@ import { describeRoute } from 'hono-openapi';
 import { resolver, validator } from 'hono-openapi/zod';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { ageSchema, evmAddressSchema, statisticsSchema, paginationQuery, walletAddressSchema, networkIdSchema } from '../../../types/zod.js';
-import { DB_SUFFIX } from '../../../config.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
-import { DEFAULT_AGE, DEFAULT_NETWORK_ID } from '../../../config.js';
+import { config, DEFAULT_AGE, DEFAULT_NETWORK_ID } from '../../../config.js';
 import { injectSymbol } from '../../../inject/symbol.js';
 import { injectPrices } from '../../../inject/prices.js';
 
@@ -95,7 +94,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
     const address = parseAddress.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? DEFAULT_NETWORK_ID;
     const age = ageSchema.safeParse(c.req.query("age")).data ?? DEFAULT_AGE;
-    const database = `${network_id}:${DB_SUFFIX}`;
+    const database = `${network_id}:${config.dbEvmSuffix}`;
 
     const contract = c.req.query("contract") ?? '';
 


### PR DESCRIPTION
fixes: https://github.com/pinax-network/token-api/issues/44

- Add `.env` & CLI support for different Database Suffixes for EVM/SVM(Solana)/Antelope
- Allow disabling OpenAPI servers, this allows the Swagger UI to use the current hostname+port as server

## `.env`
```env
# Clickhouse Database
DB_EVM_SUFFIX=evm-tokens@v1.9.0:db_out
DB_SVM_SUFFIX=svm-tokens@v1.0.0:db_out
DB_ANTELOPE_SUFFIX=antelope-tokens@v1.0.0:db_out

# OpenAPI
DISABLE_OPENAPI_SERVERS=false
```