### PR TITLE
Improve /svm/transfers query

### DIFF
--- a/src/sql/transfers/svm.sql
+++ b/src/sql/transfers/svm.sql
@@ -120,7 +120,7 @@ metadata AS
     WHERE metadata IN (
         SELECT metadata
         FROM metadata_mint_state_latest
-        JOIN filtered_transfers USING mint
+        WHERE mint IN (SELECT DISTINCT mint FROM filtered_transfers)
         GROUP BY metadata
     )
 )


### PR DESCRIPTION
It uses schema for v0.2.7, which has a breaking change and won't work with v0.2.8 database. Needs minor tweaks.