### PR TITLE
Add version mismatch check for GH release action

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -22,6 +22,28 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
 
+            - name: Check version mismatch (tags only)
+              if: startsWith(github.ref, 'refs/tags/v')
+              run: |
+                  # Extract version from package.json
+                  PACKAGE_VERSION=$(node -p "require('./package.json').version")
+                  
+                  # Extract version from git tag (remove 'v' prefix if present)
+                  GIT_TAG=${GITHUB_REF#refs/tags/}
+                  GIT_VERSION=${GIT_TAG#v}
+                  
+                  echo "Package.json version: $PACKAGE_VERSION"
+                  echo "Git tag version: $GIT_VERSION"
+                  
+                  # Compare versions
+                  if [ "$PACKAGE_VERSION" != "$GIT_VERSION" ]; then
+                      echo "❌ Error: Version mismatch!"
+                      echo "package.json version ($PACKAGE_VERSION) does not match git tag ($GIT_VERSION)"
+                      exit 1
+                  fi
+                  
+                  echo "✅ Versions match!"
+
             - name: Log in to the Container registry
               uses: docker/login-action@v3
               with:


### PR DESCRIPTION
In case the `package.json` and tag version don't match, the workflow will fail.