### PR TITLE
Add error routes to OpenAPI specs

### DIFF
--- a/src/handleQuery.ts
+++ b/src/handleQuery.ts
@@ -2,7 +2,7 @@ import { Context } from "hono";
 import { APIErrorResponse, computePagination } from "./utils.js";
 import { makeQuery } from "./clickhouse/makeQuery.js";
 import { DEFAULT_LIMIT, DEFAULT_PAGE } from "./config.js";
-import { ApiErrorResponse, ApiUsageResponse, limitSchema, pageSchema } from "./types/zod.js";
+import { ApiErrorResponse, ApiUsageResponse, ClientErrorResponse, limitSchema, pageSchema, ServerErrorResponse } from "./types/zod.js";
 import { WebClickHouseClientConfigOptions } from "@clickhouse/client-web/dist/config.js";
 import { MAX_EXECUTION_TIME } from "./clickhouse/client.js";
 import { ZodError } from "zod";
@@ -56,8 +56,8 @@ export async function makeUsageQueryJson<T = unknown>(
         // Handle query execution timeout
         if (result.statistics && result.statistics.elapsed >= MAX_EXECUTION_TIME) {
             return {
-                status: 504 as ApiErrorResponse["status"],
-                code: "database_timeout" as ApiErrorResponse["code"],
+                status: 504 as ServerErrorResponse["status"],
+                code: "database_timeout" as ServerErrorResponse["code"],
                 message: 'Query took too long. Consider applying more filter parameters if possible.'
             };
         }
@@ -78,8 +78,8 @@ export async function makeUsageQueryJson<T = unknown>(
 
         if (err instanceof ZodError)
             return {
-                status: 400 as ApiErrorResponse["status"],
-                code: "bad_query_input" as ApiErrorResponse["code"],
+                status: 400 as ClientErrorResponse["status"],
+                code: "bad_query_input" as ClientErrorResponse["code"],
                 message: err.issues[0]!.message
             };
         else if (err instanceof Error)
@@ -93,8 +93,8 @@ export async function makeUsageQueryJson<T = unknown>(
         //     message = 'Endpoint is currently not supported for this network';
 
         return {
-            status: 500 as ApiErrorResponse["status"],
-            code: "bad_database_response" as ApiErrorResponse["code"],
+            status: 500 as ServerErrorResponse["status"],
+            code: "bad_database_response" as ServerErrorResponse["code"],
             message
         };
     }

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,9 +1,9 @@
-import { Hono } from 'hono'
-import { describeRoute } from 'hono-openapi'
+import { Hono } from 'hono';
+import { describeRoute } from 'hono-openapi';
 import { resolver } from 'hono-openapi/zod';
-import client from '../clickhouse/client.js'
-import { APIErrorResponse } from '../utils.js'
-import { z } from 'zod'
+import client from '../clickhouse/client.js';
+import { APIErrorResponse, withErrorResponses } from '../utils.js';
+import { z } from 'zod';
 
 const route = new Hono();
 
@@ -13,7 +13,7 @@ const errorSchema = z.object({
     message: z.string(),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     description: 'Get health status of the API',
     tags: ['Monitoring'],
     responses: {
@@ -22,21 +22,9 @@ const openapi = describeRoute({
             content: {
                 'text/plain': { schema: resolver(z.string()), example: 'OK' },
             },
-        },
-        403: {
-            description: 'Authentication Failed',
-            content: { 'application/json': { schema: resolver(errorSchema), example: {status: 403, code: 'authentication_failed' } } }
-        },
-        502: {
-            description: 'Connection Refused',
-            content: { 'application/json': { schema: resolver(errorSchema), example: {status: 502, code: 'connection_refused'} } }
-        },
-        500: {
-            description: 'Database Error',
-            content: { 'application/json': { schema: resolver(errorSchema), example: {status: 500, code: 'bad_database_response'} } }
-        },
+        }
     },
-})
+}));
 
 route.get('/health', openapi, async (c) => {
     const response = await client().ping();

--- a/src/routes/networks.ts
+++ b/src/routes/networks.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import client from '../clickhouse/client.js';
 import { logger } from '../logger.js';
 import { config } from '../config.js';
+import { withErrorResponses } from '../utils.js';
 
 const registry = await NetworksRegistry.fromLatestVersion();
 
@@ -29,7 +30,7 @@ const responseSchema = z.object({
     networks: z.array(networksSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     description: 'Get supported networks of the API',
     tags: ['Monitoring'],
     responses: {
@@ -46,7 +47,7 @@ const openapi = describeRoute({
             },
         },
     },
-});
+}));
 
 export function getNetwork(id: string) {
     const network = registry.getNetworkById(id);

--- a/src/routes/nft/activities/evm.ts
+++ b/src/routes/nft/activities/evm.ts
@@ -6,7 +6,7 @@ import { statisticsSchema, EVM_networkIdSchema, evmAddress, evmAddressSchema, pa
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const querySchema = z.object({
     network_id: EVM_networkIdSchema,
@@ -46,7 +46,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'NFT Activities',
     description: 'Provides NFT Activities (ex: transfers, mints & burns).',
     tags: ['EVM'],
@@ -80,7 +80,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/nft/collections_for_contract/evm.ts
+++ b/src/routes/nft/collections_for_contract/evm.ts
@@ -6,7 +6,7 @@ import { statisticsSchema, EVM_networkIdSchema, evmAddressSchema, PudgyPenguins 
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
     contract: PudgyPenguins,
@@ -32,7 +32,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'NFT Collection',
     description: 'Provides single NFT collection metadata, total supply, owners & total transfers.',
     tags: ['EVM'],
@@ -63,7 +63,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/nft/holders/evm.ts
+++ b/src/routes/nft/holders/evm.ts
@@ -6,7 +6,7 @@ import { statisticsSchema, EVM_networkIdSchema, evmAddressSchema, PudgyPenguins 
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
     contract: PudgyPenguins,
@@ -28,7 +28,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'NFT Holders',
     description: 'Provides NFT holders per contract.',
     tags: ['EVM'],
@@ -54,7 +54,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/nft/items/evm.ts
+++ b/src/routes/nft/items/evm.ts
@@ -6,7 +6,7 @@ import { statisticsSchema, EVM_networkIdSchema, evmAddress, PudgyPenguins, Pudgy
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
     token_id: PudgyPenguinsItem,
@@ -41,7 +41,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'NFT Items',
     description: 'Provides single NFT token metadata, ownership & traits.',
     tags: ['EVM'],
@@ -92,7 +92,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/nft/ownerships_for_account/evm.ts
+++ b/src/routes/nft/ownerships_for_account/evm.ts
@@ -6,7 +6,7 @@ import { statisticsSchema, EVM_networkIdSchema, evmAddress, paginationQuery, Vit
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
     address: Vitalik,
@@ -38,7 +38,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'NFT Ownerships',
     description: 'Provides NFT Ownerships for Account.',
     tags: ['EVM'],
@@ -65,7 +65,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/nft/sales/evm.ts
+++ b/src/routes/nft/sales/evm.ts
@@ -6,7 +6,7 @@ import { statisticsSchema, EVM_networkIdSchema, evmAddress, evmAddressSchema, pa
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 import { natives as nativeSymbols } from '../../../inject/symbol.tokens.js';
 import { natives as nativeContracts } from '../../../inject/prices.tokens.js';
 
@@ -47,7 +47,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'NFT Sales',
     description: 'Provides latest NFT marketplace sales.',
     tags: ['EVM'],
@@ -78,7 +78,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/balances/evm.ts
+++ b/src/routes/token/balances/evm.ts
@@ -6,7 +6,7 @@ import { evmAddressSchema, paginationQuery, statisticsSchema, Vitalik, EVM_netwo
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
     address: Vitalik,
@@ -44,7 +44,7 @@ let responseSchema: any = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-let openapi = describeRoute({
+let openapi = describeRoute(withErrorResponses({
     summary: 'Balances by Address',
     description: 'Provides latest ERC-20 & Native balances by wallet address.',
     tags: ['EVM'],
@@ -73,7 +73,7 @@ let openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/balances/svm.ts
+++ b/src/routes/token/balances/svm.ts
@@ -6,7 +6,7 @@ import { svmAddressSchema, paginationQuery, statisticsSchema, SVM_networkIdSchem
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 let querySchema = z.object({
     token_account: filterByTokenAccount.default(''),
@@ -44,7 +44,7 @@ let responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-let openapi = describeRoute({
+let openapi = describeRoute(withErrorResponses({
     summary: 'Balances',
     description: 'Provides Solana SPL tokens balances by token account address.',
     tags: ['SVM'],
@@ -74,7 +74,7 @@ let openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/historical/balances/evm.ts
+++ b/src/routes/token/historical/balances/evm.ts
@@ -6,7 +6,7 @@ import { paginationQuery, statisticsSchema, Vitalik, EVM_networkIdSchema, interv
 import { sqlQueries } from '../../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../../config.js';
-import { validatorHook } from '../../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../../utils.js';
 
 const paramSchema = z.object({
     address: Vitalik,
@@ -35,7 +35,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'Historical Balances',
     description: 'Provides historical ERC-20 & Native balances by wallet address.',
     tags: ['EVM'],
@@ -66,7 +66,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -6,7 +6,7 @@ import { evmAddressSchema, statisticsSchema, paginationQuery, orderBySchemaValue
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
     contract: GRT
@@ -45,7 +45,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'Token Holders',
     description: 'Provides ERC-20 token holder balances by contract address.',
     tags: ['EVM'],
@@ -74,7 +74,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/holders/svm.ts
+++ b/src/routes/token/holders/svm.ts
@@ -6,7 +6,7 @@ import { svmAddressSchema, statisticsSchema, paginationQuery, orderBySchemaValue
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
     contract: WSOL
@@ -44,7 +44,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'Token Holders',
     description: 'Provides SVM token holder balances by contract address.',
     tags: ['SVM'],
@@ -72,7 +72,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/ohlc/pools/evm.ts
+++ b/src/routes/token/ohlc/pools/evm.ts
@@ -7,7 +7,7 @@ import { sqlQueries } from '../../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../../config.js';
 import { stables } from '../../../../inject/prices.tokens.js';
-import { validatorHook } from '../../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../../utils.js';
 
 const paramSchema = z.object({
     pool: USDC_WETH
@@ -35,7 +35,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'OHLCV by Pool',
     description: 'Provides pricing data in the Open/High/Low/Close/Volume (OHCLV) format.',
     tags: ['EVM'],
@@ -63,7 +63,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/ohlc/pools/svm.ts
+++ b/src/routes/token/ohlc/pools/svm.ts
@@ -6,7 +6,7 @@ import { statisticsSchema, paginationQuery, intervalSchema, SVM_networkIdSchema,
 import { sqlQueries } from '../../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../../config.js';
-import { validatorHook } from '../../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../../utils.js';
 import { stables } from '../../../../inject/prices.tokens.js';
 
 const paramSchema = z.object({
@@ -35,7 +35,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'OHLCV by Pool',
     description: 'Provides pricing data in the Open/High/Low/Close/Volume (OHCLV) format.',
     tags: ['SVM'],
@@ -67,7 +67,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/ohlc/prices/evm.ts
+++ b/src/routes/token/ohlc/prices/evm.ts
@@ -7,7 +7,7 @@ import { sqlQueries } from '../../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../../config.js';
 import { stables } from '../../../../inject/prices.tokens.js';
-import { validatorHook } from '../../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../../utils.js';
 
 const paramSchema = z.object({
     contract: WETH
@@ -35,7 +35,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'OHLCV by Contract',
     description: 'Provides pricing data in the Open/High/Low/Close/Volume (OHCLV) format.',
     tags: ['EVM'],
@@ -64,7 +64,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/pools/evm.ts
+++ b/src/routes/token/pools/evm.ts
@@ -6,7 +6,7 @@ import { evmAddressSchema, EVM_networkIdSchema, statisticsSchema, USDC_WETH, pro
 import { config } from '../../../config.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const querySchema = z.object({
     network_id: EVM_networkIdSchema,
@@ -41,7 +41,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'Liquidity Pools',
     description: 'Provides Uniswap V2 & V3 liquidity pool metadata.',
     tags: ['EVM'],
@@ -79,7 +79,7 @@ const openapi = describeRoute({
             }
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/pools/svm.ts
+++ b/src/routes/token/pools/svm.ts
@@ -6,7 +6,7 @@ import { svmAddressSchema, SVM_networkIdSchema, statisticsSchema, USDC_WSOL, tok
 import { config } from '../../../config.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const querySchema = z.object({
     pool: USDC_WSOL,
@@ -39,7 +39,7 @@ const responseSchema = z.object({
 });
 
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'Liquidity Pools',
     description: 'Provides Raydium liquidity pool metadata.',
     tags: ['SVM'],
@@ -77,7 +77,7 @@ const openapi = describeRoute({
             }
         },
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/swaps/evm.ts
+++ b/src/routes/token/swaps/evm.ts
@@ -6,7 +6,7 @@ import { evmAddressSchema, EVM_networkIdSchema, statisticsSchema, protocolSchema
 import { config } from '../../../config.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const querySchema = z.object({
     network_id: EVM_networkIdSchema,
@@ -61,7 +61,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'Swap Events',
     description: 'Provides Uniswap V2 & V3 swap events.',
     tags: ['EVM'],
@@ -108,7 +108,7 @@ const openapi = describeRoute({
             }
         },
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/swaps/svm.ts
+++ b/src/routes/token/swaps/svm.ts
@@ -6,7 +6,7 @@ import { svmAddressSchema, SVM_networkIdSchema, statisticsSchema, tokenSchema, s
 import { config } from '../../../config.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const querySchema = z.object({
     network_id: SVM_networkIdSchema,
@@ -62,7 +62,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'Swap Events',
     description: 'Provides AMM Swap events.',
     tags: ['SVM'],
@@ -97,7 +97,7 @@ const openapi = describeRoute({
             }
         },
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/tokens/evm.ts
+++ b/src/routes/token/tokens/evm.ts
@@ -6,7 +6,7 @@ import { GRT, evmAddressSchema, statisticsSchema, EVM_networkIdSchema } from '..
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 import { injectSymbol } from '../../../inject/symbol.js';
 import { injectIcons } from '../../../inject/icon.js';
 
@@ -54,7 +54,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'Token Metadata',
     description: 'Provides ERC-20 token contract metadata.',
     tags: ['EVM'],
@@ -88,7 +88,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/tokens/svm.ts
+++ b/src/routes/token/tokens/svm.ts
@@ -8,7 +8,7 @@ import { z } from 'zod';
 import { config } from '../../../config.js';
 import { injectIcons } from '../../../inject/icon.js';
 import { injectSymbol } from '../../../inject/symbol.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
     contract: WSOL,
@@ -52,7 +52,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'Token Metadata',
     description: 'Provides SVM token contract metadata.',
     tags: ['SVM'],
@@ -81,7 +81,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -6,7 +6,7 @@ import { evmAddressSchema, statisticsSchema, paginationQuery, Vitalik, EVM_netwo
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const querySchema = z.object({
     network_id: EVM_networkIdSchema,
@@ -58,7 +58,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'Transfers Events',
     description: 'Provides ERC-20 & Native transfer events.',
     tags: ['EVM'],
@@ -88,7 +88,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/token/transfers/svm.ts
+++ b/src/routes/token/transfers/svm.ts
@@ -6,7 +6,7 @@ import { svmAddressSchema, statisticsSchema, paginationQuery, SVM_networkIdSchem
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
 import { config } from '../../../config.js';
-import { validatorHook } from '../../../utils.js';
+import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const querySchema = z.object({
     network_id: SVM_networkIdSchema,
@@ -56,7 +56,7 @@ const responseSchema = z.object({
     statistics: z.optional(statisticsSchema),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     summary: 'Transfers Events',
     description: 'Provides SPL transfer events.',
     tags: ['SVM'],
@@ -89,7 +89,7 @@ const openapi = describeRoute({
             },
         }
     },
-});
+}));
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>; }; }>();
 

--- a/src/routes/version.ts
+++ b/src/routes/version.ts
@@ -1,8 +1,9 @@
-import { Hono } from 'hono'
-import { describeRoute } from 'hono-openapi'
-import { resolver } from 'hono-openapi/zod'
-import { GIT_APP } from '../config.js'
-import { z } from 'zod'
+import { Hono } from 'hono';
+import { describeRoute } from 'hono-openapi';
+import { resolver } from 'hono-openapi/zod';
+import { GIT_APP } from '../config.js';
+import { z } from 'zod';
+import { withErrorResponses } from '../utils.js';
 
 const route = new Hono();
 
@@ -12,7 +13,7 @@ const responseSchema = z.object({
     commit: z.string(),
 });
 
-const openapi = describeRoute({
+const openapi = describeRoute(withErrorResponses({
     description: 'Get the version of the API',
     tags: ['Monitoring'],
     responses: {
@@ -23,10 +24,10 @@ const openapi = describeRoute({
             },
         },
     },
-})
+}));
 
 route.get('/version', openapi, (c) => {
-    return c.json(GIT_APP)
+    return c.json(GIT_APP);
 });
 
 export default route;

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -174,12 +174,6 @@ export type PaginationSchema = z.infer<typeof paginationSchema>;
 // ----------------------
 // API Responses
 // ----------------------
-export const apiErrorResponse = z.object({
-    "status": z.union([z.literal(500), z.literal(502), z.literal(504), z.literal(400), z.literal(401), z.literal(403), z.literal(404), z.literal(405)]),
-    "code": z.enum(["bad_database_response", "connection_refused", "authentication_failed", "bad_header", "missing_required_header", "bad_query_input", "database_timeout", "forbidden", "internal_server_error", "method_not_allowed", "route_not_found", "unauthorized", "not_found_data"]),
-    "message": z.coerce.string()
-});
-export type ApiErrorResponse = z.infer<typeof apiErrorResponse>;
 
 export const apiUsageResponse = z.object({
     data: z.array(z.any()),
@@ -191,3 +185,36 @@ export const apiUsageResponse = z.object({
     duration_ms: z.number()
 });
 export type ApiUsageResponse = z.infer<typeof apiUsageResponse>;
+
+const baseMessage = z.coerce.string();
+
+// Define error code mappings by status code category
+const clientErrorCodes = [
+    "authentication_failed", "bad_header", "missing_required_header", 
+    "bad_query_input", "forbidden", "method_not_allowed", 
+    "route_not_found", "unauthorized", "not_found_data"
+] as const;
+
+const serverErrorCodes = [
+    "bad_database_response", "connection_refused", "database_timeout", 
+    "internal_server_error"
+] as const;
+
+// Create filtered schemas with status-code-specific error codes
+export const clientErrorResponse = z.object({
+    status: z.union([z.literal(400), z.literal(401), z.literal(403), z.literal(404), z.literal(405)]),
+    code: z.enum(clientErrorCodes),
+    message: baseMessage
+});
+export type ClientErrorResponse = z.infer<typeof clientErrorResponse>;
+
+export const serverErrorResponse = z.object({
+    status: z.union([z.literal(500), z.literal(502), z.literal(504)]),
+    code: z.enum(serverErrorCodes),
+    message: baseMessage
+});
+export type ServerErrorResponse = z.infer<typeof serverErrorResponse>;
+
+// Redefine apiErrorResponse as a union of client and server errors
+export const apiErrorResponse = z.union([clientErrorResponse, serverErrorResponse]);
+export type ApiErrorResponse = z.infer<typeof apiErrorResponse>;


### PR DESCRIPTION
- Separate API errors between `ClientErrorResponse` and `ServerErrorResponse`
- Use wrapper for adding error routes to all API endpoints