### PR TITLE
Update `metadata` JOINs for EVM token endpoints

### DIFF
--- a/src/sql/balances_for_account/evm.sql
+++ b/src/sql/balances_for_account/evm.sql
@@ -25,4 +25,4 @@ SELECT
     decimals,
     {network_id: String} AS network_id
 FROM filtered_balances AS a
-LEFT JOIN metadata AS b USING contract
+LEFT JOIN metadata_view AS b USING contract

--- a/src/sql/historical_balances_for_account/evm.sql
+++ b/src/sql/historical_balances_for_account/evm.sql
@@ -29,7 +29,7 @@ SELECT
     close_raw / pow(10, decimals) AS close,
     {network_id: String} as network_id
 FROM ohlc AS o
-LEFT JOIN metadata AS c USING contract
+LEFT JOIN metadata_view AS c USING contract
 ORDER BY datetime DESC
 LIMIT   {limit:UInt64}
 OFFSET  {offset:UInt64}

--- a/src/sql/holders_for_contract/evm.sql
+++ b/src/sql/holders_for_contract/evm.sql
@@ -25,4 +25,4 @@ SELECT
     decimals,
     {network_id: String} as network_id
 FROM filtered_balances AS a
-LEFT JOIN metadata AS b USING contract
+LEFT JOIN metadata_view AS b USING contract

--- a/src/sql/tokens_for_contract/evm.sql
+++ b/src/sql/tokens_for_contract/evm.sql
@@ -3,7 +3,7 @@ WITH m AS (
         symbol,
         name,
         decimals
-    FROM metadata
+    FROM metadata_view
     WHERE contract = {contract: String}
 ), s AS (
     SELECT

--- a/src/sql/transfers/evm.sql
+++ b/src/sql/transfers/evm.sql
@@ -33,5 +33,5 @@ SELECT
     t.amount / pow(10, decimals) AS value,
     {network_id:String} AS network_id
 FROM filtered_transfers AS t
-LEFT JOIN metadata AS c USING contract
+LEFT JOIN metadata_view AS c USING contract
 ORDER BY timestamp DESC


### PR DESCRIPTION
New substreams version 1.17.2 for EVM tokens renamed `metadata` table to `metadata_view`.
This affects:
- `/balances`
- `/historical/balances`
- `/transfers`
- `/tokens`
- `/holders`