### PR TITLE
add filter by address

### DIFF
--- a/src/routes/v1/svm/transfers/svm.ts
+++ b/src/routes/v1/svm/transfers/svm.ts
@@ -34,7 +34,7 @@ const querySchema = createQuerySchema({
         default: '',
         meta: { example: SVM_TRANSACTION_TRANSFER_EXAMPLE },
     },
-    // address: { schema: svmTokenAccountSchema, batched: true, default: '' },
+    address: { schema: svmTokenAccountSchema, batched: true, default: '' },
     source: { schema: svmTokenAccountSchema, batched: true, default: '' },
     destination: {
         schema: svmTokenAccountSchema,


### PR DESCRIPTION
Related to: https://github.com/pinax-network/substreams-solana/blob/main/clickhouse-solana-tokens/schema.3.mv.accounts_by_date.sql

```sql
-- Accounts interactions by Date --
CREATE TABLE IF NOT EXISTS accounts_by_date (
    account                 String,
    date                    Date COMMENT 'toDate(timestamp)',

    INDEX idx_date          (date) TYPE minmax GRANULARITY 1
)
ENGINE = ReplacingMergeTree
ORDER BY (account, date)
COMMENT 'Accounts interactions by date';
```