### PR TITLE
Make all endpoint use `apiUsageResponse` schema as base

### DIFF
--- a/src/routes/nft/activities/evm.ts
+++ b/src/routes/nft/activities/evm.ts
@@ -6,6 +6,7 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     endTimeSchema,
     evmAddress,
@@ -15,7 +16,6 @@ import {
     PudgyPenguins,
     paginationQuery,
     startTimeSchema,
-    statisticsSchema,
 } from '../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../utils.js';
 
@@ -37,7 +37,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // NFT token metadata
@@ -57,7 +57,6 @@ const responseSchema = z.object({
             token_standard: z.optional(z.string()),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/nft/collections_for_contract/evm.ts
+++ b/src/routes/nft/collections_for_contract/evm.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
-import { EVM_networkIdSchema, evmAddressSchema, PudgyPenguins, statisticsSchema } from '../../../types/zod.js';
+import { apiUsageResponse, EVM_networkIdSchema, evmAddressSchema, PudgyPenguins } from '../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
@@ -16,7 +16,7 @@ const querySchema = z.object({
     network_id: EVM_networkIdSchema,
 });
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             contract: evmAddressSchema,
@@ -31,7 +31,6 @@ const responseSchema = z.object({
             network_id: EVM_networkIdSchema,
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/nft/holders/evm.ts
+++ b/src/routes/nft/holders/evm.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
-import { EVM_networkIdSchema, evmAddressSchema, PudgyPenguins, statisticsSchema } from '../../../types/zod.js';
+import { apiUsageResponse, EVM_networkIdSchema, evmAddressSchema, PudgyPenguins } from '../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
@@ -16,7 +16,7 @@ const querySchema = z.object({
     network_id: EVM_networkIdSchema,
 });
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             token_standard: z.string(),
@@ -27,7 +27,6 @@ const responseSchema = z.object({
             network_id: EVM_networkIdSchema,
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/nft/items/evm.ts
+++ b/src/routes/nft/items/evm.ts
@@ -6,11 +6,11 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     evmAddress,
     PudgyPenguins,
     PudgyPenguinsItem,
-    statisticsSchema,
     tokenStandardSchema,
 } from '../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../utils.js';
@@ -24,7 +24,7 @@ const querySchema = z.object({
     network_id: EVM_networkIdSchema,
 });
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // NFT token metadata
@@ -50,7 +50,6 @@ const responseSchema = z.object({
             network_id: EVM_networkIdSchema,
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/nft/ownerships_for_account/evm.ts
+++ b/src/routes/nft/ownerships_for_account/evm.ts
@@ -6,11 +6,11 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     evmAddress,
     evmAddressSchema,
     paginationQuery,
-    statisticsSchema,
     tokenStandardSchema,
     Vitalik,
 } from '../../../types/zod.js';
@@ -28,7 +28,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // NFT token metadata
@@ -48,7 +48,6 @@ const responseSchema = z.object({
             network_id: EVM_networkIdSchema,
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/nft/sales/evm.ts
+++ b/src/routes/nft/sales/evm.ts
@@ -8,6 +8,7 @@ import { natives as nativeContracts } from '../../../inject/prices.tokens.js';
 import { natives as nativeSymbols } from '../../../inject/symbol.tokens.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     endTimeSchema,
     evmAddress,
@@ -18,7 +19,6 @@ import {
     PudgyPenguinsItem,
     paginationQuery,
     startTimeSchema,
-    statisticsSchema,
 } from '../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../utils.js';
 
@@ -41,7 +41,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // Block
@@ -60,7 +60,6 @@ const responseSchema = z.object({
             sale_currency: z.string(),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/balances/evm.ts
+++ b/src/routes/token/balances/evm.ts
@@ -6,10 +6,10 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     evmAddressSchema,
     paginationQuery,
-    statisticsSchema,
     Vitalik,
 } from '../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../utils.js';
@@ -25,7 +25,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // -- block --
@@ -51,7 +51,6 @@ const responseSchema = z.object({
             low_liquidity: z.optional(z.boolean()),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/balances/svm.ts
+++ b/src/routes/token/balances/svm.ts
@@ -6,11 +6,11 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     filterByTokenAccount,
     paginationQuery,
     SolanaSPLTokenProgramIds,
     SVM_networkIdSchema,
-    statisticsSchema,
     svmAddressSchema,
     WSOL,
 } from '../../../types/zod.js';
@@ -25,7 +25,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // -- block --
@@ -53,7 +53,6 @@ const responseSchema = z.object({
             // decimals: z.optional(z.number())
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/historical/balances/evm.ts
+++ b/src/routes/token/historical/balances/evm.ts
@@ -6,13 +6,13 @@ import { config } from '../../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../../handleQuery.js';
 import { sqlQueries } from '../../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     endTimeSchema,
     evmAddressSchema,
     intervalSchema,
     paginationQuery,
     startTimeSchema,
-    statisticsSchema,
     Vitalik,
 } from '../../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../../utils.js';
@@ -31,7 +31,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             datetime: z.iso.datetime(),
@@ -45,7 +45,6 @@ const responseSchema = z.object({
             close: z.number(),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -6,13 +6,13 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     evmAddressSchema,
     GRT,
     orderBySchemaValue,
     orderDirectionSchema,
     paginationQuery,
-    statisticsSchema,
 } from '../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../utils.js';
 
@@ -28,7 +28,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // -- block --
@@ -54,7 +54,6 @@ const responseSchema = z.object({
             low_liquidity: z.optional(z.boolean()),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/holders/svm.ts
+++ b/src/routes/token/holders/svm.ts
@@ -6,11 +6,11 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     orderBySchemaValue,
     orderDirectionSchema,
     paginationQuery,
     SVM_networkIdSchema,
-    statisticsSchema,
     svmAddressSchema,
     WSOL,
 } from '../../../types/zod.js';
@@ -28,7 +28,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // -- block --
@@ -53,7 +53,6 @@ const responseSchema = z.object({
             // low_liquidity: z.optional(z.boolean()),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/ohlc/pools/evm.ts
+++ b/src/routes/token/ohlc/pools/evm.ts
@@ -7,12 +7,12 @@ import { handleUsageQueryError, makeUsageQueryJson } from '../../../../handleQue
 import { stables } from '../../../../inject/prices.tokens.js';
 import { sqlQueries } from '../../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     endTimeSchema,
     intervalSchema,
     paginationQuery,
     startTimeSchema,
-    statisticsSchema,
     USDC_WETH,
 } from '../../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../../utils.js';
@@ -30,7 +30,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             datetime: z.iso.datetime(),
@@ -44,7 +44,6 @@ const responseSchema = z.object({
             transactions: z.number(),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/ohlc/pools/svm.ts
+++ b/src/routes/token/ohlc/pools/svm.ts
@@ -7,12 +7,12 @@ import { handleUsageQueryError, makeUsageQueryJson } from '../../../../handleQue
 import { stables } from '../../../../inject/prices.tokens.js';
 import { sqlQueries } from '../../../../sql/index.js';
 import {
+    apiUsageResponse,
     endTimeSchema,
     intervalSchema,
     paginationQuery,
     SVM_networkIdSchema,
     startTimeSchema,
-    statisticsSchema,
     USDC_WSOL,
 } from '../../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../../utils.js';
@@ -30,7 +30,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             datetime: z.iso.datetime(),
@@ -44,7 +44,6 @@ const responseSchema = z.object({
             transactions: z.number(),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/ohlc/prices/evm.ts
+++ b/src/routes/token/ohlc/prices/evm.ts
@@ -7,12 +7,12 @@ import { handleUsageQueryError, makeUsageQueryJson } from '../../../../handleQue
 import { stables } from '../../../../inject/prices.tokens.js';
 import { sqlQueries } from '../../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     endTimeSchema,
     intervalSchema,
     paginationQuery,
     startTimeSchema,
-    statisticsSchema,
     WETH,
 } from '../../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../../utils.js';
@@ -30,7 +30,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             datetime: z.iso.datetime(),
@@ -44,7 +44,6 @@ const responseSchema = z.object({
             transactions: z.number(),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/pools/evm.ts
+++ b/src/routes/token/pools/evm.ts
@@ -6,11 +6,11 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     evmAddressSchema,
     paginationQuery,
     protocolSchema,
-    statisticsSchema,
     tokenSchema,
     USDC_WETH,
     uniswapPoolSchema,
@@ -28,7 +28,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // -- block --
@@ -50,7 +50,6 @@ const responseSchema = z.object({
             network_id: EVM_networkIdSchema,
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/pools/svm.ts
+++ b/src/routes/token/pools/svm.ts
@@ -6,13 +6,13 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     filterByAmm,
     filterByAmmPool,
     filterByMint,
     PumpFunAmmProgramId,
     paginationQuery,
     SVM_networkIdSchema,
-    statisticsSchema,
     svmAddressSchema,
     tokenSchema,
 } from '../../../types/zod.js';
@@ -31,7 +31,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             program_id: svmAddressSchema,
@@ -56,7 +56,6 @@ const responseSchema = z.object({
             network_id: SVM_networkIdSchema,
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/swaps/evm.ts
+++ b/src/routes/token/swaps/evm.ts
@@ -6,6 +6,7 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     endTimeSchema,
     evmAddressSchema,
@@ -15,7 +16,6 @@ import {
     paginationQuery,
     protocolSchema,
     startTimeSchema,
-    statisticsSchema,
     tokenSchema,
     USDC_WETH,
     uniswapPoolSchema,
@@ -44,7 +44,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // -- block --
@@ -76,7 +76,6 @@ const responseSchema = z.object({
             protocol: z.string(),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/swaps/svm.ts
+++ b/src/routes/token/swaps/svm.ts
@@ -6,6 +6,7 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     endTimeSchema,
     filterByAmm,
     filterByAmmPool,
@@ -17,7 +18,6 @@ import {
     paginationQuery,
     SVM_networkIdSchema,
     startTimeSchema,
-    statisticsSchema,
     svmAddressSchema,
     svmTransactionSchema,
     tokenSchema,
@@ -47,7 +47,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // -- block --
@@ -79,7 +79,6 @@ const responseSchema = z.object({
             network_id: SVM_networkIdSchema,
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/tokens/evm.ts
+++ b/src/routes/token/tokens/evm.ts
@@ -7,7 +7,7 @@ import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.
 import { injectIcons } from '../../../inject/icon.js';
 import { injectSymbol } from '../../../inject/symbol.js';
 import { sqlQueries } from '../../../sql/index.js';
-import { EVM_networkIdSchema, evmAddressSchema, GRT, statisticsSchema } from '../../../types/zod.js';
+import { apiUsageResponse, EVM_networkIdSchema, evmAddressSchema, GRT } from '../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
@@ -18,7 +18,7 @@ const querySchema = z.object({
     network_id: EVM_networkIdSchema,
 });
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // -- block --
@@ -53,7 +53,6 @@ const responseSchema = z.object({
             low_liquidity: z.optional(z.boolean()),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/tokens/svm.ts
+++ b/src/routes/token/tokens/svm.ts
@@ -7,7 +7,7 @@ import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.
 import { injectIcons } from '../../../inject/icon.js';
 import { injectSymbol } from '../../../inject/symbol.js';
 import { sqlQueries } from '../../../sql/index.js';
-import { SVM_networkIdSchema, statisticsSchema, svmAddressSchema, WSOL } from '../../../types/zod.js';
+import { apiUsageResponse, SVM_networkIdSchema, svmAddressSchema, WSOL } from '../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const paramSchema = z.object({
@@ -18,7 +18,7 @@ const querySchema = z.object({
     network_id: SVM_networkIdSchema,
 });
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // -- block --
@@ -51,7 +51,6 @@ const responseSchema = z.object({
             // low_liquidity: z.optional(z.boolean()),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -6,6 +6,7 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     EVM_networkIdSchema,
     endTimeSchema,
     evmAddressSchema,
@@ -14,7 +15,6 @@ import {
     orderDirectionSchema,
     paginationQuery,
     startTimeSchema,
-    statisticsSchema,
     Vitalik,
 } from '../../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../../utils.js';
@@ -39,7 +39,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // -- block --
@@ -70,7 +70,6 @@ const responseSchema = z.object({
             // low_liquidity: z.optional(z.boolean()),
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/routes/token/transfers/svm.ts
+++ b/src/routes/token/transfers/svm.ts
@@ -6,6 +6,7 @@ import { config } from '../../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.js';
 import { sqlQueries } from '../../../sql/index.js';
 import {
+    apiUsageResponse,
     endTimeSchema,
     filterByAuthority,
     filterByTokenAccount,
@@ -15,7 +16,6 @@ import {
     SolanaSPLTokenProgramIds,
     SVM_networkIdSchema,
     startTimeSchema,
-    statisticsSchema,
     svmAddressSchema,
     WSOL,
 } from '../../../types/zod.js';
@@ -43,7 +43,7 @@ const querySchema = z
     })
     .extend(paginationQuery.shape);
 
-const responseSchema = z.object({
+const responseSchema = apiUsageResponse.extend({
     data: z.array(
         z.object({
             // -- block --
@@ -70,7 +70,6 @@ const responseSchema = z.object({
             network_id: SVM_networkIdSchema,
         })
     ),
-    statistics: z.optional(statisticsSchema),
 });
 
 const openapi = describeRoute(

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -303,10 +303,10 @@ export type PaginationSchema = z.infer<typeof paginationSchema>;
 
 export const apiUsageResponse = z.object({
     data: z.array(z.any()),
-    statistics: z.optional(statisticsSchema),
+    statistics: statisticsSchema,
     pagination: paginationSchema,
-    results: z.optional(z.number()),
-    total_results: z.optional(z.number()),
+    results: z.number(),
+    total_results: z.number(),
     request_time: z.date(),
     duration_ms: z.number(),
 });


### PR DESCRIPTION
This includes fields like `pagination`, `statistics`, etc. to be included in the response for all EVM/SVM endpoints.
This is only for accurate reporting of OpenAPI spec to responses.