### PR TITLE
fix: disable enable_shared_storage_snapshot_in_query to prevent segfault

### DIFF
--- a/src/clickhouse/client.ts
+++ b/src/clickhouse/client.ts
@@ -63,6 +63,10 @@ const client = (custom_config?: ClientOptions) => {
             readonly: '0',
             interactive_delay: '500000', // Interval between query progress reports in microseconds
             max_execution_time: config.maxQueryExecutionTime,
+            // Workaround for ClickHouse 26.1.x bug (PR #92118): BlockIO::operator= does not move
+            // query_metadata_cache, causing use-after-free in MergeTreeIndexReader destructor when
+            // enable_shared_storage_snapshot_in_query=1 (the default). Fixed in 26.2 via PR #96995.
+            enable_shared_storage_snapshot_in_query: 0,
             use_query_cache: config.disableQueryCache ? 0 : 1,
             enable_writes_to_query_cache: config.disableQueryCache ? 0 : 1,
             enable_reads_from_query_cache: config.disableQueryCache ? 0 : 1,


### PR DESCRIPTION
ClickHouse PR #92118 (merged Dec 2025, present in all 26.1.x) introduced a use-after-free bug in BlockIO::operator= which drops query_metadata_cache without moving it, causing MergeTreeIndexReader background threads to access freed memory and SIGSEGV.

The bug is likely triggered by the start_ts/end_ts/clamped_start_ts CTE pattern (correlated subqueries against the blocks table) introduced in v3.11.0.

Setting `enable_shared_storage_snapshot_in_query=0` disables the shared storage snapshot mechanism that contains the bug. The fix is upstream in ClickHouse 26.2 via PR #96995 — revert this workaround once all nodes are upgraded.