### PR TITLE
Handle database timeout issue from error message

### DIFF
--- a/src/handleQuery.ts
+++ b/src/handleQuery.ts
@@ -2,7 +2,7 @@ import type { WebClickHouseClientConfigOptions } from '@clickhouse/client-web/di
 import type { Context } from 'hono';
 import { ZodError } from 'zod';
 import { makeQuery } from './clickhouse/makeQuery.js';
-import { DEFAULT_LIMIT, DEFAULT_PAGE, MAX_EXECUTION_TIME } from './config.js';
+import { DEFAULT_LIMIT, DEFAULT_PAGE } from './config.js';
 import {
     type ApiErrorResponse,
     type ApiUsageResponse,
@@ -54,15 +54,6 @@ export async function makeUsageQueryJson<T = unknown>(
 
     try {
         const result = await makeQuery<T>(query.join(' '), params, overwrite_config);
-
-        // Handle query execution timeout
-        if (result.statistics && result.statistics.elapsed >= MAX_EXECUTION_TIME) {
-            return {
-                status: 504 as ServerErrorResponse['status'],
-                code: 'database_timeout' as ServerErrorResponse['code'],
-                message: 'Query took too long. Consider applying more filter parameters if possible.',
-            };
-        }
 
         const total_results = result.rows_before_limit_at_least ?? 0;
         return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,13 +28,22 @@ export function APIErrorResponse(
         message = err.message;
     }
 
-    const api_error = {
+    let api_error = {
         status,
         code,
         message,
     };
 
     logger.error(api_error);
+
+    // Handle query execution timeout
+    if (message.includes('Timeout')) {
+        api_error = {
+            status: 504 as ServerErrorResponse['status'],
+            code: 'database_timeout' as ServerErrorResponse['code'],
+            message: 'Query took too long. Consider applying more filter parameters if possible.',
+        };
+    }
 
     if (status >= 500) return c.json<ServerErrorResponse, typeof status>(api_error as ServerErrorResponse, status);
 


### PR DESCRIPTION
Don't catch database timeout from `elapsed` statistics but from database error message.