### PR TITLE
Remove default 1s cache

### DIFF
--- a/reports/2026-02-27-http-cache-control-refactor.md
+++ b/reports/2026-02-27-http-cache-control-refactor.md
@@ -154,8 +154,7 @@ http_filters:
 
 Cache headers are applied via Hono middleware in `src/routes/index.ts`:
 
-1. **`cacheControlDefault()`** — registered globally on `/v1/*`, sets minimal 1s cache. Only sets headers if no `Cache-Control` header exists (avoids overwriting extended tier).
-2. **`cacheControl()`** — registered on specific route patterns, sets full env-configured cache headers. Overwrites any existing `Cache-Control` header.
+1. **`cacheControl()`** — registered on specific route patterns, sets full env-configured cache headers. Overwrites any existing `Cache-Control` header.
 
 ### Cached routes (extended tier)
 

--- a/src/middleware/cacheControl.ts
+++ b/src/middleware/cacheControl.ts
@@ -22,7 +22,6 @@ import { config } from '../config.js';
  *   CACHE_STALE_WHILE_REVALIDATE – RFC 5861 stale-while-revalidate window. Default: 30
  *
  * Routes with `cacheControl()` get the full env-configured TTLs.
- * Routes with `cacheControlDefault()` get a minimal 1s cache (no stale-while-revalidate).
  *
  * @see https://datatracker.ietf.org/doc/html/rfc5861
  */
@@ -45,25 +44,5 @@ export function cacheControl() {
             'Cache-Control',
             `public, max-age=${cacheMaxAge}, s-maxage=${cacheServerMaxAge}, stale-while-revalidate=${cacheStaleWhileRevalidate}`
         );
-    };
-}
-
-/**
- * Lightweight default cache for all API routes (1s max-age, no stale-while-revalidate).
- * Applied globally to `/v1/*` — routes with `cacheControl()` will override this since
- * their middleware runs after and overwrites the Cache-Control header.
- */
-export function cacheControlDefault() {
-    return async (ctx: Context, next: Next) => {
-        await next();
-
-        if (config.cacheDisable) return;
-        if (ctx.req.header('Cache-Control') === 'no-cache') return;
-        if (ctx.res.status !== 200) return;
-
-        // Only set if not already set by cacheControl()
-        if (!ctx.res.headers.has('Cache-Control')) {
-            ctx.res.headers.set('Cache-Control', 'public, max-age=1');
-        }
     };
 }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { cacheControl, cacheControlDefault } from '../middleware/cacheControl.js';
+import { cacheControl } from '../middleware/cacheControl.js';
 // Balances
 import evmBalances from './balances/evm.js';
 // import tvmBalancesNative from './balances/tvm_native.js';
@@ -65,7 +65,7 @@ const router = new Hono();
 // --- HTTP Cache-Control middleware ---
 // Default: all /v1/* routes get a minimal 1s cache (no SWR).
 // Specific routes below override with longer env-configured TTLs.
-router.use('/v1/*', cacheControlDefault());
+router.use('/v1/*');
 router.use('/v1/*/holders', cacheControl());
 router.use('/v1/*/holders/native', cacheControl());
 router.use('/v1/*/dexes', cacheControl());


### PR DESCRIPTION
- Remove cacheControlDefault() middleware and global /v1/* cache
- Keep cacheControl() only on specific routes (holders, dexes, etc.)
- Update report to reflect single-tier caching strategy
- Simplify middleware logic — no more conditional header checks