### PR TITLE
Update endpoints to use latest databases versions

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -123,7 +123,7 @@ let config = z.object({
         ...Object.keys(data.tokenDatabases),
         ...Object.keys(data.nftDatabases),
         ...Object.keys(data.uniswapDatabases)
-    ])]
+    ])].sort()
 })).parse(opts);
 
 export { config };

--- a/src/handleQuery.ts
+++ b/src/handleQuery.ts
@@ -72,10 +72,23 @@ export async function makeUsageQueryJson<T = unknown>(
             duration_ms: Number(new Date()) - Number(request_time),
         };
     } catch (err) {
+        let message: string;
+        const filter_error_messages = ['Unknown', 'does not exist']
+  
+        if (err instanceof Error)
+            message = err.message;
+        else if (typeof err === 'string')
+            message = err;
+        else
+            message = 'An unknown error occurred';
+
+        if (filter_error_messages.some(w => message.includes(w)))
+            message = 'Endpoint is currently not supported for this network';
+
         return {
             status: 500 as ApiErrorResponse["status"],
             code: "bad_database_response" as ApiErrorResponse["code"],
-            message: `${err}`
+            message
         };
     }
 }

--- a/src/routes/networks.ts
+++ b/src/routes/networks.ts
@@ -51,8 +51,10 @@ const openapi = describeRoute({
 export function getNetwork(id: string) {
     const network = registry.getNetworkById(id);
     if (!network) {
-        throw new Error(`Network ${id} not found`);
+        logger.warn(`Network ${id} not found`);
+        return {};
     }
+
     return {
         id,
         fullName: network.fullName,

--- a/src/routes/token/balances/evm.ts
+++ b/src/routes/token/balances/evm.ts
@@ -84,7 +84,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
 
     const address = parseAddress.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:evm-tokens@v1.11.0:db_out`; // Hotfix
+    const database = config.tokenDatabases[network_id];
 
     const contract = c.req.query("contract") ?? '';
 

--- a/src/routes/token/historical/balances/evm.ts
+++ b/src/routes/token/historical/balances/evm.ts
@@ -83,7 +83,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
     const address = parseAddress.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
     const contracts = parseContracts.data ?? [];
-    const database = `${network_id}:evm-tokens@v1.11.0:db_out`; // Hotfix
+    const database = config.tokenDatabases[network_id];
 
     const query = sqlQueries['historical_balances_for_account']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -84,7 +84,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 
     const contract = parseContract.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:evm-tokens@v1.11.0:db_out`; // Hotfix
+    const database = config.tokenDatabases[network_id];
 
     let query = sqlQueries['holders_for_contract']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);

--- a/src/routes/token/pools/evm.ts
+++ b/src/routes/token/pools/evm.ts
@@ -121,7 +121,7 @@ route.get('/', openapi, validator('query', querySchema), async (c) => {
     }
 
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:evm-tokens@v1.11.0:db_out`; // Hotfix
+    const database = config.uniswapDatabases[network_id];
 
     const query = sqlQueries['pools']?.['evm'];
     if (!query) return c.json({ error: 'Query for tokens could not be loaded' }, 500);

--- a/src/routes/token/swaps/evm.ts
+++ b/src/routes/token/swaps/evm.ts
@@ -168,7 +168,7 @@ route.get('/', openapi, validator('query', querySchema), async (c) => {
     }
 
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:evm-tokens@v1.11.0:db_out`; // Hotfix
+    const database = config.uniswapDatabases[network_id];
 
     // -- `time` filter --
     const endTime = c.req.query('endTime') ?? now();

--- a/src/routes/token/tokens/evm.ts
+++ b/src/routes/token/tokens/evm.ts
@@ -96,7 +96,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
 
     const contract = parseContract.data;
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:evm-tokens@v1.11.0:db_out`; // Hotfix
+    const database = config.tokenDatabases[network_id];
 
     const query = sqlQueries['tokens_for_contract']?.['evm'];
     if (!query) return c.json({ error: 'Query for tokens could not be loaded' }, 500);

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -117,7 +117,7 @@ route.get('/', openapi, validator('query', querySchema), async (c) => {
 
 
     const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? config.defaultNetwork;
-    const database = `${network_id}:evm-tokens@v1.11.0:db_out`; // Hotfix
+    const database = config.tokenDatabases[network_id];
 
     let contract = c.req.query("contract") ?? '';
     if (contract) {

--- a/src/sql/balances_for_account/evm.sql
+++ b/src/sql/balances_for_account/evm.sql
@@ -2,16 +2,14 @@ SELECT
     block_num,
     timestamp as datetime,
     toString(contract) AS contract,
-    toString(new_balance) AS amount,
-    new_balance / pow(10, decimals) as value,
+    toString(balance_raw) AS amount,
+    balance as value,
     decimals,
     trim(symbol) as symbol,
     {network_id: String} as network_id
 FROM balances FINAL
-JOIN contracts
-    ON balances.contract = contracts.address
 WHERE
-    (address = {address: String} AND new_balance > 0)
+    (address = {address: String} AND balance_raw > 0)
     AND ({contract: String} = '' OR contract = {contract: String})
 ORDER BY timestamp DESC
 LIMIT   {limit:int}

--- a/src/sql/historical_balances_for_account/evm.sql
+++ b/src/sql/historical_balances_for_account/evm.sql
@@ -37,6 +37,6 @@ SELECT
     ) * pow(10, -decimals) AS low,
     close_raw * pow(10, -decimals) AS close
 FROM ohlc AS o
-INNER JOIN contracts AS c ON o.contract = c.address
+INNER JOIN erc20_metadata_initialize AS c ON o.contract = c.address
 LIMIT   {limit:int}
 OFFSET  {offset:int}

--- a/src/sql/holders_for_contract/evm.sql
+++ b/src/sql/holders_for_contract/evm.sql
@@ -1,17 +1,18 @@
 SELECT
     block_num,
-    timestamp as datetime,
+    timestamp as last_balance_update,
     address,
-    toString(new_balance) AS amount,
-    new_balance / pow(10, decimals) as value,
+    toString(balance_raw) AS amount,
+    balance as value,
     decimals,
     trim(symbol) as symbol,
     {network_id: String} as network_id
-FROM balances_by_contract FINAL
-JOIN contracts
-    ON balances_by_contract.contract = contracts.address
+FROM balances_by_contract
+FINAL
+JOIN erc20_metadata_initialize
+    ON balances_by_contract.contract = erc20_metadata_initialize.address
 WHERE
-    contract = {contract: String} AND new_balance > 0
+    contract = {contract: String} AND balance_raw > 0
 ORDER BY value DESC
 LIMIT   {limit:int}
 OFFSET  {offset:int}

--- a/src/sql/pools/evm.sql
+++ b/src/sql/pools/evm.sql
@@ -1,7 +1,7 @@
 SELECT
     pools.block_num AS block_num,
     pools.timestamp as datetime,
-    transaction_id,
+    tx_hash AS transaction_id,
     toString(factory) AS factory,
     pool,
     CAST(
@@ -16,8 +16,8 @@ SELECT
     protocol,
     {network_id: String} as network_id
 FROM pools
-JOIN contracts AS c0 ON c0.address = pools.token0
-JOIN contracts AS c1 ON c1.address = pools.token1
+JOIN erc20_metadata_initialize AS c0 ON c0.address = pools.token0
+JOIN erc20_metadata_initialize AS c1 ON c1.address = pools.token1
 WHERE
     isNotNull(c0.symbol) AND isNotNull(c1.symbol) AND
     if ({pool:String} == '', true, pools.pool  = {pool:String}) AND

--- a/src/sql/swaps/evm.sql
+++ b/src/sql/swaps/evm.sql
@@ -2,7 +2,7 @@ WITH s AS (
     SELECT
         block_num,
         timestamp,
-        transaction_id,
+        tx_hash,
         caller,
         pool,
         sender,
@@ -11,9 +11,9 @@ WITH s AS (
         amount1,
         price,
         protocol
-    FROM    swaps
-    WHERE   timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
-        AND ({transaction_id:String} = '' OR transaction_id = {transaction_id:String})
+    FROM swaps
+    WHERE timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
+        AND ({transaction_id:String} = '' OR tx_hash = {transaction_id:String})
         AND ({caller:String}     = '' OR caller         = {caller:String})
         AND ({sender:String}     = '' OR sender         = {sender:String})
         AND ({recipient:String}  = '' OR recipient      = {recipient:String})
@@ -22,31 +22,49 @@ WITH s AS (
     ORDER BY timestamp DESC
     LIMIT   {limit:int}
     OFFSET  {offset:int}
+),
+filtered_pools AS (
+    SELECT
+        pool,
+        factory,
+        token0,
+        token1
+    FROM pools
+    WHERE ({pool:String} = '' OR pool = {pool:String})
+    AND ({protocol:String} = '' OR protocol = {protocol:String})
+),
+p AS (
+    SELECT
+        pool,
+        factory,
+        c0.decimals AS decimals0,
+        c1.decimals AS decimals1,
+        CAST(( p.token0, if(isNull(c0.symbol), '', c0.symbol), c0.decimals ) AS Tuple(address String, symbol  String, decimals UInt8)) AS token0,
+        CAST(( p.token1, if(isNull(c1.symbol), '', c1.symbol), c1.decimals ) AS Tuple(address String, symbol  String, decimals UInt8)) AS token1
+    FROM filtered_pools AS p
+    JOIN erc20_metadata_initialize  AS c0 ON c0.address = p.token0
+    JOIN erc20_metadata_initialize  AS c1 ON c1.address = p.token1
 )
 SELECT
     s.block_num         AS block_num,
     s.timestamp         AS datetime,
     toUnixTimestamp(s.timestamp) as timestamp,
-    s.transaction_id    AS transaction_id,
+    s.tx_hash    AS transaction_id,
     s.caller            AS caller,
     s.pool              AS pool,
     p.factory           AS factory,
-    CAST(( pools.token0, if(isNull(c0.symbol), '', c0.symbol), c0.decimals ) AS Tuple(address String, symbol  String, decimals UInt8)) AS token0,
-    CAST(( pools.token1, if(isNull(c1.symbol), '', c1.symbol), c1.decimals ) AS Tuple(address String, symbol  String, decimals UInt8)) AS token1,
+    token0,
+    token1,
     s.sender,
     s.recipient,
     toString(s.amount0) as amount0,
     toString(s.amount1) as amount1,
-    s.amount0 / pow(10, c0.decimals) AS value0,
-    s.amount1 / pow(10, c1.decimals) AS value1,
-    s.price   / pow(10, c1.decimals - c0.decimals) AS price0,
+    s.amount0 / pow(10, decimals0) AS value0,
+    s.amount1 / pow(10, decimals1) AS value1,
+    s.price   / pow(10, decimals1 - decimals0) AS price0,
     1.0 / price0 AS price1,
     s.protocol as protocol,
     {network_id:String} as network_id
 FROM s
-JOIN pools      AS p ON p.pool = s.pool
-    AND ({pool:String}       = '' OR p.pool           = {pool:String})
-    AND ({protocol:String}   = '' OR p.protocol       = {protocol:String})
-JOIN contracts  AS c0 ON c0.address = p.token0
-JOIN contracts  AS c1 ON c1.address = p.token1
+JOIN p USING (pool)
 ORDER BY timestamp DESC

--- a/src/sql/tokens_for_contract/evm.sql
+++ b/src/sql/tokens_for_contract/evm.sql
@@ -5,14 +5,15 @@ SELECT
     decimals,
     trim(symbol) as symbol,
     name,
-    toString(sum(new_balance)) as circulating_supply,
+    toString(sum(balance)) as circulating_supply,
     count() as holders,
     {network_id: String} as network_id
-FROM balances_by_contract FINAL
-JOIN contracts
-    ON balances_by_contract.contract = contracts.address
+FROM balances_by_contract
+FINAL
+JOIN erc20_metadata_initialize
+    ON balances_by_contract.contract = erc20_metadata_initialize.address
 WHERE
-    contract = {contract: String} AND new_balance > 0
+    contract = {contract: String} AND balance > 0
 GROUP BY contract, symbol, name, decimals
 LIMIT   {limit:int}
 OFFSET  {offset:int}

--- a/src/sql/transfers/evm.sql
+++ b/src/sql/transfers/evm.sql
@@ -1,57 +1,34 @@
-WITH transfers AS (
+WITH
+filtered_transfers AS (
     SELECT
         block_num,
         timestamp,
-        transaction_id,
-        contract,
-        `from`,
-        `to`,
-        value
-    FROM erc20_transfers
-    UNION ALL
-    SELECT
-        block_num,
-        timestamp,
-        transaction_id,
-        contract,
-        `from`,
-        `to`,
-        value
-    FROM native_transfers
-),
-t AS (
-    SELECT
-        block_num,
-        timestamp,
-        transaction_id,
+        tx_hash,
         contract,
         `from`,
         `to`,
         value
     FROM transfers
-    WHERE   timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
-        AND ({transaction_id:String} = '' OR transaction_id = {transaction_id:String})
+    WHERE timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
+        AND ({transaction_id:String} = '' OR tx_hash = {transaction_id:String})
         AND ({from:String} = ''  OR `from` = {from:String})
         AND ({to:String} = ''  OR `to` = {to:String})
         AND ({contract:String} = '' OR contract = {contract:String})
-    ORDER BY timestamp DESC
-    LIMIT   {limit:int}
-    OFFSET  {offset:int}
 )
 SELECT
     t.block_num as block_num,
     t.timestamp as datetime,
     toUnixTimestamp(t.timestamp) as timestamp,
-    toString(t.transaction_id) as transaction_id,
+    toString(t.tx_hash) as transaction_id,
     contract,
     `from`,
     `to`,
-    if (contract = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', 18, c.decimals) AS decimals,
-    if (contract = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', 'Native', c.symbol) AS symbol,
-    toString(t.value) as amount,
-    value / pow(10, decimals) AS value
-FROM t
-LEFT JOIN contracts AS c ON c.address = t.contract
+    decimals,
+    symbol,
+    value
+FROM filtered_transfers AS t
+LEFT JOIN erc20_metadata_initialize AS c ON c.address = t.contract
     AND ({contract:String} = '' OR c.address = {contract:String})
-WHERE isNotNull(decimals)
 ORDER BY timestamp DESC
+LIMIT   {limit:int}
+OFFSET  {offset:int}


### PR DESCRIPTION
- Use `erc20_metadata_initialize` instead of `erc20_metadata` due to MV not updating correctly
- Networks that don't have latest database versions show error message on endpoints not yet supported