### PR TITLE
Add log_index to /swaps response

### DIFF
--- a/src/routes/swaps/evm.sql
+++ b/src/routes/swaps/evm.sql
@@ -175,6 +175,9 @@ SELECT
 
     /* transaction */
     s.tx_hash AS transaction_id,
+
+    /* log */
+    s.log_index AS log_index,
     /* s.log_ordinal AS ordinal, for `/v2` endpoint */
 
     /* swap */

--- a/src/routes/swaps/evm.ts
+++ b/src/routes/swaps/evm.ts
@@ -80,6 +80,7 @@ const responseSchema = apiUsageResponseSchema.extend({
 
             // -- swap --
             transaction_id: z.string(),
+            log_index: z.number(),
             factory: evmFactorySchema,
             pool: evmPoolSchema,
             input_token: evmTokenResponseSchema,
@@ -88,9 +89,6 @@ const responseSchema = apiUsageResponseSchema.extend({
             caller: evmAddressSchema,
             sender: evmAddressSchema,
             recipient: evmAddressSchema,
-
-            // -- log --
-            // ordinal: z.number(),
 
             // -- price --
             input_amount: z.string(),
@@ -131,6 +129,7 @@ const openapi = describeRoute(
                                             timestamp: 1760618927,
                                             transaction_id:
                                                 '0xf6374799c227c9db38ff5ac1d5bebe8b607a1de1238cd861ebd1053ec07305ca',
+                                            log_index: 42,
                                             factory: '0x1f98431c8ad98523631ae4a59f267346ea31f984',
                                             pool: '0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640',
                                             input_token: {

--- a/src/routes/swaps/tvm.ts
+++ b/src/routes/swaps/tvm.ts
@@ -83,6 +83,7 @@ const responseSchema = apiUsageResponseSchema.extend({
 
             // -- swap --
             transaction_id: z.string(),
+            log_index: z.number(),
             factory: tvmFactorySchema,
             pool: tvmPoolSchema,
             input_token: tvmTokenResponseSchema,
@@ -91,9 +92,6 @@ const responseSchema = apiUsageResponseSchema.extend({
             caller: tvmAddressSchema,
             sender: tvmAddressSchema,
             recipient: tvmAddressSchema,
-
-            // -- log --
-            // ordinal: z.number(),
 
             // -- price --
             input_amount: z.string(),
@@ -134,6 +132,7 @@ const openapi = describeRoute(
                                             timestamp: 1615351413,
                                             transaction_id:
                                                 '0x3e0f39b48dae8c49d3f95bc6206a632af484059764487b0c7d3e3c97bb433130',
+                                            log_index: 0,
                                             factory: 'TXk8rQSAvPvBBNtqSoY6nCfsXWCSSpTVQF',
                                             pool: 'TAqCH2kadHAugPEorFrpT7Kogqo2FckxWA',
                                             caller: 'TSLjVj4sL7uDWQXDbHyV3Kbgz1KL9jB78w',


### PR DESCRIPTION
Exposes the existing log_index column from the swaps table, matching the field already present on /transfers. Allows callers to determine the order of swap events within a transaction.