### PR TITLE
Refactor spam scoring

### DIFF
--- a/src/routes/v1/evm/nft/collections/evm.ts
+++ b/src/routes/v1/evm/nft/collections/evm.ts
@@ -113,7 +113,11 @@ route.get('/', openapi, validator('query', querySchema, validatorHook), async (c
         let spamStatus: 'spam' | 'not_spam' | 'pending' | 'not_supported' | 'error' = 'pending';
 
         if (spamScore.result === 'success') {
-            spamStatus = spamScore.contract_spam_status ? 'spam' : 'not_spam';
+            if (spamScore.contract_spam_status === 'spam') {
+                spamStatus = 'spam';
+            } else {
+                spamStatus = 'not_spam';
+            }
         } else if (spamScore.result === 'error') {
             spamStatus = 'error';
         } else if (spamScore.result === 'not_supported') {

--- a/src/services/redis.ts
+++ b/src/services/redis.ts
@@ -75,5 +75,5 @@ export async function setInCache<T>(key: string, value: T, ttl: number = DEFAULT
  * @returns Cache key string
  */
 export function getSpamScoreKey(contractAddress: string, networkId: string): string {
-    return `spam:${networkId}:${contractAddress}`;
+    return `spam:v0.3.0:${networkId}:${contractAddress}`;
 }


### PR DESCRIPTION
This pull request updates the spam scoring logic for NFT collections, focusing on improved integration with a new version of the external spam API, better cache management, and more robust response handling. The changes ensure that only valid spam statuses are cached, add support for additional networks, and clarify the contract spam status logic throughout the codebase.
