### PR TITLE
Update SVM Balances to use `metadata` REFRESH MV

### DIFF
--- a/src/routes/balances/svm.sql
+++ b/src/routes/balances/svm.sql
@@ -27,42 +27,17 @@ balances AS
 mints AS (
     SELECT DISTINCT mint FROM balances
 ),
-metadata_mint_state AS (
-    SELECT mint, metadata
-    FROM {db_metadata:Identifier}.metadata_mint_state
-    WHERE mint IN (SELECT mint FROM mints)
-),
-decimals_state AS (
+decimals AS (
     SELECT mint, decimals
-    FROM {db_accounts:Identifier}.decimals_state FINAL
-    WHERE mint IN (SELECT mint FROM mints)
+    FROM {db_accounts:Identifier}.decimals_state
+    WHERE mint IN mints
+    LIMIT 1 BY mint
 ),
-metadata_name_state AS (
-    SELECT metadata, name
-    FROM {db_metadata:Identifier}.metadata_name_state FINAL
-    WHERE metadata IN (SELECT metadata FROM metadata_mint_state)
-),
-metadata_symbol_state AS (
-    SELECT metadata, symbol
-    FROM {db_metadata:Identifier}.metadata_symbol_state FINAL
-    WHERE metadata IN (SELECT metadata FROM metadata_mint_state)
-),
-metadata_uri_state AS (
-    SELECT metadata, uri
-    FROM {db_metadata:Identifier}.metadata_uri_state FINAL
-    WHERE metadata IN (SELECT metadata FROM metadata_mint_state)
-),
-metadata_state AS (
-    SELECT
-        mm.mint,
-        mm.metadata as metadata,
-        n.name,
-        s.symbol,
-        u.uri
-    FROM metadata_mint_state AS mm
-    LEFT JOIN metadata_name_state AS n ON mm.metadata = n.metadata
-    LEFT JOIN metadata_symbol_state AS s ON mm.metadata = s.metadata
-    LEFT JOIN metadata_uri_state AS u ON mm.metadata = u.metadata
+metadata AS (
+    SELECT mint, name, symbol, uri
+    FROM {db_metadata:Identifier}.metadata
+    WHERE mint IN mints
+    LIMIT 1 BY mint
 )
 SELECT
     /* block */
@@ -90,6 +65,6 @@ SELECT
     {network:String} AS network
 FROM balances AS b
 LEFT JOIN owners AS o USING (account)
-LEFT JOIN decimals_state AS d USING (mint)
-LEFT JOIN metadata_state AS m USING (mint)
+LEFT JOIN decimals AS d USING (mint)
+LEFT JOIN metadata AS m USING (mint)
 ORDER BY b.timestamp DESC, b.account, b.mint

--- a/src/routes/balances/svm.sql
+++ b/src/routes/balances/svm.sql
@@ -14,11 +14,11 @@ balances AS
         mint,
         decimals
     FROM {db_balances:Identifier}.balances AS b
-    WHERE account IN (SELECT account FROM owners)
+    WHERE b.account IN (SELECT account FROM owners)
         AND (empty({token_account:Array(String)}) OR b.account IN {token_account:Array(String)})
         AND (empty({mint:Array(String)}) OR b.mint IN {mint:Array(String)})
         AND (isNull({program_id:Nullable(String)}) OR b.program_id = {program_id:Nullable(String)})
-    GROUP BY program_id, account, mint, decimals
+    GROUP BY b.mint, b.account, b.program_id, b.decimals
     HAVING {include_null_balances:Bool} OR amount > 0
     ORDER BY timestamp DESC, account, mint
     LIMIT  {limit:UInt64}

--- a/src/routes/swaps/svm.sql
+++ b/src/routes/swaps/svm.sql
@@ -186,13 +186,15 @@ metadata AS
 (
     SELECT mint, name, symbol, uri
     FROM {db_metadata:Identifier}.metadata
-    WHERE mint IN (SELECT DISTINCT mint FROM mints)
+    WHERE mint IN mints
+    LIMIT 1 BY mint
 ),
 decimals AS
 (
     SELECT mint, decimals
     FROM {db_accounts:Identifier}.decimals_state
-    WHERE mint IN (SELECT DISTINCT mint FROM mints)
+    WHERE mint IN mints
+    LIMIT 1 BY mint
 )
 SELECT
     /* block */

--- a/src/routes/transfers/svm.sql
+++ b/src/routes/transfers/svm.sql
@@ -160,12 +160,14 @@ metadata AS
     SELECT mint, name, symbol, uri
     FROM {db_metadata:Identifier}.metadata
     WHERE mint IN mints
+    LIMIT 1 BY mint
 ),
 decimals AS
 (
     SELECT mint, decimals
     FROM {db_accounts:Identifier}.decimals_state
     WHERE mint IN mints
+    LIMIT 1 BY mint
 )
 SELECT
     /* block */


### PR DESCRIPTION
This pull request refactors SQL queries across several routes to improve consistency, efficiency, and correctness in how metadata and decimals are joined and grouped. The main changes involve simplifying subqueries, ensuring deduplication of results, and aligning groupings and joins.

Query and Join Refactoring:

- Replaced multiple subqueries and joins for metadata and decimals in `src/routes/balances/svm.sql` with simplified CTEs (`metadata` and `decimals`) that deduplicate by `mint` using `LIMIT 1 BY mint`, and updated the main query to join these new CTEs. [[1]](diffhunk://#diff-f1c47a5004bff0d017244c3fb7d96779a4b2d409f14f7d883a20e97570cd6877L30-R40) [[2]](diffhunk://#diff-f1c47a5004bff0d017244c3fb7d96779a4b2d409f14f7d883a20e97570cd6877L93-R69)
- Updated the `GROUP BY` clause in the balances query to group by all selected columns using explicit table aliases, improving query correctness and readability.

Deduplication and Consistency:

- Added `LIMIT 1 BY mint` to the `metadata` and `decimals` subqueries in both `src/routes/swaps/svm.sql` and `src/routes/transfers/svm.sql` to ensure only one row per mint is joined, preventing duplicate results. [[1]](diffhunk://#diff-8439c9b22a3b6c67bbb9d4d46ead1ce45eca2d25c7ba8dbd7ab96c16e9618ca2L189-R197) [[2]](diffhunk://#diff-e911a06ee7e95d6667a304dcae5483be03780222608022c6267637b4eeaf8508R163-R170)