### PR TITLE
Return null native SOL Balances instead of filtering them out

### DIFF
--- a/src/sql/native_balances_for_account/svm.sql
+++ b/src/sql/native_balances_for_account/svm.sql
@@ -11,7 +11,6 @@ WITH filtered_balances AS
     FROM balances AS b
     WHERE mint = 'So11111111111111111111111111111111111111111'
         AND account = {address:String}
-        AND b.amount > 0
     GROUP BY program_id, mint, account
     ORDER BY timestamp DESC
     LIMIT  {limit:UInt64}


### PR DESCRIPTION
Otherwise the response looks like empty data.