### PR TITLE
Improve filtering by pool

### DIFF
--- a/src/sql/pools/evm.sql
+++ b/src/sql/pools/evm.sql
@@ -13,8 +13,8 @@ WITH filtered_pools AS (
     WHERE
         if ({pool:String} == '', true, pool  = {pool:String}) AND
         if ({factory:String} == '', true, factory = {factory:String}) AND
-        if ({token0:String} == '', true, token0 = {token0:String}) AND
-        if ({token1:String} == '', true, token1 = {token1:String}) AND
+        if ({token0:String} == '', true, (token0 = {token0:String} OR token1 = {token0:String})) AND
+        if ({token1:String} == '', true, (token1 = {token1:String} OR token0 = {token1:String})) AND
         if ({protocol:String} == '', true, protocol = {protocol:String})
 )
 SELECT


### PR DESCRIPTION
When specifying token0 and token1 in `/pools/evm` endpoint, this allows searching both token0/token1 and token1/token0 pools.
Improves #157 fix