### PR TITLE
Return empty data array instead of 404

### DIFF
--- a/src/handleQuery.ts
+++ b/src/handleQuery.ts
@@ -61,14 +61,6 @@ export async function makeUsageQueryJson<T = unknown>(
             };
         }
 
-        if (result.data.length === 0) {
-            return {
-                status: 404 as ApiErrorResponse["status"],
-                code: "not_found_data" as ApiErrorResponse["code"],
-                message: 'No data found'
-            };
-        }
-
         const total_results = result.rows_before_limit_at_least ?? 0;
         return {
             data: result.data,


### PR DESCRIPTION
Instead of returning 404 with message and status code when there is no results for a query, return a 200 with empty `data` array in response.

**Before**
```json
{
  "status": 404,
  "code": "not_found_data",
  "message": "No data found"
}
```

**After**
```json
{
  "data": [],
  "statistics": {
    "bytes_read": 110134179,
    "rows_read": 1745869,
    "elapsed": 0.123360055
  },
  "pagination": {
    "previous_page": 1,
    "current_page": 1,
    "next_page": 1,
    "total_pages": 1
  },
  "results": 0,
  "total_results": 0,
  "request_time": "2025-05-05T18:22:53.248Z",
  "duration_ms": 300
}
```