### PR TITLE
Remove `FINAL` for EVM balances SQL

### DIFF
--- a/src/sql/balances_for_account/evm.sql
+++ b/src/sql/balances_for_account/evm.sql
@@ -1,16 +1,17 @@
 SELECT
-    block_num,
-    timestamp as datetime,
+    max(block_num) AS block_num,
+    max(timestamp) AS datetime,
     toString(contract) AS contract,
-    toString(balance_raw) AS amount,
-    balance as value,
+    toString(argMax(balance_raw, timestamp)) AS amount,
+    argMax(balance, timestamp) as value,
     decimals,
     trim(symbol) as symbol,
     {network_id: String} as network_id
-FROM balances FINAL
+FROM balances
 WHERE
     (address = {address: String} AND balance_raw > 0)
     AND ({contract: String} = '' OR contract = {contract: String})
-ORDER BY timestamp DESC
+GROUP BY contract, symbol, decimals
+ORDER BY datetime DESC
 LIMIT   {limit:int}
 OFFSET  {offset:int}


### PR DESCRIPTION
Replace with argMax functions for dealing with duplicates.