### PR TITLE
Return cached spam status even when stale

### DIFF
--- a/src/services/spamScoring.ts
+++ b/src/services/spamScoring.ts
@@ -67,20 +67,18 @@ export async function querySpamScore(contractAddress: string, networkId: string)
             if (!cachedData.timestamp || Date.now() - cachedData.timestamp > STALE_MS) {
                 Promise.resolve().then(() => {
                     fetchAndCacheSpamScore(contractAddress, chainId, cacheKey).catch((error) =>
-                        console.error('Background fetch error:', error),
+                        console.error('Background fetch error:', error)
                     );
                 });
             }
 
-            const { timestamp, ...data } = cachedData;
-
             return {
-                ...data,
+                ...cachedData,
                 result: 'success',
             };
         }
     } catch (error) {
-        console.error('Error checking cache:', error);
+        console.error('Error checking cache: ', error, ', fetching from API');
     }
 
     // Not in cache - trigger background fetch and return pending status


### PR DESCRIPTION
Implements #202 

- keep spam status cached for 30 days and track timestamp
- serve cached spam status even when stale and refresh asynchronously
