### PR TITLE
Refactor database config handling

### DIFF
--- a/src/banner.ts
+++ b/src/banner.ts
@@ -1,5 +1,5 @@
 import pkg from "../package.json" with { type: "json" };
-import { APP_VERSION, config } from "./config.js";
+import { APP_VERSION } from "./config.js";
 
 export function banner() {
     let text = `
@@ -13,9 +13,6 @@ export function banner() {
 `;
     text += `                 Token API v${APP_VERSION}\n`
     text += `               ${pkg.homepage}\n`
-    text += `                      ${config.dbEvmSuffix}\n`
-    text += `                      ${config.dbSvmSuffix}\n`
-    text += `                    ${config.dbAntelopeSuffix}\n`
 
     return text;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,14 +32,9 @@ export const DEFAULT_NETWORKS = DEFAULT_DEFAULT_NETWORK_ID;
 export const DEFAULT_LOW_LIQUIDITY_CHECK = 10000; // $10K USD
 export const DEFAULT_DISABLE_OPENAPI_SERVERS = false;
 
-// Token Substreams
-// https://github.com/pinax-network/substreams-evm-tokens
-export const DEFAULT_DB_EVM_SUFFIX = "evm-tokens@v1.11.0:db_out";
-export const DEFAULT_DB_EVM_NFT_SUFFIX = "evm-nft-tokens@v0.4.3";
-// https://github.com/pinax-network/substreams-svm-tokens
-export const DEFAULT_DB_SVM_SUFFIX = "svm-tokens@v1.0.0:db_out"; // NOT YET IMPLEMENTED
-// https://github.com/pinax-network/substreams-antelope-tokens
-export const DEFAULT_DB_ANTELOPE_SUFFIX = "antelope-tokens@v1.0.0:db_out"; // NOT YET IMPLEMENTED
+export const DEFAULT_DBS_TOKEN = "mainnet:evm-tokens@v1.14.0";
+export const DEFAULT_DBS_NFT = "mainnet:evm-nft-tokens@v0.4.3";
+export const DEFAULT_DBS_UNISWAP = "mainnet:evm-uniswaps@v0.1.5";
 
 // GitHub metadata
 const GIT_COMMIT = (process.env.GIT_COMMIT ?? await $`git rev-parse HEAD`.text()).replace(/\n/, "").slice(0, 7);
@@ -69,12 +64,10 @@ const opts = program
     .addOption(new Option("--database <string>", "The database to use inside ClickHouse").env("DATABASE").default(DEFAULT_DATABASE))
     .addOption(new Option("--username <string>", "Database user for API").env("USERNAME").default(DEFAULT_USERNAME))
     .addOption(new Option("--password <string>", "Password associated with the specified API username").env("PASSWORD").default(DEFAULT_PASSWORD))
-    .addOption(new Option("--networks <string>", "Supported The Graph Network IDs").env("NETWORKS").default(DEFAULT_NETWORKS))
     .addOption(new Option("--default-network <string>", "Default Network ID").env("DEFAULT_NETWORK_ID").default(DEFAULT_DEFAULT_NETWORK_ID))
-    .addOption(new Option("--db-evm-suffix <string>", "EVM Token Clickhouse database suffix").env("DB_EVM_SUFFIX").default(DEFAULT_DB_EVM_SUFFIX))
-    .addOption(new Option("--db-evm-nft-suffix <string>", "EVM NFT Token Clickhouse database suffix").env("DB_EVM_NFT_SUFFIX").default(DEFAULT_DB_EVM_NFT_SUFFIX))
-    .addOption(new Option("--db-svm-suffix <string>", "SVM (Solana) Token Clickhouse database suffix").env("DB_SVM_SUFFIX").default(DEFAULT_DB_SVM_SUFFIX))
-    .addOption(new Option("--db-antelope-suffix <string>", "Antelope Token Clickhouse database suffix").env("DB_ANTELOPE_SUFFIX").default(DEFAULT_DB_ANTELOPE_SUFFIX))
+    .addOption(new Option("--token-databases <string>", "Token Clickhouse databases").env("DBS_TOKEN").default(DEFAULT_DBS_TOKEN))
+    .addOption(new Option("--nft-databases <string>", "NFT Clickhouse databases").env("DBS_NFT").default(DEFAULT_DBS_NFT))
+    .addOption(new Option("--uniswap-databases <string>", "Uniswap Clickhouse databases").env("DBS_UNISWAP").default(DEFAULT_DBS_UNISWAP))
     .addOption(new Option("--mcp-username <string>", "Database user for MCP").env("MCP_USERNAME").default(DEFAULT_MCP_USERNAME))
     .addOption(new Option("--mcp-password <string>", "Password associated with the specified MCP username").env("MCP_PASSWORD").default(DEFAULT_MCP_PASSWORD))
     .addOption(new Option("--max-limit <number>", "Maximum LIMIT queries").env("MAX_LIMIT").default(DEFAULT_MAX_LIMIT))
@@ -87,7 +80,16 @@ const opts = program
     .parse()
     .opts();
 
-export const config = z.object({
+function parseDatabases(dbs: string): Record<string, string> {
+    return Object.assign({}, ...dbs.split(';').map((db) => {
+        const [network_id, db_suffix] = db.split(':', 2);
+
+        if (network_id && db_suffix)
+            return { [ network_id ]: `${network_id}:${db_suffix}` };
+    }));
+}
+
+let config = z.object({
     port: z.string(),
     hostname: z.string(),
     ssePort: z.coerce.number(),
@@ -96,12 +98,10 @@ export const config = z.object({
     database: z.string(),
     username: z.string(),
     password: z.string(),
-    networks: z.string().transform((networks) => networks.split(',')),
     defaultNetwork: z.string(),
-    dbEvmSuffix: z.string(),
-    dbEvmNftSuffix: z.string(),
-    dbSvmSuffix: z.string(),
-    dbAntelopeSuffix: z.string(),
+    tokenDatabases: z.string().transform(parseDatabases),
+    nftDatabases: z.string().transform(parseDatabases),
+    uniswapDatabases: z.string().transform(parseDatabases),
     mcpUsername: z.string(),
     mcpPassword: z.string(),
     maxLimit: z.coerce.number(),
@@ -112,4 +112,13 @@ export const config = z.object({
     prettyLogging: z.coerce.string().transform((val) => val.toLowerCase() === "true"),
     disableOpenapiServers: z.coerce.string().transform((val) => val.toLowerCase() === "true"),
     verbose: z.coerce.string().transform((val) => val.toLowerCase() === "true"),
-}).parse(opts);
+}).transform((data) => ({
+    ...data,
+    networks: [...new Set([
+        ...Object.keys(data.tokenDatabases),
+        ...Object.keys(data.nftDatabases),
+        ...Object.keys(data.uniswapDatabases)
+    ])]
+})).parse(opts);
+
+export { config };

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,11 +82,16 @@ const opts = program
 
 function parseDatabases(dbs: string): Record<string, string> {
     return Object.assign({}, ...dbs.split(';').map((db) => {
+        if (!db.includes(':')) {
+            console.warn(`Malformed database entry: "${db}". Skipping.`);
+            return null;
+        }
+
         const [network_id, db_suffix] = db.split(':', 2);
 
         if (network_id && db_suffix)
             return { [ network_id ]: `${network_id}:${db_suffix}` };
-    }));
+    }).filter(Boolean));
 }
 
 let config = z.object({

--- a/src/inject/prices.ts
+++ b/src/inject/prices.ts
@@ -34,7 +34,7 @@ interface ComputedPrice {
 }
 
 export async function injectPrices(response: ApiUsageResponse|ApiErrorResponse, network_id: string, contract?: string) {
-    const database = `${network_id}:${config.dbEvmSuffix}`;
+    const database = config.tokenDatabases[network_id];
     const prices = await getPrices(database);
 
     // Native price

--- a/src/inject/prices.ts
+++ b/src/inject/prices.ts
@@ -33,8 +33,12 @@ interface ComputedPrice {
     liquidity_usd: number;
 }
 
-export async function injectPrices(response: ApiUsageResponse|ApiErrorResponse, network_id: string, contract?: string) {
+export async function injectPrices(response: ApiUsageResponse | ApiErrorResponse, network_id: string, contract?: string) {
     const database = config.tokenDatabases[network_id];
+
+    if (!database)
+        throw new Error(`Could not find database for network_id: ${network_id}`);
+
     const prices = await getPrices(database);
 
     // Native price
@@ -43,7 +47,7 @@ export async function injectPrices(response: ApiUsageResponse|ApiErrorResponse, 
     if ('data' in response) {
         response.data.forEach((row: Data) => {
             const address = contract ?? row.contract ?? row.address;
-            if ( !address || !row.symbol ) return;
+            if (!address || !row.symbol) return;
 
             // // Must be native token
             // // Note: Optimism has two native assets `OP` & `WETH`
@@ -53,25 +57,25 @@ export async function injectPrices(response: ApiUsageResponse|ApiErrorResponse, 
 
             // Token price
             const price = computeTokenPrice(prices, address, native_price);
-            if ( !price ) return;
-            const {price_usd, liquidity_usd } = price;
+            if (!price) return;
+            const { price_usd, liquidity_usd } = price;
 
             // USD price
             row.price_usd = price_usd;
 
             // Liquidity check
-            if ( liquidity_usd < DEFAULT_LOW_LIQUIDITY_CHECK ) {
+            if (liquidity_usd < DEFAULT_LOW_LIQUIDITY_CHECK) {
                 row.low_liquidity = true;
             }
 
             // Value in USD
-            if ( row.amount ) {
+            if (row.amount) {
                 const value = Number(row.amount) / 10 ** row.decimals;
                 row.value_usd = value * price_usd;
             }
 
             // Market Cap
-            if ( row.circulating_supply ) {
+            if (row.circulating_supply) {
                 row.market_cap = Number(row.circulating_supply) / 10 ** row.decimals * price_usd;
             }
         });
@@ -89,14 +93,14 @@ function computeNativePrice(prices: Price[], network_id: string): ComputedPrice 
     let token = '';
     let reserve_usd = 0;
     let reserve_native = 0;
-    for ( const price of prices ) {
+    for (const price of prices) {
         // native -> USD
         if (stables.has(price.token0) && natives.has(price.token1)) {
             symbol = price.symbol1;
             token = price.token1;
             reserve_usd += price.reserve0;
             reserve_native += price.reserve1;
-        // USD -> native
+            // USD -> native
         } else if (stables.has(price.token1) && natives.has(price.token0)) {
             symbol = price.symbol0;
             token = price.token0;
@@ -104,9 +108,9 @@ function computeNativePrice(prices: Price[], network_id: string): ComputedPrice 
             reserve_native += price.reserve0;
         }
     }
-    const price_usd = reserve_usd / reserve_native
-    const liquidity_usd = reserve_usd * 2
-    const price = {token, pair: `${symbol}USD`, price_usd, liquidity_usd};
+    const price_usd = reserve_usd / reserve_native;
+    const liquidity_usd = reserve_usd * 2;
+    const price = { token, pair: `${symbol}USD`, price_usd, liquidity_usd };
 
     return price;
 }
@@ -119,37 +123,37 @@ function computeTokenPrice(prices: Price[], token: string, native_price: Compute
     // override prices for natives
     if (natives.has(token)) return native_price;
 
-    for ( const price of prices ) {
+    for (const price of prices) {
         // USD -> token
         if (stables.has(price.token0) && price.token1 == token) {
             symbol = price.symbol1;
             reserve_usd += price.reserve0;
             reserve_token += price.reserve1;
-        // token -> USD
+            // token -> USD
         } else if (stables.has(price.token1) && price.token0 == token) {
             symbol = price.symbol0;
             reserve_usd += price.reserve1;
             reserve_token += price.reserve0;
-        // native -> token -> USD
+            // native -> token -> USD
         } else if (natives.has(price.token0) && price.token1 == token) {
             symbol = price.symbol1;
             reserve_usd += price.reserve0 * native_price.price_usd;
             reserve_token += price.reserve1;
-        // token -> native -> USD
+            // token -> native -> USD
         } else if (natives.has(price.token1) && price.token0 == token) {
             symbol = price.symbol0;
             reserve_usd += price.reserve1 * native_price.price_usd;
             reserve_token += price.reserve0;
         }
     }
-    let price_usd = reserve_usd / reserve_token
+    let price_usd = reserve_usd / reserve_token;
 
     // override prices for stables
-    if (stables.has(token)) price_usd = 1.00
-    if ( !price_usd ) return null;
+    if (stables.has(token)) price_usd = 1.00;
+    if (!price_usd) return null;
 
-    const liquidity_usd = reserve_usd * 2
-    const price = {token, pair: `${symbol}USD`, price_usd, liquidity_usd};
+    const liquidity_usd = reserve_usd * 2;
+    const price = { token, pair: `${symbol}USD`, price_usd, liquidity_usd };
 
     return price;
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -8,8 +8,25 @@ export default [
         name: "list_databases",
         description: "List available databases",
         parameters: z.object({}), // Always needs a parameter (even if empty)
-        execute: async ({ reportProgress }) => {
-            return runSQLMCP(`SHOW DATABASES LIKE '%${config.dbEvmSuffix}'`, reportProgress);
+        execute: async () => {
+            return JSON.stringify(
+                Object.values(config.tokenDatabases).concat(
+                    Object.values(config.nftDatabases),
+                    Object.values(config.uniswapDatabases)
+                ).map((db) => {
+                    const [network, suffix] = db.split(':', 2);
+                    if (!suffix)
+                        throw new Error(`Could not parse suffix for network: ${network}`);
+
+                    const [database, version] = suffix.split('@', 2);
+
+                    return {
+                        network,
+                        database,
+                        version
+                    }
+                })
+            );
         },
     },
     {

--- a/src/routes/networks.ts
+++ b/src/routes/networks.ts
@@ -69,12 +69,15 @@ async function validateNetworks() {
     if (!config.networks.includes(config.defaultNetwork)) {
         throw new Error(`Default network ${config.defaultNetwork} not found`);
     }
-    const query = `SHOW DATABASES LIKE '%:${config.dbEvmSuffix}'`;
+    const query = `SHOW DATABASES`;
     const result = await client({ database: config.database }).query({ query, format: "JSONEachRow" });
     const dbs = await result.json<{ name: string; }>();
     for (const network of config.networks) {
-        if (!dbs.find(db => db.name === `${network}:${config.dbEvmSuffix}`)) {
-            throw new Error(`Database ${network}:${config.dbEvmSuffix} not found`);
+        if (!dbs.find(db => db.name === config.tokenDatabases[network]
+            || db.name === config.nftDatabases[network]
+            || db.name === config.uniswapDatabases[network])
+        ) {
+            throw new Error(`Databases for ${network} not found`);
         }
     }
 }

--- a/src/routes/nft/activities/evm.ts
+++ b/src/routes/nft/activities/evm.ts
@@ -145,7 +145,7 @@ route.get('/', openapi, validator('param', paramSchema), validator('query', quer
 
     // OPTIONAL URL query
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmNftSuffix}`;
+    const database = config.nftDatabases[network_id];
 
     const query = sqlQueries['nft_activities']?.['evm'];
     if (!query) return c.json({ error: 'Query could not be loaded' }, 500);

--- a/src/routes/nft/collections_for_contract/evm.ts
+++ b/src/routes/nft/collections_for_contract/evm.ts
@@ -72,7 +72,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 
     // OPTIONAL URL query
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmNftSuffix}`;
+    const database = config.nftDatabases[network_id];
 
     const query = sqlQueries['nft_metadata_for_collection']?.['evm'];
     if (!query) return c.json({ error: 'Query could not be loaded' }, 500);

--- a/src/routes/nft/holders/evm.ts
+++ b/src/routes/nft/holders/evm.ts
@@ -66,7 +66,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 
     // OPTIONAL URL query
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmNftSuffix}`;
+    const database = config.nftDatabases[network_id];
 
     const query = sqlQueries['nft_holders']?.['evm'];
     if (!query) return c.json({ error: 'Query could not be loaded' }, 500);

--- a/src/routes/nft/items/evm.ts
+++ b/src/routes/nft/items/evm.ts
@@ -111,7 +111,7 @@ route.get('/contract/:contract/token_id/:token_id', openapi, validator('param', 
 
     // OPTIONAL URL query
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmNftSuffix}`;
+    const database = config.nftDatabases[network_id];
 
     const query = sqlQueries['nft_metadata_for_token']?.['evm'];
     if (!query) return c.json({ error: 'Query could not be loaded' }, 500);

--- a/src/routes/nft/ownerships_for_account/evm.ts
+++ b/src/routes/nft/ownerships_for_account/evm.ts
@@ -75,7 +75,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
 
     const address = parseAddress.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmNftSuffix}`;
+    const database = config.nftDatabases[network_id];
 
     const query = sqlQueries['nft_ownerships_for_account']?.['evm'];
     if (!query) return c.json({ error: 'Query could not be loaded' }, 500);

--- a/src/routes/nft/sales/evm.ts
+++ b/src/routes/nft/sales/evm.ts
@@ -139,7 +139,7 @@ route.get('/', openapi, validator('param', paramSchema), validator('query', quer
 
     // OPTIONAL URL query
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmNftSuffix}`;
+    const database = config.nftDatabases[network_id];
 
     const query = sqlQueries['nft_sales']?.['evm'];
     if (!query) return c.json({ error: 'Query could not be loaded' }, 500);

--- a/src/routes/token/balances/evm.ts
+++ b/src/routes/token/balances/evm.ts
@@ -84,7 +84,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
 
     const address = parseAddress.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmSuffix}`;
+    const database = config.tokenDatabases[network_id];
 
     const contract = c.req.query("contract") ?? '';
 

--- a/src/routes/token/historical/balances/evm.ts
+++ b/src/routes/token/historical/balances/evm.ts
@@ -83,7 +83,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
     const address = parseAddress.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
     const contracts = parseContracts.data ?? [];
-    const database = `${network_id}:${config.dbEvmSuffix}`;
+    const database = config.tokenDatabases[network_id];
 
     const query = sqlQueries['historical_balances_for_account']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -84,7 +84,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 
     const contract = parseContract.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmSuffix}`;
+    const database = config.tokenDatabases[network_id];
 
     let query = sqlQueries['holders_for_contract']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);

--- a/src/routes/token/ohlc/pools/evm.ts
+++ b/src/routes/token/ohlc/pools/evm.ts
@@ -72,7 +72,7 @@ route.get('/:pool', openapi, validator('param', paramSchema), validator('query',
 
     const pool = parsePool.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = config.tokenDatabases[network_id];
+    const database = config.uniswapDatabases[network_id];
 
     const query = sqlQueries['ohlcv_prices_for_pool']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for OHLCV pool prices could not be loaded' }, 500);

--- a/src/routes/token/ohlc/pools/evm.ts
+++ b/src/routes/token/ohlc/pools/evm.ts
@@ -72,7 +72,7 @@ route.get('/:pool', openapi, validator('param', paramSchema), validator('query',
 
     const pool = parsePool.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmSuffix}`;
+    const database = config.tokenDatabases[network_id];
 
     const query = sqlQueries['ohlcv_prices_for_pool']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for OHLCV pool prices could not be loaded' }, 500);

--- a/src/routes/token/ohlc/prices/evm.ts
+++ b/src/routes/token/ohlc/prices/evm.ts
@@ -73,7 +73,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 
     const contract = parseContract.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = config.tokenDatabases[network_id];
+    const database = config.uniswapDatabases[network_id];
 
     const query = sqlQueries['ohlcv_prices_usd_for_contract']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for OHLCV prices could not be loaded' }, 500);

--- a/src/routes/token/ohlc/prices/evm.ts
+++ b/src/routes/token/ohlc/prices/evm.ts
@@ -73,7 +73,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 
     const contract = parseContract.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmSuffix}`;
+    const database = config.tokenDatabases[network_id];
 
     const query = sqlQueries['ohlcv_prices_usd_for_contract']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for OHLCV prices could not be loaded' }, 500);

--- a/src/routes/token/pools/evm.ts
+++ b/src/routes/token/pools/evm.ts
@@ -121,7 +121,7 @@ route.get('/', openapi, validator('query', querySchema), async (c) => {
     }
 
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmSuffix}`;
+    const database = config.tokenDatabases[network_id];
 
     const query = sqlQueries['pools']?.['evm'];
     if (!query) return c.json({ error: 'Query for tokens could not be loaded' }, 500);

--- a/src/routes/token/swaps/evm.ts
+++ b/src/routes/token/swaps/evm.ts
@@ -168,7 +168,7 @@ route.get('/', openapi, validator('query', querySchema), async (c) => {
     }
 
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmSuffix}`;
+    const database = config.tokenDatabases[network_id];
 
     // -- `time` filter --
     const endTime = c.req.query('endTime') ?? now();

--- a/src/routes/token/tokens/evm.ts
+++ b/src/routes/token/tokens/evm.ts
@@ -96,7 +96,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 
     const contract = parseContract.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmSuffix}`;
+    const database = config.tokenDatabases[network_id];
 
     const query = sqlQueries['tokens_for_contract']?.['evm'];
     if (!query) return c.json({ error: 'Query for tokens could not be loaded' }, 500);

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -117,7 +117,7 @@ route.get('/', openapi, validator('query', querySchema), async (c) => {
 
 
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:${config.dbEvmSuffix}`;
+    const database = config.tokenDatabases[network_id];
 
     let contract = c.req.query("contract") ?? '';
     if (contract) {


### PR DESCRIPTION
Use 3 new config parameters for handling databases:
  - `DBS_TOKEN`
  - `DBS_NFT`
  - `DBS_UNISWAP`

This allows for having different networks with different databases names and versions instead of a single default one for all.
  
**Example**
```env
DBS_TOKEN=mainnet:evm-tokens@v1.14.0;arbitrum-one:evm-tokens@v1.11.0:db_out
DBS_NFT=mainnet:evm-nft-tokens@v0.5.1;optimism:evm-nft-tokens@v0.5.1
DBS_UNISWAP=mainnet:evm-uniswaps@v0.1.5;bsc:evm-uniswaps@v0.1.5
```