### PR TITLE
Optimize `/evm/holders`

### DIFF
--- a/src/sql/holders_for_contract/evm.sql
+++ b/src/sql/holders_for_contract/evm.sql
@@ -16,13 +16,13 @@ cutoff AS (
     SELECT
         multiIf(
             {network: String} = 'unichain', toUInt64(1),
-            {network: String} = 'avalanche', toUInt64(10),
+            {network: String} = 'optimism', toUInt64(10),
+            {network: String} = 'base', toUInt64(10),
             {network: String} = 'arbitrum-one', toUInt64(100),
-            {network: String} = 'optimism', toUInt64(100),
-            {network: String} = 'base', toUInt64(100),
-            {network: String} = 'bsc', toUInt64(1000),
+            {network: String} = 'bsc', toUInt64(100),
+            {network: String} = 'avalanche', toUInt64(1000),
             {network: String} = 'mainnet', toUInt64(5000),
-            {network: String} = 'polygon', toUInt64(10000),
+            {network: String} = 'polygon', toUInt64(50000),
             toUInt64(100)
         ) AS eth_cut
 ),


### PR DESCRIPTION
This pull request refactors the logic for selecting token holders in the `src/sql/holders_for_contract/evm.sql` file. The main improvements include splitting the query into separate branches for native tokens and ERC20 tokens, introducing a dynamic cutoff for native token balances based on the network, and simplifying the metadata join. These changes are aimed at improving query performance and accuracy when retrieving top holders for different types of tokens.

**Query logic improvements:**

* Added a dynamic cutoff value for native tokens based on the network, ensuring the query remains performant and returns a reasonable number of holders.
* Split the query into two branches: one for native tokens (with cutoff) and one for ERC20 tokens (no cutoff), allowing more precise selection of holders.
