### PR TITLE
Fix `authority` filter in SVM Transfers

### DIFF
--- a/src/routes/transfers/svm.sql
+++ b/src/routes/transfers/svm.sql
@@ -39,6 +39,13 @@ minutes_union AS
 
     SELECT minute
     FROM {db_transfers:Identifier}.transfers
+    WHERE (notEmpty({authority:Array(String)}) AND authority IN {authority:Array(String)})
+    GROUP BY minute
+
+    UNION ALL
+
+    SELECT minute
+    FROM {db_transfers:Identifier}.transfers
     WHERE (notEmpty({mint:Array(String)}) AND mint IN {mint:Array(String)})
     GROUP BY minute
 


### PR DESCRIPTION
This pull request updates the `minutes_union` query in `src/routes/transfers/svm.sql` to add support for filtering by the `authority` field in addition to the existing `mint` filter. This allows the query to group and select `minute` values based on the presence of an `authority` filter.

Query enhancements:

* Added a new `SELECT` statement to the `minutes_union` subquery to support filtering by `authority`, enabling queries to group by `minute` where the `authority` field matches the provided filter.