### PR TITLE
Update SVM swaps SQL and response

### DIFF
--- a/src/routes/token/swaps/svm.ts
+++ b/src/routes/token/swaps/svm.ts
@@ -35,25 +35,24 @@ const responseSchema = z.object({
         datetime: z.string(),
         timestamp: z.number(),
 
-        // -- chain --
-        network_id: SVM_networkIdSchema,
-
         // -- transaction --
         transaction_id: z.string(),
 
         // -- swap --
-        sender: svmAddressSchema,
         pool: svmAddressSchema,
         token0: tokenSchema,
         token1: tokenSchema,
+        sender: svmAddressSchema,
         amount0: z.string(),
         amount1: z.string(),
-        price0: z.number(),
-        price1: z.number(),
         value0: z.number(),
         value1: z.number(),
-        fee: z.string(),
+        price0: z.number(),
+        price1: z.number(),
         protocol: z.string(),
+
+        // -- chain --
+        network_id: SVM_networkIdSchema,
     })),
     statistics: z.optional(statisticsSchema),
 });
@@ -71,33 +70,30 @@ const openapi = describeRoute({
                     schema: resolver(responseSchema), example: {
                         data: [
                             {
-                                "block_num": 22589391,
-                                "datetime": "2025-05-29 15:47:47",
-                                "timestamp": 1748533667,
-                                "transaction_id": "0x1ce019b0ad129b8bd21b6c83b75de5e5fd7cd07f2ee739ca3198adcbeb61f5a9",
-                                "caller": "0x66a9893cc07d91d95644aedd05d03f95e1dba8af",
-                                "pool": "0xb98437c7ba28c6590dd4e1cc46aa89eed181f97108e5b6221730d41347bc817f",
-                                "factory": "0x000000000004444c5dc75cb358380d2e3de08a90",
+                                "block_num": 351750524,
+                                "datetime": "2025-07-07 16:02:09",
+                                "timestamp": 1751904129,
+                                "transaction_id": "64qhvcRb5siuSVoH7ZoNTVgDqnMcxmPZrw6ZKtTWSjJ6e8sexhT9EpjuwhmzkjjJV9JxegKmr2gD7mkiA3QcnUH6",
+                                "pool": "3LcXtfrBixJu3ZZanoz6DfwFGThZ85ufVJe5co71b4eg",
                                 "token0": {
-                                    "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
-                                    "symbol": "WBTC",
-                                    "decimals": 8
-                                },
-                                "token1": {
-                                    "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-                                    "symbol": "USDC",
+                                    "address": "3tGNX8UMyxy48WQnWr7TQyUBGuwiS6ZcBhPSiR5RYMfM",
+                                    "symbol": "TO IMPLEMENT",
                                     "decimals": 6
                                 },
-                                "sender": "0x66a9893cc07d91d95644aedd05d03f95e1dba8af",
-                                "recipient": null,
-                                "amount0": "-894320",
-                                "amount1": "957798098",
-                                "value0": -0.0089432,
-                                "value1": 957.798098,
-                                "price0": 107417.48517180652,
-                                "price1": 0.00000930947134352077,
-                                "protocol": "uniswap_v4",
-                                "network_id": "mainnet"
+                                "token1": {
+                                    "address": "So11111111111111111111111111111111111111112",
+                                    "symbol": "TO IMPLEMENT",
+                                    "decimals": 9
+                                },
+                                "sender": "B3TehHmo3oWNJxr4VC3D2t8eLRZ7um3tpJCZ7PJKnGYP",
+                                "amount0": "-12042561",
+                                "amount1": "1869917",
+                                "value0": -12.042561,
+                                "value1": 0.001869917,
+                                "price0": 0.006440158039100132,
+                                "price1": 155.2756926039237,
+                                "protocol": "raydium_amm_v4",
+                                "network_id": "solana"
                             }
                         ]
                     }


### PR DESCRIPTION
Remove unnecessary JOIN since `token0` and `token1` are now directly in `swaps` table.