### PR TITLE
Return 500 on database execution timeout

### DIFF
--- a/src/clickhouse/client.ts
+++ b/src/clickhouse/client.ts
@@ -2,6 +2,8 @@ import { createClient } from "@clickhouse/client-web";
 import { APP_NAME, config } from "../config.js";
 import { WebClickHouseClientConfigOptions } from "@clickhouse/client-web/dist/config.js";
 
+export const MAX_EXECUTION_TIME = 10;
+
 // TODO: Check how to abort previous queries if haven't returned yet
 const client = (custom_config?: WebClickHouseClientConfigOptions) => {
     const c = createClient({
@@ -12,7 +14,7 @@ const client = (custom_config?: WebClickHouseClientConfigOptions) => {
             output_format_json_quote_64bit_integers: 0,
             readonly: "1",
             interactive_delay: '500000', // Interval between query progress reports in microseconds
-            max_execution_time: 10, // 10 seconds query timeout to match `fetch` MCP timeout
+            max_execution_time: MAX_EXECUTION_TIME, // 10 seconds query timeout to match `fetch` MCP timeout
         },
         application: APP_NAME,
     });


### PR DESCRIPTION
Previously the API would return 404 on database timeout since no rows where returned in the result.
This fix will return 500 if the elapsed query time statistic is above the `MAX_EXECUTION_TIME` threshold defined in the client config.