### PR TITLE
Make `network_id` required and fix optional fields for all endpoints

### DIFF
--- a/src/routes/nft/activities/evm.ts
+++ b/src/routes/nft/activities/evm.ts
@@ -25,15 +25,15 @@ const querySchema = z
         contract: PudgyPenguins,
 
         // -- `token` filter --
-        anyAddress: evmAddressSchema.default(''),
-        fromAddress: evmAddressSchema.default(''),
-        toAddress: evmAddressSchema.default(''),
+        anyAddress: evmAddressSchema.optional(),
+        fromAddress: evmAddressSchema.optional(),
+        toAddress: evmAddressSchema.optional(),
 
         // -- `time` filter --
-        startTime: startTimeSchema,
-        endTime: endTimeSchema,
-        orderBy: orderBySchemaTimestamp,
-        orderDirection: orderDirectionSchema,
+        startTime: startTimeSchema.optional(),
+        endTime: endTimeSchema.optional(),
+        orderBy: orderBySchemaTimestamp.optional(),
+        orderDirection: orderDirectionSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/nft/ownerships_for_account/evm.ts
+++ b/src/routes/nft/ownerships_for_account/evm.ts
@@ -23,8 +23,8 @@ const paramSchema = z.object({
 const querySchema = z
     .object({
         network_id: EVM_networkIdSchema,
-        token_standard: tokenStandardSchema,
-        contract: evmAddressSchema.default(''),
+        token_standard: tokenStandardSchema.optional(),
+        contract: evmAddressSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/nft/sales/evm.ts
+++ b/src/routes/nft/sales/evm.ts
@@ -28,16 +28,16 @@ const querySchema = z
         contract: PudgyPenguins,
 
         // -- `token` filter --
-        token_id: PudgyPenguinsItem.default(''),
-        anyAddress: evmAddressSchema.default(''),
-        offererAddress: evmAddressSchema.default(''),
-        recipientAddress: evmAddressSchema.default(''),
+        token_id: PudgyPenguinsItem.optional(),
+        anyAddress: evmAddressSchema.optional(),
+        offererAddress: evmAddressSchema.optional(),
+        recipientAddress: evmAddressSchema.optional(),
 
         // -- `time` filter --
-        startTime: startTimeSchema,
-        endTime: endTimeSchema,
-        orderBy: orderBySchemaTimestamp,
-        orderDirection: orderDirectionSchema,
+        startTime: startTimeSchema.optional(),
+        endTime: endTimeSchema.optional(),
+        orderBy: orderBySchemaTimestamp.optional(),
+        orderDirection: orderDirectionSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/balances/evm.ts
+++ b/src/routes/token/balances/evm.ts
@@ -21,7 +21,7 @@ const paramSchema = z.object({
 const querySchema = z
     .object({
         network_id: EVM_networkIdSchema,
-        contract: evmAddressSchema.default(''),
+        contract: evmAddressSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/balances/svm.ts
+++ b/src/routes/token/balances/svm.ts
@@ -18,10 +18,10 @@ import { validatorHook, withErrorResponses } from '../../../utils.js';
 
 const querySchema = z
     .object({
-        token_account: filterByTokenAccount.default(''),
-        mint: WSOL.default(''),
-        program_id: SolanaSPLTokenProgramIds.default(''),
         network_id: SVM_networkIdSchema,
+        token_account: filterByTokenAccount.optional(),
+        mint: WSOL.optional(),
+        program_id: SolanaSPLTokenProgramIds.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/historical/balances/evm.ts
+++ b/src/routes/token/historical/balances/evm.ts
@@ -23,11 +23,11 @@ const paramSchema = z.object({
 
 const querySchema = z
     .object({
-        interval: intervalSchema,
         network_id: EVM_networkIdSchema,
-        contracts: evmAddressSchema.array().default([]),
-        startTime: startTimeSchema,
-        endTime: endTimeSchema,
+        interval: intervalSchema.optional(),
+        contracts: evmAddressSchema.array().default([]).optional(),
+        startTime: startTimeSchema.optional(),
+        endTime: endTimeSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -23,8 +23,8 @@ const paramSchema = z.object({
 const querySchema = z
     .object({
         network_id: EVM_networkIdSchema,
-        orderBy: orderBySchemaValue,
-        orderDirection: orderDirectionSchema,
+        orderBy: orderBySchemaValue.optional(),
+        orderDirection: orderDirectionSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/holders/svm.ts
+++ b/src/routes/token/holders/svm.ts
@@ -23,8 +23,8 @@ const paramSchema = z.object({
 const querySchema = z
     .object({
         network_id: SVM_networkIdSchema,
-        orderBy: orderBySchemaValue,
-        orderDirection: orderDirectionSchema,
+        orderBy: orderBySchemaValue.optional(),
+        orderDirection: orderDirectionSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/ohlc/pools/evm.ts
+++ b/src/routes/token/ohlc/pools/evm.ts
@@ -24,9 +24,9 @@ const paramSchema = z.object({
 const querySchema = z
     .object({
         network_id: EVM_networkIdSchema,
-        interval: intervalSchema,
-        startTime: startTimeSchema,
-        endTime: endTimeSchema,
+        interval: intervalSchema.optional(),
+        startTime: startTimeSchema.optional(),
+        endTime: endTimeSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/ohlc/pools/svm.ts
+++ b/src/routes/token/ohlc/pools/svm.ts
@@ -24,9 +24,9 @@ const paramSchema = z.object({
 const querySchema = z
     .object({
         network_id: SVM_networkIdSchema,
-        interval: intervalSchema,
-        startTime: startTimeSchema,
-        endTime: endTimeSchema,
+        interval: intervalSchema.optional(),
+        startTime: startTimeSchema.optional(),
+        endTime: endTimeSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/ohlc/prices/evm.ts
+++ b/src/routes/token/ohlc/prices/evm.ts
@@ -24,9 +24,9 @@ const paramSchema = z.object({
 const querySchema = z
     .object({
         network_id: EVM_networkIdSchema,
-        interval: intervalSchema,
-        startTime: startTimeSchema,
-        endTime: endTimeSchema,
+        interval: intervalSchema.optional(),
+        startTime: startTimeSchema.optional(),
+        endTime: endTimeSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/pools/evm.ts
+++ b/src/routes/token/pools/evm.ts
@@ -21,10 +21,10 @@ import { validatorHook, withErrorResponses } from '../../../utils.js';
 const querySchema = z
     .object({
         network_id: EVM_networkIdSchema,
-        pool: USDC_WETH.default(''),
-        factory: evmAddressSchema.default(''),
-        token: WETH.default(''),
-        protocol: protocolSchema,
+        pool: USDC_WETH.optional(),
+        factory: evmAddressSchema.optional(),
+        token: WETH.optional(),
+        protocol: protocolSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/pools/svm.ts
+++ b/src/routes/token/pools/svm.ts
@@ -24,10 +24,10 @@ const querySchema = z
 
         // -- `swaps` filter --
         program_id: PumpFunAmmProgramId,
-        amm: filterByAmm.default(''),
-        amm_pool: filterByAmmPool.default(''),
-        input_mint: filterByMint.default(''),
-        output_mint: filterByMint.default(''),
+        amm: filterByAmm.optional(),
+        amm_pool: filterByAmmPool.optional(),
+        input_mint: filterByMint.optional(),
+        output_mint: filterByMint.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/swaps/evm.ts
+++ b/src/routes/token/swaps/evm.ts
@@ -27,20 +27,20 @@ const querySchema = z
         network_id: EVM_networkIdSchema,
 
         // -- `swaps` filter --
-        pool: USDC_WETH.default(''),
-        caller: evmAddressSchema.default(''),
-        sender: evmAddressSchema.default(''),
-        recipient: evmAddressSchema.default(''),
-        protocol: protocolSchema.default(''),
+        pool: USDC_WETH.optional(),
+        caller: evmAddressSchema.optional(),
+        sender: evmAddressSchema.optional(),
+        recipient: evmAddressSchema.optional(),
+        protocol: protocolSchema.optional(),
 
         // -- `time` filter --
-        startTime: startTimeSchema,
-        endTime: endTimeSchema,
-        orderBy: orderBySchemaTimestamp,
-        orderDirection: orderDirectionSchema,
+        startTime: startTimeSchema.optional(),
+        endTime: endTimeSchema.optional(),
+        orderBy: orderBySchemaTimestamp.optional(),
+        orderDirection: orderDirectionSchema.optional(),
 
         // -- `transaction` filter --
-        transaction_id: evmTransactionSchema.default(''),
+        transaction_id: evmTransactionSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/swaps/svm.ts
+++ b/src/routes/token/swaps/svm.ts
@@ -30,20 +30,20 @@ const querySchema = z
 
         // -- `swaps` filter --
         program_id: PumpFunAmmProgramId,
-        amm: filterByAmm.default(''),
-        amm_pool: filterByAmmPool.default(''),
-        user: filterByUser.default(''),
-        input_mint: filterByMint.default(''),
-        output_mint: filterByMint.default(''),
+        amm: filterByAmm.optional(),
+        amm_pool: filterByAmmPool.optional(),
+        user: filterByUser.optional(),
+        input_mint: filterByMint.optional(),
+        output_mint: filterByMint.optional(),
 
         // -- `time` filter --
-        startTime: startTimeSchema,
-        endTime: endTimeSchema,
-        orderBy: orderBySchemaTimestamp,
-        orderDirection: orderDirectionSchema,
+        startTime: startTimeSchema.optional(),
+        endTime: endTimeSchema.optional(),
+        orderBy: orderBySchemaTimestamp.optional(),
+        orderDirection: orderDirectionSchema.optional(),
 
         // -- `transaction` filter --
-        signature: svmTransactionSchema.default(''),
+        signature: svmTransactionSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -24,18 +24,18 @@ const querySchema = z
         network_id: EVM_networkIdSchema,
 
         // -- `token` filter --
-        from: evmAddressSchema.default(''),
-        to: Vitalik.default(''),
-        contract: evmAddressSchema.default(''),
+        from: evmAddressSchema.optional(),
+        to: Vitalik.optional(),
+        contract: evmAddressSchema.optional(),
 
         // -- `time` filter --
-        startTime: startTimeSchema,
-        endTime: endTimeSchema,
-        orderBy: orderBySchemaTimestamp,
-        orderDirection: orderDirectionSchema,
+        startTime: startTimeSchema.optional(),
+        endTime: endTimeSchema.optional(),
+        orderBy: orderBySchemaTimestamp.optional(),
+        orderDirection: orderDirectionSchema.optional(),
 
         // -- `transaction` filter --
-        transaction_id: evmTransactionSchema.default(''),
+        transaction_id: evmTransactionSchema.optional(),
     })
     .extend(paginationQuery.shape);
 

--- a/src/routes/token/transfers/svm.ts
+++ b/src/routes/token/transfers/svm.ts
@@ -26,17 +26,17 @@ const querySchema = z
         network_id: SVM_networkIdSchema,
 
         // -- `token` filter --
-        mint: WSOL.default(''),
-        source: filterByTokenAccount.default(''),
-        destination: filterByTokenAccount.default(''),
-        authority: filterByAuthority.default(''),
-        program_id: SolanaSPLTokenProgramIds.default(''),
+        mint: WSOL.optional(),
+        source: filterByTokenAccount.optional(),
+        destination: filterByTokenAccount.optional(),
+        authority: filterByAuthority.optional(),
+        program_id: SolanaSPLTokenProgramIds.optional(),
 
         // -- `time` filter --
-        startTime: startTimeSchema,
-        endTime: endTimeSchema,
-        orderBy: orderBySchemaTimestamp,
-        orderDirection: orderDirectionSchema,
+        startTime: startTimeSchema.optional(),
+        endTime: endTimeSchema.optional(),
+        orderBy: orderBySchemaTimestamp.optional(),
+        orderDirection: orderDirectionSchema.optional(),
 
         // -- `transaction` filter --
         // signature: z.optional(svmTransactionSchema),

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -67,11 +67,12 @@ export const uniswapPoolSchema = z
         description: 'Filter by pool',
     });
 
-export const svmAddressSchema = svmAddress.pipe(z.string()).meta({
+export const svmAddressSchema = svmAddress.pipe(z.string()).default('').meta({
     description: 'Filter by address',
 });
 export const svmTransactionSchema = svmTransaction
     .pipe(z.string())
+    .default('')
     .meta({ description: 'Filter by transaction signature' });
 
 // z.enum argument type definition requires at least one element to be defined
@@ -272,8 +273,8 @@ export const mintSchema = z.object({
 // API Query Params
 // ----------------------
 export const paginationQuery = z.object({
-    limit: limitSchema,
-    page: pageSchema,
+    limit: limitSchema.optional(),
+    page: pageSchema.optional(),
 });
 export type PaginationQuery = z.infer<typeof paginationQuery>;
 


### PR DESCRIPTION
Zod migration to V4 made all parameters required.
This fix ensure optional parameteres remain and make `network_id` required on all endpoints.