### PR TITLE
Improve health endpoint to test for DB and endpoints status

### DIFF
--- a/src/clickhouse/client.ts
+++ b/src/clickhouse/client.ts
@@ -1,8 +1,6 @@
 import { createClient } from '@clickhouse/client-web';
 import type { WebClickHouseClientConfigOptions } from '@clickhouse/client-web/dist/config.js';
-import { APP_NAME, config } from '../config.js';
-
-export const MAX_EXECUTION_TIME = 10;
+import { APP_NAME, config, MAX_EXECUTION_TIME } from '../config.js';
 
 // TODO: Check how to abort previous queries if haven't returned yet
 const client = (custom_config?: WebClickHouseClientConfigOptions) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ export const DEFAULT_PASSWORD = '';
 export const DEFAULT_MAX_LIMIT = 1000;
 export const DEFAULT_LARGE_QUERIES_ROWS_TRIGGER = 10_000_000; // 10M rows
 export const DEFAULT_LARGE_QUERIES_BYTES_TRIGGER = 1_000_000_000; // 1Gb
+export const DEFAULT_DB_RESPONSE_TIME_TRIGGER_MS = 1000;
 export const DEFAULT_IDLE_TIMEOUT = 60;
 export const DEFAULT_PRETTY_LOGGING = false;
 export const DEFAULT_VERBOSE = false;
@@ -52,6 +53,7 @@ export const GIT_APP = {
 export const APP_NAME = pkg.name;
 export const APP_DESCRIPTION = pkg.description;
 export const APP_VERSION = `${GIT_APP.version}+${GIT_APP.commit} (${GIT_APP.date})`;
+export const MAX_EXECUTION_TIME = 10;
 
 // parse command line options
 const opts = program
@@ -127,6 +129,14 @@ const opts = program
         )
             .env('LARGE_QUERIES_BYTES_TRIGGER')
             .default(DEFAULT_LARGE_QUERIES_BYTES_TRIGGER)
