### PR TITLE
Add order by

### DIFF
--- a/src/sql/holders_for_contract/evm.sql
+++ b/src/sql/holders_for_contract/evm.sql
@@ -9,7 +9,7 @@ balances AS (
     FROM {db_balances:Identifier}.erc20_balances
     WHERE contract = {contract:String} AND balance > 0
     GROUP BY contract, address
-    ORDER BY amt DESC
+    ORDER BY amt DESC, address
     LIMIT {limit:UInt64}
     OFFSET {offset:UInt64}
 )
@@ -35,3 +35,4 @@ SELECT
     {network:String} as network
 FROM balances AS b
 LEFT JOIN metadata.metadata AS m FINAL ON m.network = {network:String} AND {contract:String} = m.contract
+ORDER BY value DESC, address

--- a/src/sql/holders_for_contract_native/evm.sql
+++ b/src/sql/holders_for_contract_native/evm.sql
@@ -52,3 +52,4 @@ SELECT
     {network:String} as network
 FROM top_native
 LEFT JOIN metadata.metadata AS m FINAL ON m.network = {network:String} AND '0x0000000000000000000000000000000000000000' = m.contract
+ORDER BY value DESC, address


### PR DESCRIPTION
This pull request updates the ordering logic in the SQL queries for retrieving holders for contracts, both ERC20 and native, to ensure deterministic and consistent results when balances or values are equal. The changes add secondary sorting by `address` after sorting by amount or value.

Ordering improvements for deterministic results:

* In `src/sql/holders_for_contract/evm.sql`, updated the `balances` CTE to order by `amt DESC, address` instead of just `amt DESC`, ensuring a consistent order when multiple holders have the same amount.
* In `src/sql/holders_for_contract/evm.sql`, added `ORDER BY value DESC, address` to the final `SELECT`, further enforcing deterministic ordering in the result set.
* In `src/sql/holders_for_contract_native/evm.sql`, added `ORDER BY value DESC, address` to the final `SELECT` for native balances, mirroring the ordering logic used for ERC20 holders.