### PR TITLE
fix: use relative path in native contract redirect

### DIFF
--- a/src/middleware/nativeContractRedirect.spec.ts
+++ b/src/middleware/nativeContractRedirect.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, mock } from 'bun:test';
 import type { Context } from 'hono';
 import { EVM_CONTRACT_NATIVE_EXAMPLE } from '../types/examples.js';
-import { nativeContractRedirect } from './nativeContractRedirect.js';
+import { nativeContractRedirect, nativeMintRedirect } from './nativeContractRedirect.js';
 
 // Helper function to create a mock Hono context
 function createMockContext(url: string): Context {
@@ -129,5 +129,71 @@ describe('nativeContractRedirect middleware', () => {
             expect(ctx.redirect).not.toHaveBeenCalled();
             expect(next).toHaveBeenCalledTimes(1);
         });
+    });
+
+    describe('redirect URL format', () => {
+        it('should use relative path (no scheme/host) for redirect behind reverse proxy', async () => {
+            const url = `http://token-api-http-svc:80/v1/evm/transfers?network=mainnet&contract=${EVM_CONTRACT_NATIVE_EXAMPLE}`;
+            const ctx = createMockContext(url);
+            const next = createMockNext();
+
+            await nativeContractRedirect(ctx, next);
+
+            const redirectedUrl = (ctx.redirect as any).mock.calls[0][0];
+            expect(redirectedUrl).not.toContain('http://');
+            expect(redirectedUrl).not.toContain('https://');
+            expect(redirectedUrl).toBe('/v1/evm/transfers/native?network=mainnet');
+        });
+    });
+});
+
+describe('nativeMintRedirect middleware', () => {
+    it('should redirect native SOL system program to /native endpoint', async () => {
+        const url =
+            'https://api.example.com/v1/svm/transfers?network=solana&mint=11111111111111111111111111111111&limit=1';
+        const ctx = createMockContext(url);
+        const next = createMockNext();
+
+        await nativeMintRedirect(ctx, next);
+
+        expect(ctx.redirect).toHaveBeenCalledTimes(1);
+        const redirectedUrl = (ctx.redirect as any).mock.calls[0][0];
+        expect(redirectedUrl).toBe('/v1/svm/transfers/native?network=solana&limit=1');
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should use relative path behind reverse proxy', async () => {
+        const url = 'http://localhost:8000/v1/svm/holders?network=solana&mint=11111111111111111111111111111111&limit=5';
+        const ctx = createMockContext(url);
+        const next = createMockNext();
+
+        await nativeMintRedirect(ctx, next);
+
+        const redirectedUrl = (ctx.redirect as any).mock.calls[0][0];
+        expect(redirectedUrl).not.toContain('http://');
+        expect(redirectedUrl).toBe('/v1/svm/holders/native?network=solana&limit=5');
+    });
+
+    it('should not redirect for wSOL mint', async () => {
+        const url =
+            'https://api.example.com/v1/svm/transfers?network=solana&mint=So11111111111111111111111111111111111111112&limit=1';
+        const ctx = createMockContext(url);
+        const next = createMockNext();
+
+        await nativeMintRedirect(ctx, next);
+
+        expect(ctx.redirect).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not redirect when no mint parameter', async () => {
+        const url = 'https://api.example.com/v1/svm/transfers?network=solana&limit=1';
+        const ctx = createMockContext(url);
+        const next = createMockNext();
+
+        await nativeMintRedirect(ctx, next);
+
+        expect(ctx.redirect).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/middleware/nativeContractRedirect.ts
+++ b/src/middleware/nativeContractRedirect.ts
@@ -15,34 +15,19 @@ import { EVM_CONTRACT_NATIVE_EXAMPLE } from '../types/examples.js';
  * @param next - Next middleware function
  */
 export async function nativeContractRedirect(c: Context, next: Next) {
-    // Get raw query parameter value
     const url = new URL(c.req.url);
     const contractParam = url.searchParams.get('contract');
 
-    // Check if contract param is a single value (not comma-separated) matching native address
-    // Note: The comma check is intentional - the createQuerySchema batching feature uses comma
-    // as the separator for multiple values (see zod.ts line 621). This ensures we only redirect
-    // single-value requests, not batched requests with multiple contracts.
-
-    // EVM
     if (
         contractParam &&
         contractParam.toLowerCase() === EVM_CONTRACT_NATIVE_EXAMPLE.toLowerCase() &&
         !contractParam.includes(',')
     ) {
-        // Remove contract parameter
         url.searchParams.delete('contract');
-
-        // Construct redirect URL to /native endpoint
-        const currentPath = url.pathname;
-        const nativePath = `${currentPath}/native`;
-        url.pathname = nativePath;
-
-        // Redirect to native endpoint with modified query params
-        return c.redirect(url.toString());
+        const query = url.searchParams.toString();
+        return c.redirect(`${url.pathname}/native${query ? `?${query}` : ''}`);
     }
 
-    // Continue with normal processing
     await next();
 }
 
@@ -60,34 +45,19 @@ export async function nativeContractRedirect(c: Context, next: Next) {
  * @param next - Next middleware function
  */
 export async function nativeMintRedirect(c: Context, next: Next) {
-    // Get raw query parameter value
     const url = new URL(c.req.url);
     const mintParam = url.searchParams.get('mint');
 
-    // Check if mint param is a single value (not comma-separated) matching native address
-    // Note: The comma check is intentional - the createQuerySchema batching feature uses comma
-    // as the separator for multiple values (see zod.ts line 621). This ensures we only redirect
-    // single-value requests, not batched requests with multiple mints.
-
-    // SVM
     if (
         mintParam &&
         (mintParam.toLowerCase() === '11111111111111111111111111111111' ||
             mintParam.toLowerCase() === 'sol11111111111111111111111111111111') &&
         !mintParam.includes(',')
     ) {
-        // Remove mint parameter
         url.searchParams.delete('mint');
-
-        // Construct redirect URL to /native endpoint
-        const currentPath = url.pathname;
-        const nativePath = `${currentPath}/native`;
-        url.pathname = nativePath;
-
-        // Redirect to native endpoint with modified query params
-        return c.redirect(url.toString());
+        const query = url.searchParams.toString();
+        return c.redirect(`${url.pathname}/native${query ? `?${query}` : ''}`);
     }
 
-    // Continue with normal processing
     await next();
 }


### PR DESCRIPTION
## Summary

- Native contract/mint redirect middleware used the full request URL (including scheme) for the redirect target
- Behind a reverse proxy, the internal URL uses `http://`, causing the 302 redirect to downgrade clients from `https://` to `http://`
- Fix: use relative path + query string only for the redirect, preserving the client's original scheme

Affects both EVM (`nativeContractRedirect`) and SVM (`nativeMintRedirect`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)