### PR TITLE
Update to use `balances_by_account`

### DIFF
--- a/src/routes/balances/svm.sql
+++ b/src/routes/balances/svm.sql
@@ -13,12 +13,12 @@ balances AS
         argMax(b.amount, b.block_num) AS amount,
         mint,
         decimals
-    FROM {db_balances:Identifier}.balances AS b
+    FROM {db_balances:Identifier}.balances_by_account AS b
     WHERE b.account IN (SELECT account FROM owners)
         AND (empty({token_account:Array(String)}) OR b.account IN {token_account:Array(String)})
         AND (empty({mint:Array(String)}) OR b.mint IN {mint:Array(String)})
         AND (isNull({program_id:Nullable(String)}) OR b.program_id = {program_id:Nullable(String)})
-    GROUP BY b.mint, b.account, b.program_id, b.decimals
+    GROUP BY b.account, b.program_id, b.mint, b.decimals
     HAVING {include_null_balances:Bool} OR amount > 0
     ORDER BY timestamp DESC, account, mint
     LIMIT  {limit:UInt64}


### PR DESCRIPTION
This pull request updates the `src/routes/balances/svm.sql` query to improve data accuracy and maintainability. The main change is switching the source table for balances and adjusting the grouping logic.

**Balances query improvements:**

* Changed the source table from `balances` to `balances_by_account` in the `FROM` clause, likely to use a more accurate or efficient dataset for account balances.
* Updated the `GROUP BY` clause to group by `b.account, b.program_id, b.mint, b.decimals` instead of the previous order, ensuring correct aggregation and possibly aligning with the new source table's schema.