### PR TITLE
Optimize swaps and transfers queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "token-api",
     "description": "Token API",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "homepage": "https://github.com/pinax-network/token-api",
     "license": "Apache-2.0",
     "type": "module",
@@ -21,6 +21,11 @@
             "name": "Mathieu Lefebvre",
             "email": "mathieu@pinax.network",
             "url": "https://github.com/Matlefebvre1234/"
+        },
+        {
+            "name": "Yaro Shkvorets",
+            "email": "yaro@pinax.network",
+            "url": "https://github.com/YaroShkvorets/"
         }
     ],
     "scripts": {

--- a/src/handleQuery.ts
+++ b/src/handleQuery.ts
@@ -57,7 +57,7 @@ export async function makeUsageQueryJson<T = unknown>(
             return {
                 status: 500 as ApiErrorResponse["status"],
                 code: "database_timeout" as ApiErrorResponse["code"],
-                message: 'Query took too long. Try adding updating the filters.'
+                message: 'Query took too long. Consider applying startTime and endTime filters.'
             };
         }
 

--- a/src/sql/swaps/evm.sql
+++ b/src/sql/swaps/evm.sql
@@ -33,6 +33,8 @@ SELECT
     s.protocol as protocol,
     {network_id:String} as network_id
 FROM s
-JOIN pools      AS p USING (pool)
-JOIN contracts  AS c0 FINAL ON c0.address = p.token0
-JOIN contracts  AS c1 FINAL ON c1.address = p.token1
+JOIN pools      AS p ON p.pool = s.pool
+    AND ({pool:String}       = '' OR pool           = {pool:String})
+    AND ({protocol:String}   = '' OR protocol       = {protocol:String})
+JOIN contracts  AS c0 ON c0.address = p.token0
+JOIN contracts  AS c1 ON c1.address = p.token1

--- a/src/sql/swaps/evm.sql
+++ b/src/sql/swaps/evm.sql
@@ -1,5 +1,16 @@
 WITH s AS (
-    SELECT  *
+    SELECT
+        block_num,
+        timestamp,
+        transaction_id,
+        caller,
+        pool,
+        sender,
+        recipient,
+        amount0,
+        amount1,
+        price,
+        protocol
     FROM    swaps
     WHERE   timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
         AND ({transaction_id:String} = '' OR transaction_id = {transaction_id:String})
@@ -34,7 +45,7 @@ SELECT
     {network_id:String} as network_id
 FROM s
 JOIN pools      AS p ON p.pool = s.pool
-    AND ({pool:String}       = '' OR pool           = {pool:String})
-    AND ({protocol:String}   = '' OR protocol       = {protocol:String})
+    AND ({pool:String}       = '' OR p.pool           = {pool:String})
+    AND ({protocol:String}   = '' OR p.protocol       = {protocol:String})
 JOIN contracts  AS c0 ON c0.address = p.token0
 JOIN contracts  AS c1 ON c1.address = p.token1

--- a/src/sql/transfers/evm.sql
+++ b/src/sql/transfers/evm.sql
@@ -29,3 +29,4 @@ SELECT
     value / pow(10, decimals) AS value
 FROM t
 JOIN contracts AS c ON c.address = t.contract
+    AND ({contract:String} = '' OR contract = {contract:String})

--- a/src/sql/transfers/evm.sql
+++ b/src/sql/transfers/evm.sql
@@ -1,10 +1,33 @@
 WITH transfers AS (
-    SELECT * FROM erc20_transfers
+    SELECT
+        block_num,
+        timestamp,
+        transaction_id,
+        contract,
+        `from`,
+        `to`,
+        value
+    FROM erc20_transfers
     UNION ALL
-    SELECT * FROM native_transfers
+    SELECT
+        block_num,
+        timestamp,
+        transaction_id,
+        contract,
+        `from`,
+        `to`,
+        value
+    FROM native_transfers
 ),
 t AS (
-    SELECT *
+    SELECT
+        block_num,
+        timestamp,
+        transaction_id,
+        contract,
+        `from`,
+        `to`,
+        value
     FROM transfers
     WHERE   timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
         AND ({transaction_id:String} = '' OR transaction_id = {transaction_id:String})
@@ -29,4 +52,4 @@ SELECT
     value / pow(10, decimals) AS value
 FROM t
 JOIN contracts AS c ON c.address = t.contract
-    AND ({contract:String} = '' OR contract = {contract:String})
+    AND ({contract:String} = '' OR c.address = {contract:String})


### PR DESCRIPTION
- Remove `FINAL` from token joins
- Add filtering to joined tables - reduced number of rows read 2-10x when filtering by `pool` and `contract`
- Explicitly list column in selects to minimize reads