### PR TITLE
Improve SVM balance performance

### DIFF
--- a/src/sql/balances_for_account/svm.sql
+++ b/src/sql/balances_for_account/svm.sql
@@ -7,21 +7,6 @@ WITH accounts AS (
       AND owner IN {owner:Array(String)}
     GROUP BY owner, o.account
 ),
-mints AS (
-    SELECT DISTINCT mint
-    FROM (
-        SELECT arrayJoin({mint:Array(String)}) AS mint
-        WHERE {mint:Array(String)} != ['']
-
-        UNION ALL
-
-        SELECT mint
-        FROM mint_state_latest
-        WHERE {mint:Array(String)} = [''] 
-          AND account IN (SELECT account FROM accounts)
-    )
-    WHERE mint != ''
-),
 filtered_balances AS
 (
     SELECT
@@ -35,8 +20,7 @@ filtered_balances AS
         any(decimals) AS decimals
     FROM balances AS b
     LEFT JOIN accounts USING account
-    WHERE mint IN (SELECT mint FROM mints)
-        AND mint != 'So11111111111111111111111111111111111111111'
+    WHERE ({mint:Array(String)} == [''] OR mint IN {mint:Array(String)})
         AND account IN (SELECT account FROM accounts)
         AND ({program_id:String} = '' OR program_id = {program_id:String})
         AND (b.amount > 0 OR {include_null_balances:Bool})


### PR DESCRIPTION
This pull request simplifies the logic for filtering `balances_for_account/svm.sql` query. The main change is the removal of the unnecessary `mints` subquery and the replacement of its logic with a more straightforward conditional in the `filtered_balances` section. 

This improves performance 2-5x and fixes https://github.com/pinax-network/pinax-stories/issues/1376#issue-3500516014
So querying balances for `9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM` whale owner returns in 4-5 seconds now. It would time out before.

I've compared against `GXYBNgyYKbSLr938VJCpmGLCUaAHWsncTi7jDoQSdFR9` owner with 420 balances and results match.
