### PR TITLE
Update SVM Balances to filter by `owner`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,8 @@ DBS_NFT=mainnet:evm-nft-tokens@v0.5.1
 DBS_UNISWAP=mainnet:evm-uniswaps@v0.1.5
 
 # Spam API
-SPAM_API_URL=http://localhost:3000
+# See https://github.com/semiotic-ai/nft-api
+SPAM_API_URL=https://localhost:3000
 REDIS_URL=redis://localhost:6379
 
 # OpenAPI

--- a/src/routes/token/balances/svm.ts
+++ b/src/routes/token/balances/svm.ts
@@ -7,6 +7,7 @@ import { handleUsageQueryError, makeUsageQueryJson } from '../../../handleQuery.
 import { sqlQueries } from '../../../sql/index.js';
 import {
     apiUsageResponse,
+    filterByOwner,
     filterByTokenAccount,
     PumpFunMetadataName,
     PumpFunMetadataSymbol,
@@ -22,6 +23,7 @@ import { validatorHook, withErrorResponses } from '../../../utils.js';
 const querySchema = z
     .object({
         network_id: SVM_networkIdSchema,
+        owner: filterByOwner,
         token_account: filterByTokenAccount.optional(),
         mint: WSOL.optional(),
         program_id: SolanaSPLTokenProgramIds.optional(),
@@ -61,8 +63,8 @@ const responseSchema = apiUsageResponse.extend({
 
 const openapi = describeRoute(
     withErrorResponses({
-        summary: 'Solana Balances',
-        description: 'Returns SPL token balances for Solana token accounts with mint and program data.',
+        summary: 'Solana Balances by Owner',
+        description: 'Returns SPL token balances for Solana token owners with mint and program data.',
 
         tags: ['SVM'],
         security: [{ bearerAuth: [] }],


### PR DESCRIPTION
For ease of use, the balances are now returned by `owner` instead of Associated Token Accounts (ATA).
- New `owner` parameter now required
- `token_account` and/or `mint` optional for filtering tokens