### PR TITLE
fix(svm): redirect native SOL placeholder mint to /native endpoint

### DIFF
--- a/src/middleware/nativeContractRedirect.spec.ts
+++ b/src/middleware/nativeContractRedirect.spec.ts
@@ -148,19 +148,29 @@ describe('nativeContractRedirect middleware', () => {
 });
 
 describe('nativeMintRedirect middleware', () => {
-    it('should redirect native SOL system program to /native endpoint', async () => {
-        const url =
-            'https://api.example.com/v1/svm/transfers?network=solana&mint=11111111111111111111111111111111&limit=1';
-        const ctx = createMockContext(url);
-        const next = createMockNext();
+    const nativeAliases = [
+        '11111111111111111111111111111111',
+        'So11111111111111111111111111111111111111111',
+        'so11111111111111111111111111111111111111111',
+        'SO11111111111111111111111111111111111111111',
+        'sol11111111111111111111111111111111',
+        'SOL11111111111111111111111111111111',
+    ];
 
-        await nativeMintRedirect(ctx, next);
+    for (const alias of nativeAliases) {
+        it(`should redirect native mint alias ${alias} to /native endpoint`, async () => {
+            const url = `https://api.example.com/v1/svm/transfers?network=solana&mint=${alias}&limit=1`;
+            const ctx = createMockContext(url);
+            const next = createMockNext();
 
-        expect(ctx.redirect).toHaveBeenCalledTimes(1);
-        const redirectedUrl = (ctx.redirect as any).mock.calls[0][0];
-        expect(redirectedUrl).toBe('/v1/svm/transfers/native?network=solana&limit=1');
-        expect(next).not.toHaveBeenCalled();
-    });
+            await nativeMintRedirect(ctx, next);
+
+            expect(ctx.redirect).toHaveBeenCalledTimes(1);
+            const redirectedUrl = (ctx.redirect as any).mock.calls[0][0];
+            expect(redirectedUrl).toBe('/v1/svm/transfers/native?network=solana&limit=1');
+            expect(next).not.toHaveBeenCalled();
+        });
+    }
 
     it('should use relative path behind reverse proxy', async () => {
         const url = 'http://localhost:8000/v1/svm/holders?network=solana&mint=11111111111111111111111111111111&limit=5';
@@ -174,9 +184,21 @@ describe('nativeMintRedirect middleware', () => {
         expect(redirectedUrl).toBe('/v1/svm/holders/native?network=solana&limit=5');
     });
 
-    it('should not redirect for wSOL mint', async () => {
+    it('should not redirect for wSOL mint (real SPL token, ends in 2)', async () => {
         const url =
             'https://api.example.com/v1/svm/transfers?network=solana&mint=So11111111111111111111111111111111111111112&limit=1';
+        const ctx = createMockContext(url);
+        const next = createMockNext();
+
+        await nativeMintRedirect(ctx, next);
+
+        expect(ctx.redirect).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not redirect when mint is comma-separated (multiple values)', async () => {
+        const url =
+            'https://api.example.com/v1/svm/transfers?network=solana&mint=So11111111111111111111111111111111111111111,So11111111111111111111111111111111111111112';
         const ctx = createMockContext(url);
         const next = createMockNext();
 

--- a/src/middleware/nativeContractRedirect.spec.ts
+++ b/src/middleware/nativeContractRedirect.spec.ts
@@ -129,6 +129,17 @@ describe('nativeContractRedirect middleware', () => {
             expect(ctx.redirect).not.toHaveBeenCalled();
             expect(next).toHaveBeenCalledTimes(1);
         });
+
+        it('should continue normal processing when contract is repeated (batched as array)', async () => {
+            const url = `https://api.example.com/v1/evm/transfers?network=mainnet&contract=${EVM_CONTRACT_NATIVE_EXAMPLE}&contract=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`;
+            const ctx = createMockContext(url);
+            const next = createMockNext();
+
+            await nativeContractRedirect(ctx, next);
+
+            expect(ctx.redirect).not.toHaveBeenCalled();
+            expect(next).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('redirect URL format', () => {
@@ -199,6 +210,18 @@ describe('nativeMintRedirect middleware', () => {
     it('should not redirect when mint is comma-separated (multiple values)', async () => {
         const url =
             'https://api.example.com/v1/svm/transfers?network=solana&mint=So11111111111111111111111111111111111111111,So11111111111111111111111111111111111111112';
+        const ctx = createMockContext(url);
+        const next = createMockNext();
+
+        await nativeMintRedirect(ctx, next);
+
+        expect(ctx.redirect).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not redirect when mint is repeated (batched as array)', async () => {
+        const url =
+            'https://api.example.com/v1/svm/transfers?network=solana&mint=So11111111111111111111111111111111111111111&mint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
         const ctx = createMockContext(url);
         const next = createMockNext();
 

--- a/src/middleware/nativeContractRedirect.ts
+++ b/src/middleware/nativeContractRedirect.ts
@@ -16,13 +16,10 @@ import { EVM_CONTRACT_NATIVE_EXAMPLE } from '../types/examples.js';
  */
 export async function nativeContractRedirect(c: Context, next: Next) {
     const url = new URL(c.req.url);
-    const contractParam = url.searchParams.get('contract');
+    const contractValues = url.searchParams.getAll('contract');
+    const only = contractValues.length === 1 ? contractValues[0] : undefined;
 
-    if (
-        contractParam &&
-        contractParam.toLowerCase() === EVM_CONTRACT_NATIVE_EXAMPLE.toLowerCase() &&
-        !contractParam.includes(',')
-    ) {
+    if (only && !only.includes(',') && only.toLowerCase() === EVM_CONTRACT_NATIVE_EXAMPLE.toLowerCase()) {
         url.searchParams.delete('contract');
         const query = url.searchParams.toString();
         return c.redirect(`${url.pathname}/native${query ? `?${query}` : ''}`);
@@ -52,9 +49,10 @@ const NATIVE_MINT_ALIASES = new Set([
  */
 export async function nativeMintRedirect(c: Context, next: Next) {
     const url = new URL(c.req.url);
-    const mintParam = url.searchParams.get('mint');
+    const mintValues = url.searchParams.getAll('mint');
+    const only = mintValues.length === 1 ? mintValues[0] : undefined;
 
-    if (mintParam && !mintParam.includes(',') && NATIVE_MINT_ALIASES.has(mintParam.toLowerCase())) {
+    if (only && !only.includes(',') && NATIVE_MINT_ALIASES.has(only.toLowerCase())) {
         url.searchParams.delete('mint');
         const query = url.searchParams.toString();
         return c.redirect(`${url.pathname}/native${query ? `?${query}` : ''}`);

--- a/src/middleware/nativeContractRedirect.ts
+++ b/src/middleware/nativeContractRedirect.ts
@@ -31,15 +31,21 @@ export async function nativeContractRedirect(c: Context, next: Next) {
     await next();
 }
 
+const NATIVE_MINT_ALIASES = new Set([
+    '11111111111111111111111111111111',
+    'so11111111111111111111111111111111111111111',
+    'sol11111111111111111111111111111111',
+]);
+
 /**
- * Middleware to redirect requests with native contract address to /native endpoint.
+ * Middleware to redirect requests with a native-SOL placeholder mint to the /native endpoint.
  *
  * This is a TEMPORARY migration feature to help users transition to the new /native endpoints.
  * TODO: Remove this middleware once migration is complete.
  *
- * Checks if the 'contract' query parameter is a single value matching the native contract address
- * (11111111111111111111111111111111). If so, redirects to the /native sub-route
- * and removes the contract parameter.
+ * Accepts several aliases users might copy from responses or docs (system program, `So1..111`
+ * placeholder returned by /native routes, `sol1..1` legacy alias). Real wSOL (`So1..112`) is
+ * intentionally excluded — it's a regular SPL token and should hit the normal route.
  *
  * @param c - Hono context
  * @param next - Next middleware function
@@ -48,12 +54,7 @@ export async function nativeMintRedirect(c: Context, next: Next) {
     const url = new URL(c.req.url);
     const mintParam = url.searchParams.get('mint');
 
-    if (
-        mintParam &&
-        (mintParam.toLowerCase() === '11111111111111111111111111111111' ||
-            mintParam.toLowerCase() === 'sol11111111111111111111111111111111') &&
-        !mintParam.includes(',')
-    ) {
+    if (mintParam && !mintParam.includes(',') && NATIVE_MINT_ALIASES.has(mintParam.toLowerCase())) {
         url.searchParams.delete('mint');
         const query = url.searchParams.toString();
         return c.redirect(`${url.pathname}/native${query ? `?${query}` : ''}`);


### PR DESCRIPTION
## Summary

The redirect middleware for SVM native endpoints only matched the system program address (`11111...1`). Our `/v1/svm/*/native` endpoints return `So11111111111111111111111111111111111111111` as the mint placeholder, so users copying that value back into a regular endpoint would fall through to the SPL path and get zero results.

This PR:
- Adds the `So1..111` placeholder to the redirect match list
- Consolidates aliases into a single `Set` and normalizes to lowercase once
- Leaves real wSOL (`So1..112`) falling through to the normal SPL path (unchanged)

## Changes

`src/middleware/nativeContractRedirect.ts`: accept system program, `So1..111`, and `sol1..1` aliases case-insensitively.
`src/middleware/nativeContractRedirect.spec.ts`: extend coverage to all aliases and case variants, plus comma-separated and wSOL negative cases.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)