### PR TITLE
Reformat `examples` for OpenAPI to show up in Scalar

### DIFF
--- a/src/routes/nft/activities/evm.ts
+++ b/src/routes/nft/activities/evm.ts
@@ -72,25 +72,31 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    '@type': 'TRANSFER',
-                                    block_num: 22588725,
-                                    block_hash: '0xe8d2f48bb5d7619fd0c180d6d54e7ca94c5f4eddfcfa7a82d4da55b310dd462a',
-                                    timestamp: '2025-05-29 13:32:23',
-                                    tx_hash: '0xa7b3302a5fe4a60e4ece22dfb2d98604daef5dc610fa328d8d0a7a92f3efc7b9',
-                                    token_standard: 'ERC721',
-                                    contract: '0xbd3531da5cf5857e7cfaa92426877b022e612cf8',
-                                    name: 'PudgyPenguins',
-                                    symbol: 'PPG',
-                                    from: '0x2afec1c9af7a5494503f8acfd5c1fdd7d2c57480',
-                                    to: '0x29469395eaf6f95920e59f858042f0e28d98a20b',
-                                    token_id: '500',
-                                    amount: 1,
-                                    transfer_type: 'Single',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            '@type': 'TRANSFER',
+                                            block_num: 22588725,
+                                            block_hash:
+                                                '0xe8d2f48bb5d7619fd0c180d6d54e7ca94c5f4eddfcfa7a82d4da55b310dd462a',
+                                            timestamp: '2025-05-29 13:32:23',
+                                            tx_hash:
+                                                '0xa7b3302a5fe4a60e4ece22dfb2d98604daef5dc610fa328d8d0a7a92f3efc7b9',
+                                            token_standard: 'ERC721',
+                                            contract: '0xbd3531da5cf5857e7cfaa92426877b022e612cf8',
+                                            name: 'PudgyPenguins',
+                                            symbol: 'PPG',
+                                            from: '0x2afec1c9af7a5494503f8acfd5c1fdd7d2c57480',
+                                            to: '0x29469395eaf6f95920e59f858042f0e28d98a20b',
+                                            token_id: '500',
+                                            amount: 1,
+                                            transfer_type: 'Single',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/nft/collections_for_contract/evm.ts
+++ b/src/routes/nft/collections_for_contract/evm.ts
@@ -46,22 +46,26 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    token_standard: 'ERC721',
-                                    contract: '0xbd3531da5cf5857e7cfaa92426877b022e612cf8',
-                                    contract_creation: '2021-07-22 12:26:01',
-                                    contract_creator: '0xe9da256a28630efdc637bfd4c65f0887be1aeda8',
-                                    name: 'PudgyPenguins',
-                                    symbol: 'PPG',
-                                    owners: 12258,
-                                    total_supply: 8888,
-                                    total_unique_supply: 8888,
-                                    total_transfers: 185128,
-                                    network_id: 'mainnet',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            token_standard: 'ERC721',
+                                            contract: '0xbd3531da5cf5857e7cfaa92426877b022e612cf8',
+                                            contract_creation: '2021-07-22 12:26:01',
+                                            contract_creator: '0xe9da256a28630efdc637bfd4c65f0887be1aeda8',
+                                            name: 'PudgyPenguins',
+                                            symbol: 'PPG',
+                                            owners: 12258,
+                                            total_supply: 8888,
+                                            total_unique_supply: 8888,
+                                            total_transfers: 185128,
+                                            network_id: 'mainnet',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/nft/holders/evm.ts
+++ b/src/routes/nft/holders/evm.ts
@@ -42,17 +42,21 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    token_standard: 'ERC721',
-                                    address: '0x29469395eaf6f95920e59f858042f0e28d98a20b',
-                                    quantity: 534,
-                                    unique_tokens: 534,
-                                    percentage: 0.06008100810081008,
-                                    network_id: 'mainnet',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            token_standard: 'ERC721',
+                                            address: '0x29469395eaf6f95920e59f858042f0e28d98a20b',
+                                            quantity: 534,
+                                            unique_tokens: 534,
+                                            percentage: 0.06008100810081008,
+                                            network_id: 'mainnet',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/nft/items/evm.ts
+++ b/src/routes/nft/items/evm.ts
@@ -65,43 +65,47 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    token_standard: 'ERC721',
-                                    contract: '0xbd3531da5cf5857e7cfaa92426877b022e612cf8',
-                                    token_id: '5712',
-                                    owner: '0x9379557bdf32f5ee296ca7b360ccb8dcb9543d8e',
-                                    uri: 'ipfs://bafybeibc5sgo2plmjkq2tzmhrn54bk3crhnc23zd2msg4ea7a4pxrkgfna/5712',
-                                    name: 'Pudgy Penguin #5712',
-                                    description:
-                                        'A collection 8888 Cute Chubby Pudgy Penquins sliding around on the freezing ETH blockchain.',
-                                    image: 'ipfs://QmNf1UsmdGaMbpatQ6toXSkzDpizaGmC9zfunCyoz1enD5/penguin/5712.png',
-                                    attributes: [
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
                                         {
-                                            trait_type: 'Background',
-                                            value: 'Blue',
-                                        },
-                                        {
-                                            trait_type: 'Skin',
-                                            value: 'Olive Green',
-                                        },
-                                        {
-                                            trait_type: 'Body',
-                                            value: 'Turtleneck Green',
-                                        },
-                                        {
-                                            trait_type: 'Face',
-                                            value: 'Scar',
-                                        },
-                                        {
-                                            trait_type: 'Head',
-                                            value: 'Party Hat',
+                                            token_standard: 'ERC721',
+                                            contract: '0xbd3531da5cf5857e7cfaa92426877b022e612cf8',
+                                            token_id: '5712',
+                                            owner: '0x9379557bdf32f5ee296ca7b360ccb8dcb9543d8e',
+                                            uri: 'ipfs://bafybeibc5sgo2plmjkq2tzmhrn54bk3crhnc23zd2msg4ea7a4pxrkgfna/5712',
+                                            name: 'Pudgy Penguin #5712',
+                                            description:
+                                                'A collection 8888 Cute Chubby Pudgy Penquins sliding around on the freezing ETH blockchain.',
+                                            image: 'ipfs://QmNf1UsmdGaMbpatQ6toXSkzDpizaGmC9zfunCyoz1enD5/penguin/5712.png',
+                                            attributes: [
+                                                {
+                                                    trait_type: 'Background',
+                                                    value: 'Blue',
+                                                },
+                                                {
+                                                    trait_type: 'Skin',
+                                                    value: 'Olive Green',
+                                                },
+                                                {
+                                                    trait_type: 'Body',
+                                                    value: 'Turtleneck Green',
+                                                },
+                                                {
+                                                    trait_type: 'Face',
+                                                    value: 'Scar',
+                                                },
+                                                {
+                                                    trait_type: 'Head',
+                                                    value: 'Party Hat',
+                                                },
+                                            ],
+                                            network_id: 'mainnet',
                                         },
                                     ],
