### PR TITLE
Fix `Too Large String` error for NFT sales

### DIFF
--- a/src/sql/nft_sales/evm.sql
+++ b/src/sql/nft_sales/evm.sql
@@ -12,7 +12,7 @@ WITH filtered_orders AS (
     FROM seaport_orders
     FINAL
     WHERE   timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
-        AND consideration_token IN {nativeContracts: Array(String)}
+        AND toString(consideration_token) IN {nativeContracts: Array(String)}
         AND offer_token = {contract:String}
         AND ({token_id:String}             = '' OR offer_token_id = {token_id:String})
         AND ({offererAddress:String}    = '' OR offerer        = {offererAddress:String})


### PR DESCRIPTION
Adding Solana address to the list was throwing that error from the database.
Add a String conversion to fix.