### PR TITLE
Add plan-based API limits

### DIFF
--- a/src/routes/v1/evm/balances/historical/evm.ts
+++ b/src/routes/v1/evm/balances/historical/evm.ts
@@ -16,14 +16,14 @@ import {
     intervalSchema,
     timestampSchema,
 } from '../../../../../types/zod.js';
-import { validatorHook, withErrorResponses } from '../../../../../utils.js';
+import { getDateMinusMonths, validatorHook, withErrorResponses } from '../../../../../utils.js';
 
 const querySchema = createQuerySchema({
     network: { schema: evmNetworkIdSchema },
     address: { schema: evmAddressSchema },
     contract: { schema: evmContractSchema, batched: true, default: '', meta: { example: EVM_CONTRACT_NATIVE_EXAMPLE } },
     interval: { schema: intervalSchema, prefault: '1d', meta: { example: '1w' } },
-    start_time: { schema: timestampSchema, prefault: '2025-01-01' },
+    start_time: { schema: timestampSchema, prefault: getDateMinusMonths(1) },
     end_time: { schema: timestampSchema, prefault: '2050-01-01' },
 });
 

--- a/src/routes/v1/evm/pools/ohlc/evm.ts
+++ b/src/routes/v1/evm/pools/ohlc/evm.ts
@@ -15,14 +15,14 @@ import {
     intervalSchema,
     timestampSchema,
 } from '../../../../../types/zod.js';
-import { validatorHook, withErrorResponses } from '../../../../../utils.js';
+import { getDateMinusMonths, validatorHook, withErrorResponses } from '../../../../../utils.js';
 
 const querySchema = createQuerySchema({
     network: { schema: evmNetworkIdSchema },
 
     pool: { schema: evmPoolSchema, meta: { example: EVM_POOL_USDC_WETH_EXAMPLE } },
     interval: { schema: intervalSchema, prefault: '1d' },
-    start_time: { schema: timestampSchema, prefault: '2025-01-01' },
+    start_time: { schema: timestampSchema, prefault: getDateMinusMonths(1) },
     end_time: { schema: timestampSchema, prefault: '2050-01-01' },
 });
 

--- a/src/routes/v1/svm/pools/ohlc/svm.ts
+++ b/src/routes/v1/svm/pools/ohlc/svm.ts
@@ -16,14 +16,14 @@ import {
     svmNetworkIdSchema,
     timestampSchema,
 } from '../../../../../types/zod.js';
-import { validatorHook, withErrorResponses } from '../../../../../utils.js';
+import { getDateMinusMonths, validatorHook, withErrorResponses } from '../../../../../utils.js';
 
 const querySchema = createQuerySchema({
     network: { schema: svmNetworkIdSchema },
     amm_pool: { schema: svmAmmPoolSchema },
 
     interval: { schema: intervalSchema, prefault: '1d' },
-    start_time: { schema: timestampSchema, prefault: '2025-01-01' },
+    start_time: { schema: timestampSchema, prefault: getDateMinusMonths(1) },
     end_time: { schema: timestampSchema, prefault: '2050-01-01' },
 });
 

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -105,7 +105,7 @@ export const svmProtocolSchema = z
     .meta({ description: 'Protocol name', example: 'raydium_amm_v4' });
 
 // ----------------------
-// Common Query Parameter Schemas (with defaults for SQL)
+// Common Query Parameter Schemas
 // ----------------------
 
 export const limitSchema = z.coerce.number().int().min(1).max(config.maxLimit).default(DEFAULT_LIMIT).optional().meta({
@@ -121,8 +121,9 @@ export const pageSchema = z.coerce
     .optional()
     .meta({ description: 'Page number to fetch.<br>Empty `data` array signifies end of results.' });
 
+const intervals = ['1h', '4h', '1d', '1w'] as const;
 export const intervalSchema = z
-    .enum(['1h', '4h', '1d', '1w'])
+    .enum(intervals)
     .transform((interval: string) => {
         switch (interval) {
             case '1h':
@@ -139,9 +140,10 @@ export const intervalSchema = z
     })
     .meta({
         type: 'string',
-        enum: ['1h', '4h', '1d', '1w'],
+        enum: intervals,
         default: '1d',
-        description: 'The interval for which to aggregate price data (hourly, 4-hours, daily or weekly).',
+        description:
+            'The interval* for which to aggregate price data (hourly, 4-hours, daily or weekly).<br>*Plan restricted.',
     });
 
 export const timestampSchema = z


### PR DESCRIPTION
Plan limits:
- Maximum results per request (`limit` parameter)
- Maximum batched parameters (addresses, contracts, etc.)
- Maximum OHLCV data bars based on time range and interval
- Allowed intervals for OHLCV endpoints

Key features:
- Plans configurable via `PLANS` env var using format:
  `name:limit,batched,bars,intervals`
  Example: `basic:5,1,64,1d|1w`
- Zero values indicate unlimited access for that restriction
- Empty `PLANS` config bypasses all limits (local development)
- Validates `X-Plan` header and enforces plan restrictions