### PR TITLE
Optimize query time windows to use latest ingested timestamp

### DIFF
--- a/src/sql/transfers/svm.sql
+++ b/src/sql/transfers/svm.sql
@@ -61,6 +61,11 @@ filtered_minutes AS
         (toUInt64({limit:UInt64}) + toUInt64({offset:UInt64})) * 10     /* unsafe limit with a multiplier - usually safe but find a way to early return */
     )
 ),
+/* Latest ingested timestamp in source table */
+latest_ts AS
+(
+    SELECT max(timestamp) AS ts FROM transfers
+),
 filtered_transfers AS
 (
     SELECT
@@ -87,11 +92,11 @@ filtered_transfers AS
         AND block_num BETWEEN {start_block: UInt64} AND {end_block: UInt64}
         AND (
             (
-                /* if no filters are active, search through the last hour only */
+                /* if no filters are active, search through the last minute only */
                 (SELECT n FROM active_filters) = 0
                 AND timestamp BETWEEN
-                    greatest( toDateTime({start_time:UInt64}), least(toDateTime({end_time:UInt64}), now()) - INTERVAL 1 HOUR)
-                    AND least(toDateTime({end_time:UInt64}), now())
+                    greatest( toDateTime({start_time:UInt64}), least(toDateTime({end_time:UInt64}), (SELECT ts FROM latest_ts)) - INTERVAL 1 MINUTE)
+                    AND least(toDateTime({end_time:UInt64}), (SELECT ts FROM latest_ts))
             )
             /* if filters are active, search through the intersecting minute ranges */
             OR toRelativeMinuteNum(timestamp) IN (SELECT minute FROM filtered_minutes)


### PR DESCRIPTION
This pull request updates the logic in our SQL queries for swaps and transfers to improve how we determine the time window for fetching recent data when no filters are applied. 

Instead of relying on the current system time, the queries now use the latest ingested timestamp from the source tables, ensuring more accurate and consistent results. 

Additionally, the default time windows for "no filter" queries have been adjusted to be more precise and appropriate for each case.
