### PR TITLE
[codex] Add DB test coverage for filters and exact bounds

### DIFF
--- a/src/routes/sql.spec.ts
+++ b/src/routes/sql.spec.ts
@@ -4,8 +4,8 @@ import {
     EVM_ADDRESS_SWAP_EXAMPLE,
     EVM_ADDRESS_TO_EXAMPLE,
     EVM_ADDRESS_VITALIK_EXAMPLE,
-    EVM_CONTRACT_USDC_EXAMPLE,
     EVM_CONTRACT_PUDGY_PENGUINS_EXAMPLE,
+    EVM_CONTRACT_USDC_EXAMPLE,
     EVM_CONTRACT_USDT_EXAMPLE,
     EVM_CONTRACT_WETH_EXAMPLE,
     EVM_FACTORY_UNISWAP_V3_EXAMPLE,
@@ -118,7 +118,11 @@ const SINGLE_FILTER_ROUTE_CASES = [
         requires: () => hasTvmTransfers,
         network: () => tvmNetwork,
         filters: [
-            { param: 'transaction_id', value: TVM_TRANSACTION_TRC20_TRANSFER_EXAMPLE, responsePath: ['transaction_id'] },
+            {
+                param: 'transaction_id',
+                value: TVM_TRANSACTION_TRC20_TRANSFER_EXAMPLE,
+                responsePath: ['transaction_id'],
+            },
             { param: 'contract', value: TVM_CONTRACT_USDT_EXAMPLE, responsePath: ['contract'] },
             { param: 'from_address', value: TVM_ADDRESS_FROM_EXAMPLE, responsePath: ['from'] },
             { param: 'to_address', value: TVM_ADDRESS_TO_EXAMPLE, responsePath: ['to'] },
@@ -130,7 +134,11 @@ const SINGLE_FILTER_ROUTE_CASES = [
         requires: () => hasTvmTransfers,
         network: () => tvmNetwork,
         filters: [
-            { param: 'transaction_id', value: TVM_TRANSACTION_NATIVE_TRANSFER_EXAMPLE, responsePath: ['transaction_id'] },
+            {
+                param: 'transaction_id',
+                value: TVM_TRANSACTION_NATIVE_TRANSFER_EXAMPLE,
+                responsePath: ['transaction_id'],
+            },
             { param: 'from_address', value: TVM_ADDRESS_FROM_EXAMPLE, responsePath: ['from'] },
             { param: 'to_address', value: TVM_ADDRESS_NATIVE_TO_EXAMPLE, responsePath: ['to'] },
         ],
@@ -655,7 +663,8 @@ describe.skipIf(!DB_TESTS)('SQL queries', () => {
     for (const routeCase of MAINNET_ROUTE_CASES) {
         for (const boundary of MAINNET_BOUNDARIES) {
             it(`GET ${routeCase.path} exact start_time=end_time on mainnet at ${boundary.label}`, async () => {
-                if ((routeCase.db === 'transfers' && !hasEvmTransfers) || (routeCase.db === 'dex' && !hasEvmDex)) return;
+                if ((routeCase.db === 'transfers' && !hasEvmTransfers) || (routeCase.db === 'dex' && !hasEvmDex))
+                    return;
 
                 const row = await fetchExactMainnetRow(
                     routeCase.path,
@@ -666,7 +675,8 @@ describe.skipIf(!DB_TESTS)('SQL queries', () => {
             });
 
             it(`GET ${routeCase.path} exact start_block=end_block on mainnet at ${boundary.label}`, async () => {
-                if ((routeCase.db === 'transfers' && !hasEvmTransfers) || (routeCase.db === 'dex' && !hasEvmDex)) return;
+                if ((routeCase.db === 'transfers' && !hasEvmTransfers) || (routeCase.db === 'dex' && !hasEvmDex))
+                    return;
 
                 const row = await fetchExactMainnetRow(
                     routeCase.path,
@@ -677,7 +687,8 @@ describe.skipIf(!DB_TESTS)('SQL queries', () => {
             });
 
             it(`GET ${routeCase.path} single transaction_id filter uses default bounds on mainnet at ${boundary.label}`, async () => {
-                if ((routeCase.db === 'transfers' && !hasEvmTransfers) || (routeCase.db === 'dex' && !hasEvmDex)) return;
+                if ((routeCase.db === 'transfers' && !hasEvmTransfers) || (routeCase.db === 'dex' && !hasEvmDex))
+                    return;
 
                 const fixture = await fetchExactMainnetRow(
                     routeCase.path,


### PR DESCRIPTION
## Summary
This PR expands DB-backed coverage in `src/routes/sql.spec.ts` for transfer and swap filters across EVM, TVM, and SVM.

It adds two kinds of regression coverage:
- exact-bound queries where `start_time=end_time` or `start_block=end_block`
- single-filter queries for every available single-value filter on the covered transfer and swap routes

## What changed
- Added exact-bound mainnet cases for:
  - `/v1/evm/transfers`
  - `/v1/evm/transfers/native`
  - `/v1/evm/swaps`
- Added single-filter coverage for:
  - EVM transfers, native transfers, and swaps
  - TVM transfers, native transfers, and swaps
  - SVM transfers and swaps
- Added small helpers to keep the DB test matrix readable and reduce repetition

## Mainnet exact-bound fixtures
The exact-bound EVM mainnet cases use these fixed points:
- block `24616075` / timestamp `1773013031` (`2026-03-08 23:37:11 UTC`)
- block `10000000` / timestamp `1588598533` (`2020-05-04 13:22:13 UTC`)

## Why this matters
Recent fixes in this area were mostly about query correctness:
- filters must constrain returned rows, not just scan scope
- exact block/time windows must still return the expected row

These DB tests make those guarantees explicit across the supported chains and route families.

## Validation
- `bun run typecheck`
- `bun test src/routes/sql.spec.ts`

## Notes
I could not complete a live `DB_TESTS=true` run in this environment because test setup fetches the external networks registry, which is blocked here. The new cases compile cleanly and are wired into the existing `test:db` suite.
