### PR TITLE
Increase native tokens execution time

### DIFF
--- a/src/routes/v1/evm/tokens/native/evm.ts
+++ b/src/routes/v1/evm/tokens/native/evm.ts
@@ -116,7 +116,10 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
             db_balances: dbBalances.database,
         },
         {
-            clickhouse_settings: { query_cache_ttl: config.cacheDurations[1] },
+            clickhouse_settings: {
+                query_cache_ttl: config.cacheDurations[1],
+                max_execution_time: 60,
+            },
         }
     );
     injectSymbol(response, params.network, true);


### PR DESCRIPTION
This pull request introduces a configuration update to the ClickHouse query settings for the native EVM tokens route. The main change is the addition of a maximum execution time limit for queries, which helps prevent long-running database operations.

**Database query configuration:**

* Added `max_execution_time: 60` to the `clickhouse_settings` object in the `/` route handler for `evm.ts`, setting a 60-second maximum for query execution time.