### PR TITLE
Prevent duplicates to be counted for NFT collection stats

### DIFF
--- a/src/routes/nft/collections_for_contract/evm.ts
+++ b/src/routes/nft/collections_for_contract/evm.ts
@@ -52,10 +52,10 @@ const openapi = describeRoute({
                                 "contract_creator": "0xe9da256a28630efdc637bfd4c65f0887be1aeda8",
                                 "name": "PudgyPenguins",
                                 "symbol": "PPG",
-                                "owners": 12284,
-                                "total_supply": 29064,
-                                "total_unique_supply": 29064,
-                                "total_transfers": 186252,
+                                "owners": 12258,
+                                "total_supply": 8888,
+                                "total_unique_supply": 8888,
+                                "total_transfers": 185128,
                                 "network_id": "mainnet"
                             }
                         ]

--- a/src/sql/nft_metadata_for_collection/evm.sql
+++ b/src/sql/nft_metadata_for_collection/evm.sql
@@ -6,7 +6,7 @@ WITH erc721 AS (
         m.symbol,
         (
             SELECT
-                count(token_id)
+                uniq(token_id)
             FROM erc721_owners
             WHERE contract = {contract: String}
         ) AS total_supply,
@@ -19,7 +19,7 @@ WITH erc721 AS (
         ) AS owners,
         (
             SELECT
-                count(*)
+                uniq(global_sequence)
             FROM erc721_transfers
             WHERE contract = {contract: String}
         ) AS total_transfers,
@@ -36,7 +36,7 @@ erc1155 AS (
         m.symbol,
         (
             SELECT
-                count(token_id)
+                uniq(token_id)
             FROM erc1155_balances
             WHERE contract = {contract: String} AND balance > 0
         ) AS total_supply,
@@ -54,7 +54,7 @@ erc1155 AS (
         ) AS owners,
         (
             SELECT
-                count(*)
+                uniq(global_sequence)
             FROM erc1155_transfers
             WHERE contract = {contract: String}
         ) AS total_transfers,


### PR DESCRIPTION
Use `uniq` instead of `count`.