### PR TITLE
Revert to parsing `timestamp` as number and as UInt64 in SQL

### DIFF
--- a/src/sql/historical_balances_for_account/evm.sql
+++ b/src/sql/historical_balances_for_account/evm.sql
@@ -15,10 +15,10 @@ ohlc AS (
         toFloat64(min(low)) AS low_raw,
         toFloat64(argMaxMerge(close)) AS close_raw
     FROM historical_balances
-    WHERE address = {address: String} AND ({contracts: Array(String)} = [] OR contract IN {contracts: Array(String)})
+    WHERE address = {address: String}
+        AND timestamp BETWEEN {startTime: UInt64} AND {endTime: UInt64}
+        AND ({contracts: Array(String)} = [] OR contract IN {contracts: Array(String)})
     GROUP BY datetime, contract, name, symbol, decimals
-    HAVING datetime >= parseDateTimeBestEffortOrZero({startTime: String})
-       AND datetime <= parseDateTimeBestEffort({endTime: String})
 )
 SELECT
     datetime,

--- a/src/sql/nft_activities/evm.sql
+++ b/src/sql/nft_activities/evm.sql
@@ -23,7 +23,7 @@ WITH erc721 AS (
         transfer_type,
         token_standard
     FROM erc721_transfers AS t
-    WHERE timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
+    WHERE timestamp BETWEEN {startTime: UInt64} AND {endTime: UInt64}
         AND contract = {contract:String}
         AND ({fromAddress:String}       = '' OR from           = {fromAddress:String})
         AND ({toAddress:String}         = '' OR to             = {toAddress:String})
@@ -54,7 +54,7 @@ erc1155 AS (
         transfer_type,
         token_standard
     FROM erc1155_transfers AS t
-    WHERE timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
+    WHERE timestamp BETWEEN {startTime: UInt64} AND {endTime: UInt64}
         AND contract = {contract:String}
         AND ({fromAddress:String}       = '' OR from           = {fromAddress:String})
         AND ({toAddress:String}         = '' OR to             = {toAddress:String})

--- a/src/sql/nft_sales/evm.sql
+++ b/src/sql/nft_sales/evm.sql
@@ -11,7 +11,7 @@ WITH filtered_orders AS (
         {sale_currency:String} AS sale_currency
     FROM seaport_orders
     FINAL
-    WHERE   timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
+    WHERE   timestamp BETWEEN {startTime: UInt64} AND {endTime: UInt64}
         AND toString(consideration_token) IN {nativeContracts: Array(String)}
         AND offer_token = {contract:String}
         AND ({token_id:String}             = '' OR offer_token_id = {token_id:String})

--- a/src/sql/ohlcv_prices_for_pool/evm.sql
+++ b/src/sql/ohlcv_prices_for_pool/evm.sql
@@ -15,10 +15,8 @@ WITH ohlc AS (
         sum(transactions) AS transactions,
         toString(token0) IN {stablecoin_contracts: Array(String)} AS is_stablecoin
     FROM ohlc_prices
-    WHERE pool = {pool: String}
+    WHERE pool = {pool: String} AND timestamp BETWEEN {startTime: UInt64} AND {endTime: UInt64}
     GROUP BY datetime, symbol0, symbol1, token0
-    HAVING datetime >= parseDateTimeBestEffortOrZero({startTime: String})
-       AND datetime <= parseDateTimeBestEffort({endTime: String})
     ORDER BY datetime DESC
     LIMIT   {limit:int}
     OFFSET  {offset:int}

--- a/src/sql/ohlcv_prices_for_pool/svm.sql
+++ b/src/sql/ohlcv_prices_for_pool/svm.sql
@@ -26,10 +26,8 @@ SELECT
     {network_id: String} AS network_id
 FROM ohlc_prices AS o
 JOIN decimals USING pool
-WHERE pool = {pool: String}
+WHERE pool = {pool: String} AND timestamp BETWEEN {startTime: UInt64} AND {endTime: UInt64}
 GROUP BY token0, token1, decimals_factor, pool, datetime
-HAVING datetime >= parseDateTimeBestEffortOrZero({startTime: String})
-   AND datetime <= parseDateTimeBestEffort({endTime: String})
 ORDER BY datetime DESC
 LIMIT   {limit:int}
 OFFSET  {offset:int}

--- a/src/sql/ohlcv_prices_usd_for_contract/evm.sql
+++ b/src/sql/ohlcv_prices_usd_for_contract/evm.sql
@@ -36,8 +36,7 @@ normalized_prices AS (
     FROM ohlc_prices_by_contract AS o
     JOIN filtered_pools AS p ON p.pool = o.pool
     WHERE token = {contract: String}
-        AND o.timestamp >= parseDateTimeBestEffortOrZero({startTime: String})
-        AND o.timestamp <= parseDateTimeBestEffort({endTime: String})
+        AND o.timestamp BETWEEN {startTime: UInt64} AND {endTime: UInt64}
     GROUP BY datetime, pool, decimals_factor, decimals
 )
 SELECT

--- a/src/sql/swaps/evm.sql
+++ b/src/sql/swaps/evm.sql
@@ -12,7 +12,7 @@ WITH s AS (
         price,
         protocol
     FROM swaps
-    WHERE timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
+    WHERE timestamp BETWEEN {startTime: UInt64} AND {endTime: UInt64}
         AND ({transaction_id:String} = '' OR tx_hash = {transaction_id:String})
         AND ({caller:String}     = '' OR caller         = {caller:String})
         AND ({sender:String}     = '' OR sender         = {sender:String})

--- a/src/sql/swaps/svm.sql
+++ b/src/sql/swaps/svm.sql
@@ -34,7 +34,7 @@ SELECT
     output_amount,
     {network_id: String} AS network_id
 FROM s
-WHERE s.timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
+WHERE s.timestamp BETWEEN {startTime: UInt64} AND {endTime: UInt64}
     AND ({signature:String}     = '' OR signature      = {signature:String})
     AND ({user:String}          = '' OR user           = {user:String})
     AND ({amm:String}           = '' OR amm            = {amm:String})

--- a/src/sql/transfers/evm.sql
+++ b/src/sql/transfers/evm.sql
@@ -9,7 +9,7 @@ filtered_transfers AS (
         `to`,
         value
     FROM transfers
-    WHERE timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
+    WHERE timestamp BETWEEN {startTime: UInt64} AND {endTime: UInt64}
         AND ({transaction_id:String} = '' OR tx_hash = {transaction_id:String})
         AND ({from:String} = ''  OR `from` = {from:String})
         AND ({to:String} = ''  OR `to` = {to:String})

--- a/src/sql/transfers/svm.sql
+++ b/src/sql/transfers/svm.sql
@@ -4,7 +4,7 @@ WITH t AS (
         decimals,
         *
     FROM transfers
-    WHERE timestamp BETWEEN {startTime:UInt32} AND {endTime:UInt32}
+    WHERE timestamp BETWEEN {startTime: UInt64} AND {endTime: UInt64}
     ORDER BY timestamp DESC
 )
 SELECT


### PR DESCRIPTION
This fixes remaining issues of weird UNIX timestamp parsing between Javascript and ClickHouse