+    )
+    .addOption(
+        new Option(
+            '--degraded-db-response-time <number>',
+            'Maximum database response time for health check to be considered degraded'
+        )
+            .env('DB_RESPONSE_TIME_TRIGGER_MS')
+            .default(DEFAULT_DB_RESPONSE_TIME_TRIGGER_MS)
     )
     .addOption(
         new Option('--idle-timeout <number>', 'HTTP server request idle timeout (seconds)')
@@ -217,6 +227,7 @@ const config = z
         maxLimit: z.coerce.number().positive('Max limit must be positive'),
         maxRowsTrigger: z.coerce.number().positive('Max rows trigger must be positive'),
         maxBytesTrigger: z.coerce.number().positive('Max bytes trigger must be positive'),
+        degradedDbResponseTime: z.coerce.number().positive('Max response time must be positive'),
         idleTimeout: z.coerce.number().nonnegative('Idle timeout must be non-negative'),
         // `z.coerce.boolean` doesn't parse boolean string values as expected (see https://github.com/colinhacks/zod/issues/1630)
         prettyLogging: z.coerce.string().transform((val) => val.toLowerCase() === 'true'),

--- a/src/handleQuery.ts
+++ b/src/handleQuery.ts
@@ -1,9 +1,8 @@
 import type { WebClickHouseClientConfigOptions } from '@clickhouse/client-web/dist/config.js';
 import type { Context } from 'hono';
 import { ZodError } from 'zod';
-import { MAX_EXECUTION_TIME } from './clickhouse/client.js';
 import { makeQuery } from './clickhouse/makeQuery.js';
-import { DEFAULT_LIMIT, DEFAULT_PAGE } from './config.js';
+import { DEFAULT_LIMIT, DEFAULT_PAGE, MAX_EXECUTION_TIME } from './config.js';
 import {
     type ApiErrorResponse,
     type ApiUsageResponse,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -16,7 +16,16 @@ class TsLogger extends Logger<ILogObj> {
 
     public disable() {
         this.settings.type = 'hidden';
+        this.settings.minLevel = 5;
         this.info('Disabled logger');
+    }
+
+    public getLevel() {
+        return this.settings.minLevel;
+    }
+
+    public setLevel(level: number) {
+        this.settings.minLevel = level;
     }
 }
 

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,38 +1,254 @@
 import { Hono } from 'hono';
 import { describeRoute } from 'hono-openapi';
-import { resolver } from 'hono-openapi/zod';
+import { resolver, validator } from 'hono-openapi/zod';
 import { z } from 'zod';
 import client from '../clickhouse/client.js';
-import { APIErrorResponse, withErrorResponses } from '../utils.js';
+import { config, MAX_EXECUTION_TIME } from '../config.js';
+import { logger } from '../logger.js';
+import { validatorHook, withErrorResponses } from '../utils.js';
 
-const route = new Hono();
+const querySchema = z.object({
+    skip_endpoints: z.optional(z.enum(['true', 'false']).default('true')),
+});
+
+const healthResponseSchema = z.object({
+    status: z.enum(['healthy', 'degraded', 'unhealthy']),
+    checks: z.object({
+        database: z.enum(['up', 'down', 'slow']),
+        api_endpoints: z.enum(['up', 'down', 'partial', 'skipped']),
+    }),
+    request_time: z.iso.datetime(),
+    duration_ms: z.number(),
+});
+type HealthResponse = z.infer<typeof healthResponseSchema>;
 
 const openapi = describeRoute(
     withErrorResponses({
         summary: 'Health Check',
-        description: 'Returns API operational status.',
+        description:
+            'Returns API operational status and dependency health. Use `skip_endpoints=true` for faster database-only checks.',
         tags: ['Monitoring'],
         responses: {
             200: {
-                description: 'Successful Response',
+                description: 'API is healthy or degraded',
                 content: {
-                    'text/plain': { schema: resolver(z.string()), examples: { example: { value: 'OK' } } },
+                    'application/json': {
+                        schema: resolver(healthResponseSchema),
+                        examples: {
+                            healthy: {
+                                summary: 'Healthy API',
+                                value: {
+                                    status: 'healthy',
+                                    checks: {
+                                        database: 'up',
+                                        api_endpoints: 'up',
+                                    },
+                                    request_time: '2025-08-06 12:00:00',
+                                    duration_ms: 1250,
+                                },
+                            },
+                            degraded: {
+                                summary: 'Degraded API',
+                                value: {
+                                    status: 'degraded',
+                                    checks: {
+                                        database: 'slow',
+                                        api_endpoints: 'partial',
+                                    },
+                                    request_time: '2025-08-06 12:00:00',
+                                    duration_ms: 3400,
+                                },
+                            },
+                            skipped: {
+                                summary: 'Database-only check',
+                                value: {
+                                    status: 'healthy',
+                                    checks: {
+                                        database: 'up',
+                                        api_endpoints: 'skipped',
+                                    },
+                                    request_time: '2025-08-06 12:00:00',
+                                    duration_ms: 125,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            503: {
+                description: 'API is unhealthy',
+                content: {
+                    'application/json': {
+                        schema: resolver(healthResponseSchema),
+                        examples: {
+                            unhealthy: {
+                                summary: 'Unhealthy API',
+                                value: {
+                                    status: 'unhealthy',
+                                    checks: {
+                                        database: 'down',
+                                        api_endpoints: 'down',
+                                    },
+                                    request_time: '2025-08-06 12:00:00',
+                                    duration_ms: 5000,
+                                },
+                            },
+                        },
+                    },
                 },
             },
         },
     })
 );
 
-route.get('/health', openapi, async (c) => {
-    const response = await client().ping();
-    if (!response.success) {
-        const message = JSON.parse(response.error.message);
-        if (message.code === 516) return APIErrorResponse(c, 403, 'authentication_failed', response.error.message);
-        if (message.code === 'ConnectionRefused')
-            return APIErrorResponse(c, 502, 'connection_refused', response.error.message);
-        return APIErrorResponse(c, 500, 'bad_database_response', response.error.message);
+const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema> } }>();
+
+route.get('/health', openapi, validator('query', querySchema, validatorHook), async (c) => {
+    const params = c.get('validatedData');
+    const startTime = Date.now();
+    const skipEndpoints = params.skip_endpoints === 'true';
+
+    let overallStatus: 'healthy' | 'degraded' | 'unhealthy' = 'healthy';
+
+    // Database check
+    let dbStatus: 'up' | 'down' | 'slow' = 'up';
+    try {
+        const dbStart = Date.now();
+        const response = await client().ping();
+        const dbResponseTime = Date.now() - dbStart;
+
+        if (!response.success) {
+            dbStatus = 'down';
+            overallStatus = 'unhealthy';
+        } else if (dbResponseTime > config.degradedDbResponseTime) {
+            dbStatus = 'slow';
+            overallStatus = 'degraded';
+        }
+    } catch (_error) {
+        dbStatus = 'down';
+        overallStatus = 'unhealthy';
     }
-    return new Response('OK');
+
+    // API endpoints check (optional)
+    let apiStatus: 'up' | 'down' | 'partial' | 'skipped' = 'skipped';
+
+    if (!skipEndpoints) {
+        try {
+            const baseUrl = `http://${config.hostname}:${config.port}`;
+
+            const testEndpoints = [
+                // Monitoring endpoints (no auth required)
+                '/openapi',
+                '/networks',
+                '/version',
+
+                // NFT endpoints
+                '/nft/ownerships/evm/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045?network_id=mainnet',
+                '/nft/collections/evm/0xbd3531da5cf5857e7cfaa92426877b022e612cf8?network_id=mainnet',
+                '/nft/items/evm/contract/0xbd3531da5cf5857e7cfaa92426877b022e612cf8/token_id/5712?network_id=mainnet',
+                '/nft/activities/evm?network_id=mainnet',
+                '/nft/holders/evm/0xbd3531da5cf5857e7cfaa92426877b022e612cf8?network_id=mainnet',
+                '/nft/sales/evm?network_id=mainnet',
+
+                // Balance endpoints
+                '/balances/evm/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045?network_id=mainnet',
+                '/balances/svm?network_id=solana',
+
+                // Transfer endpoints
+                '/transfers/evm?network_id=mainnet',
+                '/transfers/svm?network_id=solana',
+
+                // Token endpoints
+                '/tokens/evm/0xc944e90c64b2c07662a292be6244bdf05cda44a7?network_id=mainnet',
+                '/holders/evm/0xc944e90c64b2c07662a292be6244bdf05cda44a7?network_id=mainnet',
+
+                // Swap endpoints
+                '/swaps/evm?network_id=mainnet',
+                '/swaps/svm?network_id=solana',
+
+                // Pool endpoints
+                '/pools/evm?network_id=mainnet',
+
+                // OHLC endpoints
+                '/ohlc/pools/evm/0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640?network_id=mainnet',
+                '/ohlc/prices/evm/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2?network_id=mainnet',
+
+                // Historical endpoints
+                '/historical/balances/evm/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045?network_id=mainnet',
+            ];
+
+            const endpointResults = await Promise.allSettled(
+                testEndpoints.map(async (endpoint) => {
+                    const response = await fetch(`${baseUrl}${endpoint}`, {
+                        method: 'GET',
+                        signal: AbortSignal.timeout(MAX_EXECUTION_TIME * 1000),
+                    });
+
+                    const isWorking = response.status === 200;
+
+                    if (!isWorking)
+                        logger.error(
+                            `Health check failed for endpoint ${endpoint}: HTTP ${response.status} - ${response.statusText || 'Unknown error'}`
+                        );
+
+                    return {
+                        endpoint,
+                        status: response.status,
+                        working: isWorking,
+                    };
+                })
+            );
+
+            const results = endpointResults.map((result) =>
+                result.status === 'fulfilled' ? result.value : { working: false }
+            );
+
+            const workingEndpoints = results.filter((r) => r.working).length;
+            const totalEndpoints = testEndpoints.length;
+
+            if (workingEndpoints === 0) {
+                apiStatus = 'down';
+                overallStatus = 'unhealthy';
+            } else if (workingEndpoints < totalEndpoints) {
+                apiStatus = 'partial';
+                if (overallStatus === 'healthy') overallStatus = 'degraded';
+            } else {
+                apiStatus = 'up';
+            }
+        } catch (_error) {
+            apiStatus = 'down';
+            overallStatus = 'unhealthy';
+        }
+    } else {
+        // When skipping endpoints, base overall status on database status only
+        apiStatus = 'skipped';
+        // Assume API endpoints are working if database is working
+        if (dbStatus === 'down') {
+            overallStatus = 'unhealthy';
+        } else if (dbStatus === 'slow') {
+            overallStatus = 'degraded';
+        } else {
+            overallStatus = 'healthy';
+        }
+    }
+
+    const healthResponse: HealthResponse = {
+        status: overallStatus,
+        checks: {
+            database: dbStatus,
+            api_endpoints: apiStatus,
+        },
+        request_time: new Date(startTime).toISOString().replace('T', ' ').substring(0, 19),
+        duration_ms: Date.now() - startTime,
+    };
+
+    const httpStatus = overallStatus === 'unhealthy' ? 503 : 200;
+
+    c.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    c.header('Pragma', 'no-cache');
+    c.header('Expires', '0');
+
+    return c.json(healthResponse, httpStatus);
 });
 
 export default route;


### PR DESCRIPTION
- New `--degraded-db-response-time` or `DB_RESPONSE_TIME_TRIGGER_MS` config option with default of 1s
- Check for DB response time by default and skip endpoint testing
- Use `skip_endpoints=false` for testing default endpoint queries response time
- Returns health state for database and API separately