### PR TITLE
Add full database name in output of MCP tool

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -18,12 +18,13 @@ export default [
                     if (!suffix)
                         throw new Error(`Could not parse suffix for network: ${network}`);
 
-                    const [database, version] = suffix.split('@', 2);
+                    const [name, version] = suffix.split('@', 2);
 
                     return {
+                        database: db,
                         network,
-                        database,
-                        version
+                        name, 
+                        version,
                     }
                 })
             );


### PR DESCRIPTION
The database naming convention isn't explicit when receiving the output from the `list_databases` tool.
Adds a field with the full name of the database to help the LLM.