### PR TITLE
Fix missing native balances in SQL

### DIFF
--- a/src/sql/balances_for_account/evm.sql
+++ b/src/sql/balances_for_account/evm.sql
@@ -4,11 +4,11 @@ SELECT
     toString(contract) AS contract,
     toString(new_balance) AS amount,
     new_balance / pow(10, decimals) as value,
-    decimals,
-    trim(symbol) as symbol,
+    if (contract = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', 18, decimals) AS decimals,
+    if (contract = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', 'Native', trim(symbol)) AS symbol,
     {network_id: String} as network_id
 FROM balances FINAL
-JOIN contracts
+LEFT JOIN contracts
     ON balances.contract = contracts.address
 WHERE
     (address = {address: String} AND new_balance > 0)

--- a/src/sql/historical_balances_for_account/evm.sql
+++ b/src/sql/historical_balances_for_account/evm.sql
@@ -20,9 +20,9 @@ ohlc AS (
 )
 SELECT
     datetime,
-    name,
-    symbol,
-    decimals,
+    if (contract = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', 'Native', name) AS name,
+    if (contract = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', 18, decimals) AS decimals,
+    if (contract = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', 'Native', trim(symbol)) AS symbol,
     {network_id: String} as network_id,
     open_raw * pow(10, -decimals) AS open,
     multiIf(
@@ -37,6 +37,6 @@ SELECT
     ) * pow(10, -decimals) AS low,
     close_raw * pow(10, -decimals) AS close
 FROM ohlc AS o
-INNER JOIN contracts AS c ON o.contract = c.address
+LEFT JOIN contracts AS c ON o.contract = c.address
 LIMIT   {limit:int}
 OFFSET  {offset:int}


### PR DESCRIPTION
Balances for native contract (address `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`) where missing due to the `INNER JOIN` on the `contracts` table.