-                                    network_id: 'mainnet',
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/nft/ownerships_for_account/evm.ts
+++ b/src/routes/nft/ownerships_for_account/evm.ts
@@ -63,18 +63,22 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    token_id: '12',
-                                    token_standard: 'ERC721',
-                                    contract: '0x000386e3f7559d9b6a2f5c46b4ad1a9587d59dc3',
-                                    owner: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
-                                    symbol: 'BANC',
-                                    name: 'Bored Ape Nike Club',
-                                    network_id: 'mainnet',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            token_id: '12',
+                                            token_standard: 'ERC721',
+                                            contract: '0x000386e3f7559d9b6a2f5c46b4ad1a9587d59dc3',
+                                            owner: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+                                            symbol: 'BANC',
+                                            name: 'Bored Ape Nike Club',
+                                            network_id: 'mainnet',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/nft/sales/evm.ts
+++ b/src/routes/nft/sales/evm.ts
@@ -75,22 +75,27 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    timestamp: '2025-05-29 07:52:47',
-                                    block_num: 22587041,
-                                    tx_hash: '0x6755df1514a066150357d454254e1ce6c1e043f873193125dc98d4c4417861ff',
-                                    token: '0xbd3531da5cf5857e7cfaa92426877b022e612cf8',
-                                    token_id: '6398',
-                                    symbol: 'PPG',
-                                    name: 'PudgyPenguins',
-                                    offerer: '0xf671888173bf2fe28d71fba3106cf36d10f470fe',
-                                    recipient: '0x43bf952762b087195b8ea70cf81cb6715b6bf5a9',
-                                    sale_amount: 10.0667234,
-                                    sale_currency: 'ETH',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            timestamp: '2025-05-29 07:52:47',
+                                            block_num: 22587041,
+                                            tx_hash:
+                                                '0x6755df1514a066150357d454254e1ce6c1e043f873193125dc98d4c4417861ff',
+                                            token: '0xbd3531da5cf5857e7cfaa92426877b022e612cf8',
+                                            token_id: '6398',
+                                            symbol: 'PPG',
+                                            name: 'PudgyPenguins',
+                                            offerer: '0xf671888173bf2fe28d71fba3106cf36d10f470fe',
+                                            recipient: '0x43bf952762b087195b8ea70cf81cb6715b6bf5a9',
+                                            sale_amount: 10.0667234,
+                                            sale_currency: 'ETH',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/balances/evm.ts
+++ b/src/routes/token/balances/evm.ts
@@ -66,20 +66,24 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 22968741,
-                                    last_balance_update: '2025-07-21 16:24:47',
-                                    contract: '0x6993301413c1867aafe2caaa692ec53a0118f06e',
-                                    amount: '7917650000000000000000',
-                                    value: 7917.65,
-                                    name: 'BOLD',
-                                    symbol: 'BOLD',
-                                    decimals: 18,
-                                    network_id: 'mainnet',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 22968741,
+                                            last_balance_update: '2025-07-21 16:24:47',
+                                            contract: '0x6993301413c1867aafe2caaa692ec53a0118f06e',
+                                            amount: '7917650000000000000000',
+                                            value: 7917.65,
+                                            name: 'BOLD',
+                                            symbol: 'BOLD',
+                                            decimals: 18,
+                                            network_id: 'mainnet',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/balances/svm.ts
+++ b/src/routes/token/balances/svm.ts
@@ -68,21 +68,25 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 352305913,
-                                    datetime: '2025-07-10 05:14:43',
-                                    timestamp: 1752124483,
-                                    program_id: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-                                    token_account: '4ct7br2vTPzfdmY3S5HLtTxcGSBfn6pnw98hsS6v359A',
-                                    mint: 'So11111111111111111111111111111111111111112',
-                                    amount: '30697740781078',
-                                    value: 30697.740781078,
-                                    decimals: 9,
-                                    network_id: 'solana',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 352305913,
+                                            datetime: '2025-07-10 05:14:43',
+                                            timestamp: 1752124483,
+                                            program_id: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                                            token_account: '4ct7br2vTPzfdmY3S5HLtTxcGSBfn6pnw98hsS6v359A',
+                                            mint: 'So11111111111111111111111111111111111111112',
+                                            amount: '30697740781078',
+                                            value: 30697.740781078,
+                                            decimals: 9,
+                                            network_id: 'solana',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/historical/balances/evm.ts
+++ b/src/routes/token/historical/balances/evm.ts
@@ -61,21 +61,25 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    datetime: '2025-05-29 00:00:00',
-                                    contract: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-                                    name: 'Native',
-                                    symbol: 'ETH',
-                                    decimals: 18,
-                                    open: 237.63774262699187,
-                                    high: 237.6377453469919,
-                                    low: 0.10533323067535896,
-                                    close: 0.15438623067535898,
-                                    network_id: 'mainnet',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            datetime: '2025-05-29 00:00:00',
+                                            contract: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+                                            name: 'Native',
+                                            symbol: 'ETH',
+                                            decimals: 18,
+                                            open: 237.63774262699187,
+                                            high: 237.6377453469919,
+                                            low: 0.10533323067535896,
+                                            close: 0.15438623067535898,
+                                            network_id: 'mainnet',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -69,20 +69,24 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 22966764,
-                                    last_balance_update: '2025-07-21 09:47:11',
-                                    address: '0x36aff7001294dae4c2ed4fdefc478a00de77f090',
-                                    amount: '2904244446383157108596275005',
-                                    value: 2904244446.3831573,
-                                    name: 'Graph Token',
-                                    decimals: 18,
-                                    symbol: 'GRT',
-                                    network_id: 'mainnet',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 22966764,
+                                            last_balance_update: '2025-07-21 09:47:11',
+                                            address: '0x36aff7001294dae4c2ed4fdefc478a00de77f090',
+                                            amount: '2904244446383157108596275005',
+                                            value: 2904244446.3831573,
+                                            name: 'Graph Token',
+                                            decimals: 18,
+                                            symbol: 'GRT',
+                                            network_id: 'mainnet',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/holders/svm.ts
+++ b/src/routes/token/holders/svm.ts
@@ -68,19 +68,23 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 269656050,
-                                    last_balance_update: '2024-06-03 15:10:14',
-                                    owner: 'HuX8huX8VfNw9WpMNpgzD8TC1fXiBqhpBeBvGhJXSuaL',
-                                    amount: 7915210148973539,
-                                    value: '7915210.148973539',
-                                    decimals: 9,
-                                    symbol: 'TO IMPLEMENT',
-                                    network_id: 'solana',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 269656050,
+                                            last_balance_update: '2024-06-03 15:10:14',
+                                            owner: 'HuX8huX8VfNw9WpMNpgzD8TC1fXiBqhpBeBvGhJXSuaL',
+                                            amount: 7915210148973539,
+                                            value: '7915210.148973539',
+                                            decimals: 9,
+                                            symbol: 'TO IMPLEMENT',
+                                            network_id: 'solana',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/ohlc/pools/evm.ts
+++ b/src/routes/token/ohlc/pools/evm.ts
@@ -59,19 +59,23 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    datetime: '2025-05-29 15:00:00',
-                                    ticker: 'WETHUSDC',
-                                    open: 2674.206768283323,
-                                    high: 2674.206768283323,
-                                    low: 2648.1288363948797,
-                                    close: 2648.1288363948797,
-                                    volume: 5062048.294222999,
-                                    transactions: 169,
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            datetime: '2025-05-29 15:00:00',
+                                            ticker: 'WETHUSDC',
+                                            open: 2674.206768283323,
+                                            high: 2674.206768283323,
+                                            low: 2648.1288363948797,
+                                            close: 2648.1288363948797,
+                                            volume: 5062048.294222999,
+                                            transactions: 169,
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/ohlc/pools/svm.ts
+++ b/src/routes/token/ohlc/pools/svm.ts
@@ -59,23 +59,27 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    datetime: '2025-06-20 00:00:00',
-                                    pool: '58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2',
-                                    token0: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-                                    token1: 'So11111111111111111111111111111111111111112',
-                                    open: 146.64474747474748,
-                                    high: 147.71993287074972,
-                                    low: 145.0099569301824,
-                                    close: 147.36215787385962,
-                                    volume: 551499356.7426533,
-                                    uaw: 337,
-                                    transactions: 1021110,
-                                    network_id: 'solana',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            datetime: '2025-06-20 00:00:00',
+                                            pool: '58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2',
+                                            token0: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                                            token1: 'So11111111111111111111111111111111111111112',
+                                            open: 146.64474747474748,
+                                            high: 147.71993287074972,
+                                            low: 145.0099569301824,
+                                            close: 147.36215787385962,
+                                            volume: 551499356.7426533,
+                                            uaw: 337,
+                                            transactions: 1021110,
+                                            network_id: 'solana',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/ohlc/prices/evm.ts
+++ b/src/routes/token/ohlc/prices/evm.ts
@@ -59,20 +59,24 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    datetime: '2025-05-29 15:00:00',
-                                    ticker: 'WETHUSD',
-                                    open: 2669.130852861705,
-                                    high: 2669.130852861705,
-                                    low: 2669.130852861705,
-                                    close: 2669.130852861705,
-                                    volume: 184897.1695477702,
-                                    uaw: 31,
-                                    transactions: 35,
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            datetime: '2025-05-29 15:00:00',
+                                            ticker: 'WETHUSD',
+                                            open: 2669.130852861705,
+                                            high: 2669.130852861705,
+                                            low: 2669.130852861705,
+                                            close: 2669.130852861705,
+                                            volume: 184897.1695477702,
+                                            uaw: 31,
+                                            transactions: 35,
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/pools/evm.ts
+++ b/src/routes/token/pools/evm.ts
@@ -67,30 +67,34 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 22589384,
-                                    datetime: '2025-05-29 15:46:23',
-                                    transaction_id:
-                                        '0x43cee95f1449b6b4d394fab31234fd6decdcd049153cc1338fe627e5483a3d36',
-                                    factory: '0x000000000004444c5dc75cb358380d2e3de08a90',
-                                    pool: '0x12b900f4e5c4b1d2aab6870220345c668b068fc6e588dd59dfe6f223d60608f1',
-                                    token0: {
-                                        address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-                                        symbol: 'USDT',
-                                        decimals: 6,
-                                    },
-                                    token1: {
-                                        address: '0xf2c88757f8d03634671208935974b60a2a28bdb3',
-                                        symbol: 'SHELL',
-                                        decimals: 18,
-                                    },
-                                    fee: 699000,
-                                    protocol: 'uniswap_v4',
-                                    network_id: 'mainnet',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 22589384,
+                                            datetime: '2025-05-29 15:46:23',
+                                            transaction_id:
+                                                '0x43cee95f1449b6b4d394fab31234fd6decdcd049153cc1338fe627e5483a3d36',
+                                            factory: '0x000000000004444c5dc75cb358380d2e3de08a90',
+                                            pool: '0x12b900f4e5c4b1d2aab6870220345c668b068fc6e588dd59dfe6f223d60608f1',
+                                            token0: {
+                                                address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+                                                symbol: 'USDT',
+                                                decimals: 6,
+                                            },
+                                            token1: {
+                                                address: '0xf2c88757f8d03634671208935974b60a2a28bdb3',
+                                                symbol: 'SHELL',
+                                                decimals: 18,
+                                            },
+                                            fee: 699000,
+                                            protocol: 'uniswap_v4',
+                                            network_id: 'mainnet',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/pools/svm.ts
+++ b/src/routes/token/pools/svm.ts
@@ -61,30 +61,34 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 22589384,
-                                    datetime: '2025-05-29 15:46:23',
-                                    transaction_id:
-                                        '0x43cee95f1449b6b4d394fab31234fd6decdcd049153cc1338fe627e5483a3d36',
-                                    factory: '0x000000000004444c5dc75cb358380d2e3de08a90',
-                                    pool: '0x12b900f4e5c4b1d2aab6870220345c668b068fc6e588dd59dfe6f223d60608f1',
-                                    token0: {
-                                        address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-                                        symbol: 'USDT',
-                                        decimals: 6,
-                                    },
-                                    token1: {
-                                        address: '0xf2c88757f8d03634671208935974b60a2a28bdb3',
-                                        symbol: 'SHELL',
-                                        decimals: 18,
-                                    },
-                                    fee: 699000,
-                                    protocol: 'uniswap_v4',
-                                    network_id: 'mainnet',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 22589384,
+                                            datetime: '2025-05-29 15:46:23',
+                                            transaction_id:
+                                                '0x43cee95f1449b6b4d394fab31234fd6decdcd049153cc1338fe627e5483a3d36',
+                                            factory: '0x000000000004444c5dc75cb358380d2e3de08a90',
+                                            pool: '0x12b900f4e5c4b1d2aab6870220345c668b068fc6e588dd59dfe6f223d60608f1',
+                                            token0: {
+                                                address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+                                                symbol: 'USDT',
+                                                decimals: 6,
+                                            },
+                                            token1: {
+                                                address: '0xf2c88757f8d03634671208935974b60a2a28bdb3',
+                                                symbol: 'SHELL',
+                                                decimals: 18,
+                                            },
+                                            fee: 699000,
+                                            protocol: 'uniswap_v4',
+                                            network_id: 'mainnet',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/swaps/evm.ts
+++ b/src/routes/token/swaps/evm.ts
@@ -91,39 +91,43 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 22589391,
-                                    datetime: '2025-05-29 15:47:47',
-                                    timestamp: 1748533667,
-                                    transaction_id:
-                                        '0x1ce019b0ad129b8bd21b6c83b75de5e5fd7cd07f2ee739ca3198adcbeb61f5a9',
-                                    caller: '0x66a9893cc07d91d95644aedd05d03f95e1dba8af',
-                                    pool: '0xb98437c7ba28c6590dd4e1cc46aa89eed181f97108e5b6221730d41347bc817f',
-                                    factory: '0x000000000004444c5dc75cb358380d2e3de08a90',
-                                    token0: {
-                                        address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
-                                        symbol: 'WBTC',
-                                        decimals: 8,
-                                    },
-                                    token1: {
-                                        address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-                                        symbol: 'USDC',
-                                        decimals: 6,
-                                    },
-                                    sender: '0x66a9893cc07d91d95644aedd05d03f95e1dba8af',
-                                    recipient: null,
-                                    amount0: '-894320',
-                                    amount1: '957798098',
-                                    value0: -0.0089432,
-                                    value1: 957.798098,
-                                    price0: 107417.48517180652,
-                                    price1: 0.00000930947134352077,
-                                    protocol: 'uniswap_v4',
-                                    network_id: 'mainnet',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 22589391,
+                                            datetime: '2025-05-29 15:47:47',
+                                            timestamp: 1748533667,
+                                            transaction_id:
+                                                '0x1ce019b0ad129b8bd21b6c83b75de5e5fd7cd07f2ee739ca3198adcbeb61f5a9',
+                                            caller: '0x66a9893cc07d91d95644aedd05d03f95e1dba8af',
+                                            pool: '0xb98437c7ba28c6590dd4e1cc46aa89eed181f97108e5b6221730d41347bc817f',
+                                            factory: '0x000000000004444c5dc75cb358380d2e3de08a90',
+                                            token0: {
+                                                address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+                                                symbol: 'WBTC',
+                                                decimals: 8,
+                                            },
+                                            token1: {
+                                                address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                                                symbol: 'USDC',
+                                                decimals: 6,
+                                            },
+                                            sender: '0x66a9893cc07d91d95644aedd05d03f95e1dba8af',
+                                            recipient: null,
+                                            amount0: '-894320',
+                                            amount1: '957798098',
+                                            value0: -0.0089432,
+                                            value1: 957.798098,
+                                            price0: 107417.48517180652,
+                                            price1: 0.00000930947134352077,
+                                            protocol: 'uniswap_v4',
+                                            network_id: 'mainnet',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/swaps/svm.ts
+++ b/src/routes/token/swaps/svm.ts
@@ -94,27 +94,31 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 352243599,
-                                    datetime: '2025-07-09 22:24:36',
-                                    timestamp: 1752099876,
-                                    signature:
-                                        'oWHA7wPQwpZhr9RJSbTNxsnPkBo1wnd68Zt2fJZPyK3cf1vYVzQiC9Et2mRNvh1t9Zt5dtmoEeSErSCqmMQ58Ls\u0000',
-                                    program_id: 'pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA',
-                                    program_name: 'Pump.fun AMM',
-                                    amm: 'pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA',
-                                    amm_name: 'Pump.fun AMM',
-                                    amm_pool: 'AmmpSnW5xVeKHTAU9fMjyKEMPgrzmUj3ah5vgvHhAB5J',
-                                    user: 'AEWxmZPEdHkCjJXVT9MreY7fCvzbpEK3wCVouCoEnmvE',
-                                    input_mint: '9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump',
-                                    input_amount: 3653743,
-                                    output_mint: 'So11111111111111111111111111111111111111112',
-                                    output_amount: 25548025,
-                                    network_id: 'solana',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 352243599,
+                                            datetime: '2025-07-09 22:24:36',
+                                            timestamp: 1752099876,
+                                            signature:
+                                                'oWHA7wPQwpZhr9RJSbTNxsnPkBo1wnd68Zt2fJZPyK3cf1vYVzQiC9Et2mRNvh1t9Zt5dtmoEeSErSCqmMQ58Ls\u0000',
+                                            program_id: 'pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA',
+                                            program_name: 'Pump.fun AMM',
+                                            amm: 'pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA',
+                                            amm_name: 'Pump.fun AMM',
+                                            amm_pool: 'AmmpSnW5xVeKHTAU9fMjyKEMPgrzmUj3ah5vgvHhAB5J',
+                                            user: 'AEWxmZPEdHkCjJXVT9MreY7fCvzbpEK3wCVouCoEnmvE',
+                                            input_mint: '9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump',
+                                            input_amount: 3653743,
+                                            output_mint: 'So11111111111111111111111111111111111111112',
+                                            output_amount: 25548025,
+                                            network_id: 'solana',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/tokens/evm.ts
+++ b/src/routes/token/tokens/evm.ts
@@ -68,25 +68,29 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 22966816,
-                                    datetime: '2025-07-21 09:57:35',
-                                    timestamp: 1753091855,
-                                    contract: '0xc944e90c64b2c07662a292be6244bdf05cda44a7',
-                                    decimals: 18,
-                                    symbol: 'GRT',
-                                    name: 'Graph Token',
-                                    circulating_supply: 27051707794.58071,
-                                    total_supply: 10800262823.318213,
-                                    holders: 175151,
-                                    network_id: 'mainnet',
-                                    icon: {
-                                        web3icon: 'GRT',
-                                    },
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 22966816,
+                                            datetime: '2025-07-21 09:57:35',
+                                            timestamp: 1753091855,
+                                            contract: '0xc944e90c64b2c07662a292be6244bdf05cda44a7',
+                                            decimals: 18,
+                                            symbol: 'GRT',
+                                            name: 'Graph Token',
+                                            circulating_supply: 27051707794.58071,
+                                            total_supply: 10800262823.318213,
+                                            holders: 175151,
+                                            network_id: 'mainnet',
+                                            icon: {
+                                                web3icon: 'GRT',
+                                            },
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/tokens/svm.ts
+++ b/src/routes/token/tokens/svm.ts
@@ -66,20 +66,24 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 279194558,
-                                    datetime: '2024-07-23 10:54:15',
-                                    contract: '11112zAgXhc6hGfdfr5anSY91mq7Cs4HHpSVEQc4ASG\u0000',
-                                    decimals: 9,
-                                    symbol: 'TO IMPLEMENT',
-                                    name: 'TO IMPLEMENT',
-                                    circulating_supply: '1000048190.3747444',
-                                    holders: 74,
-                                    network_id: 'solana',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 279194558,
+                                            datetime: '2024-07-23 10:54:15',
+                                            contract: '11112zAgXhc6hGfdfr5anSY91mq7Cs4HHpSVEQc4ASG\u0000',
+                                            decimals: 9,
+                                            symbol: 'TO IMPLEMENT',
+                                            name: 'TO IMPLEMENT',
+                                            circulating_supply: '1000048190.3747444',
+                                            holders: 74,
+                                            network_id: 'solana',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -85,22 +85,26 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 22349873,
-                                    datetime: '2025-04-26 01:18:47',
-                                    timestamp: 1745630327,
-                                    transaction_id:
-                                        '0xd80ed9764b0bc25b982668f66ec1cf46dbe27bcd01dffcd487f43c92f72b2a84',
-                                    contract: '0xc944e90c64b2c07662a292be6244bdf05cda44a7',
-                                    from: '0x7d2fbc0eefdb8721b27d216469e79ef288910a83',
-                                    to: '0xa5eb953d1ce9d6a99893cbf6d83d8abcca9b8804',
-                                    decimals: 18,
-                                    symbol: 'GRT',
-                                    value: 11068.393958659999,
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 22349873,
+                                            datetime: '2025-04-26 01:18:47',
+                                            timestamp: 1745630327,
+                                            transaction_id:
+                                                '0xd80ed9764b0bc25b982668f66ec1cf46dbe27bcd01dffcd487f43c92f72b2a84',
+                                            contract: '0xc944e90c64b2c07662a292be6244bdf05cda44a7',
+                                            from: '0x7d2fbc0eefdb8721b27d216469e79ef288910a83',
+                                            to: '0xa5eb953d1ce9d6a99893cbf6d83d8abcca9b8804',
+                                            decimals: 18,
+                                            symbol: 'GRT',
+                                            value: 11068.393958659999,
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/routes/token/transfers/svm.ts
+++ b/src/routes/token/transfers/svm.ts
@@ -85,25 +85,29 @@ const openapi = describeRoute(
                 content: {
                     'application/json': {
                         schema: resolver(responseSchema),
-                        example: {
-                            data: [
-                                {
-                                    block_num: 352372432,
-                                    datetime: '2025-07-10 12:32:03',
-                                    timestamp: 1752150723,
-                                    signature:
-                                        '4t7ZD3Fd8i9md6CTF6SEoZ9aPkr1fhRpXXSK2DhrUe5Wcm9VFdJ9Sn4WvbhdQaetLkiq8Xm3r5YgU1ffSJaA6c2e',
-                                    program_id: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-                                    authority: 'J5kWrUKVPrtjwMVQLNgUEC9RY9Ujh8pYTN3nqWUkg1zp',
-                                    mint: 'So11111111111111111111111111111111111111112',
-                                    source: 'G4sbSww72omqHsC6tYe4syFtzHyBieS6MjbRWmSn1mt5',
-                                    destination: '7ds7shXvLdNzihJXrjuoYYTr8bD5c2zwRxmZrrSZXgmM',
-                                    amount: 333993128,
-                                    decimals: 9,
-                                    value: 0.333993128,
-                                    network_id: 'solana',
+                        examples: {
+                            example: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 352372432,
+                                            datetime: '2025-07-10 12:32:03',
+                                            timestamp: 1752150723,
+                                            signature:
+                                                '4t7ZD3Fd8i9md6CTF6SEoZ9aPkr1fhRpXXSK2DhrUe5Wcm9VFdJ9Sn4WvbhdQaetLkiq8Xm3r5YgU1ffSJaA6c2e',
+                                            program_id: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                                            authority: 'J5kWrUKVPrtjwMVQLNgUEC9RY9Ujh8pYTN3nqWUkg1zp',
+                                            mint: 'So11111111111111111111111111111111111111112',
+                                            source: 'G4sbSww72omqHsC6tYe4syFtzHyBieS6MjbRWmSn1mt5',
+                                            destination: '7ds7shXvLdNzihJXrjuoYYTr8bD5c2zwRxmZrrSZXgmM',
+                                            amount: 333993128,
+                                            decimals: 9,
+                                            value: 0.333993128,
+                                            network_id: 'solana',
+                                        },
+                                    ],
                                 },
-                            ],
+                            },
                         },
                     },
                 },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -104,10 +104,14 @@ export function withErrorResponses(routeDescription: RouteDescription) {
                 content: {
                     'application/json': {
                         schema: resolver(clientErrorResponse),
-                        example: {
-                            status: 400,
-                            code: 'bad_query_input',
-                            message: 'Invalid query parameter provided',
+                        examples: {
+                            example: {
+                                value: {
+                                    status: 400,
+                                    code: 'bad_query_input',
+                                    message: 'Invalid query parameter provided',
+                                },
+                            },
                         },
                     },
                 },
@@ -117,10 +121,14 @@ export function withErrorResponses(routeDescription: RouteDescription) {
                 content: {
                     'application/json': {
                         schema: resolver(clientErrorResponse),
-                        example: {
-                            status: 401,
-                            code: 'unauthorized',
-                            message: 'Authentication required',
+                        examples: {
+                            example: {
+                                value: {
+                                    status: 401,
+                                    code: 'unauthorized',
+                                    message: 'Authentication required',
+                                },
+                            },
                         },
                     },
                 },
@@ -130,10 +138,14 @@ export function withErrorResponses(routeDescription: RouteDescription) {
                 content: {
                     'application/json': {
                         schema: resolver(clientErrorResponse),
-                        example: {
-                            status: 403,
-                            code: 'forbidden',
-                            message: 'Access denied',
+                        examples: {
+                            example: {
+                                value: {
+                                    status: 403,
+                                    code: 'forbidden',
+                                    message: 'Access denied',
+                                },
+                            },
                         },
                     },
                 },
@@ -143,10 +155,14 @@ export function withErrorResponses(routeDescription: RouteDescription) {
                 content: {
                     'application/json': {
                         schema: resolver(clientErrorResponse),
-                        example: {
-                            status: 404,
-                            code: 'not_found_data',
-                            message: 'Resource not found',
+                        examples: {
+                            example: {
+                                value: {
+                                    status: 404,
+                                    code: 'not_found_data',
+                                    message: 'Resource not found',
+                                },
+                            },
                         },
                     },
                 },
@@ -156,10 +172,14 @@ export function withErrorResponses(routeDescription: RouteDescription) {
                 content: {
                     'application/json': {
                         schema: resolver(serverErrorResponse),
-                        example: {
-                            status: 500,
-                            code: 'internal_server_error',
-                            message: 'An unexpected error occurred',
+                        examples: {
+                            example: {
+                                value: {
+                                    status: 500,
+                                    code: 'internal_server_error',
+                                    message: 'An unexpected error occurred',
+                                },
+                            },
                         },
                     },
                 },


### PR DESCRIPTION
Turn this:
```
example: {
  data: ...
}
```
Into this:
```
examples: {
  example: {
    value: {
      data: ...
    }
  }
}
```