### PR TITLE
Increase default scan window from 10 minutes to 1 hour

### DIFF
--- a/src/routes/nft/sales_evm.sql
+++ b/src/routes/nft/sales_evm.sql
@@ -28,7 +28,7 @@ clamped_start_ts AS (
     SELECT if(
         (SELECT yes FROM has_filters) OR isNotNull({start_time:Nullable(UInt64)}) OR isNotNull({start_block:Nullable(UInt64)}),
         (SELECT ts FROM start_ts),
-        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 10 MINUTE)
+        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 1 HOUR)
     ) AS ts
 ),
 filtered_orders AS (

--- a/src/routes/nft/transfers_evm.sql
+++ b/src/routes/nft/transfers_evm.sql
@@ -6,7 +6,7 @@
     enabling granule skipping on the primary index.
     When no lower bound → falls back to epoch (toDateTime(0)) → no-op.
     When no upper bound → falls back to now() → no-op.
-/* Only clamp to 10 minutes when no narrowing filters are active.
+/* Only clamp to 1 hour when no narrowing filters are active.
    start_time/start_block are already incorporated into start_ts, so the
    clamp's greatest() handles them correctly without disabling it. */
 
@@ -44,7 +44,7 @@ clamped_start_ts AS (
     SELECT if(
         (SELECT yes FROM has_filters) OR (SELECT yes FROM has_explicit_start),
         (SELECT ts FROM start_ts),
-        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 10 MINUTE)
+        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 1 HOUR)
     ) AS ts
 ),
 erc721 AS (

--- a/src/routes/swaps/evm.sql
+++ b/src/routes/swaps/evm.sql
@@ -83,7 +83,7 @@ minutes_union AS
     Uses coalesce instead of `isNull(X) OR timestamp >= (subquery)` because
     the OR pattern prevents ClickHouse from recognizing a clean primary-key range.
     greatest/least picks the tighter bound when both are provided.
-    clamped_start_ts ensures the scan window is at most 10 minutes wide.
+    clamped_start_ts ensures the scan window is at most 1 hour wide.
 */
 start_ts AS (
     SELECT greatest(
@@ -101,7 +101,7 @@ clamped_start_ts AS (
     SELECT if(
         (SELECT n FROM active_filters) > 0 OR isNotNull({start_time:Nullable(UInt64)}) OR isNotNull({start_block:Nullable(UInt64)}),
         (SELECT ts FROM start_ts),
-        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 10 MINUTE)
+        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 1 HOUR)
     ) AS ts
 ),
 /* 3) Intersect: keep only buckets present in ALL active filters, bounded by requested time/block window */

--- a/src/routes/swaps/sql.sql
+++ b/src/routes/swaps/sql.sql
@@ -67,7 +67,7 @@ minutes_union AS
     Uses coalesce instead of `isNull(X) OR timestamp >= (subquery)` because
     the OR pattern prevents ClickHouse from recognizing a clean primary-key range.
     greatest/least picks the tighter bound when both are provided.
-    clamped_start_ts ensures the scan window is at most 10 minutes wide.
+    clamped_start_ts ensures the scan window is at most 1 hour wide.
 */
 start_ts AS (
     SELECT greatest(
@@ -85,7 +85,7 @@ clamped_start_ts AS (
     SELECT if(
         (SELECT n FROM active_filters) > 0 OR isNotNull({start_time:Nullable(UInt64)}) OR isNotNull({start_block:Nullable(UInt32)}),
         (SELECT ts FROM start_ts),
-        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 10 MINUTE)
+        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 1 HOUR)
     ) AS ts
 ),
 /* 3) Intersect: keep only buckets present in ALL active filters, bounded by requested time/block window */

--- a/src/routes/swaps/svm.sql
+++ b/src/routes/swaps/svm.sql
@@ -41,7 +41,7 @@ clamped_start_ts AS (
     SELECT if(
         (SELECT yes FROM has_filters) OR (SELECT yes FROM has_explicit_start),
         (SELECT ts FROM start_ts),
-        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 10 MINUTE)
+        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 1 HOUR)
     ) AS ts
 )
 SELECT

--- a/src/routes/transfers/evm.sql
+++ b/src/routes/transfers/evm.sql
@@ -43,7 +43,7 @@ minutes_union AS
     Uses coalesce instead of `isNull(X) OR timestamp >= (subquery)` because
     the OR pattern prevents ClickHouse from recognizing a clean primary-key range.
     greatest/least picks the tighter bound when both are provided.
-    clamped_start_ts ensures the scan window is at most 10 minutes wide for bare queries.
+    clamped_start_ts ensures the scan window is at most 1 hour wide for bare queries.
 */
 start_ts AS (
     SELECT greatest(
@@ -61,7 +61,7 @@ clamped_start_ts AS (
     SELECT if(
         (SELECT n FROM active_filters) > 0,
         (SELECT ts FROM start_ts),
-        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 10 MINUTE)
+        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 1 HOUR)
     ) AS ts
 ),
 /* 3) Intersect: keep only buckets present in ALL active filters, bounded by requested time/block window */

--- a/src/routes/transfers/evm_native.sql
+++ b/src/routes/transfers/evm_native.sql
@@ -35,7 +35,7 @@ minutes_union AS
     Uses coalesce instead of `isNull(X) OR timestamp >= (subquery)` because
     the OR pattern prevents ClickHouse from recognizing a clean primary-key range.
     greatest/least picks the tighter bound when both are provided.
-    clamped_start_ts ensures the scan window is at most 10 minutes wide for bare queries.
+    clamped_start_ts ensures the scan window is at most 1 hour wide for bare queries.
 */
 start_ts AS (
     SELECT greatest(
@@ -53,7 +53,7 @@ clamped_start_ts AS (
     SELECT if(
         (SELECT n FROM active_filters) > 0,
         (SELECT ts FROM start_ts),
-        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 10 MINUTE)
+        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 1 HOUR)
     ) AS ts
 ),
 /* 3) Intersect: keep only buckets present in ALL active filters, bounded by requested time window */

--- a/src/routes/transfers/svm.sql
+++ b/src/routes/transfers/svm.sql
@@ -51,7 +51,7 @@ minutes_union AS
     Uses coalesce instead of `isNull(X) OR timestamp >= (subquery)` because
     the OR pattern prevents ClickHouse from recognizing a clean primary-key range.
     greatest/least picks the tighter bound when both are provided.
-    clamped_start_ts ensures the scan window is at most 10 minutes wide.
+    clamped_start_ts ensures the scan window is at most 1 hour wide.
 */
 start_ts AS (
     SELECT greatest(
@@ -69,7 +69,7 @@ clamped_start_ts AS (
     SELECT if(
         (SELECT n FROM active_filters) > 0 OR isNotNull({start_time:Nullable(UInt64)}) OR isNotNull({start_block:Nullable(UInt32)}),
         (SELECT ts FROM start_ts),
-        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 10 MINUTE)
+        greatest((SELECT ts FROM start_ts), (SELECT ts FROM end_ts) - INTERVAL 1 HOUR)
     ) AS ts
 ),
 /* 3) Intersect: keep only buckets present in ALL active filters, bounded by requested time/block window */


### PR DESCRIPTION
This pull request updates the clamping logic for time window queries across several SQL route files. The main change is increasing the maximum scan window from 10 minutes to 1 hour when no explicit narrowing filters are present. This adjustment affects NFT sales, NFT transfers, swaps, and transfers routes for both EVM and SVM chains.
10-minute interval proved to be too narrow for some chains.