### PR TITLE
fix(svm): accept canonical `meteora_dlmm` spelling on swaps and pools

### DIFF
--- a/src/routes/pools/svm.sql
+++ b/src/routes/pools/svm.sql
@@ -44,7 +44,8 @@ SELECT
     /* DEX */
     p.program_id AS program_id,
     program_names(p.program_id) AS program_name,
-    p.protocol AS protocol,
+    /* map the legacy `meteora_dllm` storage value to the canonical `meteora_dlmm` */
+    if(p.protocol = 'meteora_dllm', 'meteora_dlmm', p.protocol) AS protocol,
     p.amm as amm,
     program_names(p.amm) as amm_name,
     p.amm_pool AS amm_pool,

--- a/src/routes/pools/svm.ts
+++ b/src/routes/pools/svm.ts
@@ -14,6 +14,7 @@ import {
     svmNetworkIdSchema,
     svmProgramIdSchema,
     svmProtocolWithoutAggregatorSchema,
+    toSvmProtocolDbValue,
 } from '../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../utils.js';
 
@@ -104,6 +105,7 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
 
     const response = await makeUsageQueryJson(c, [query], {
         ...params,
+        protocol: toSvmProtocolDbValue(params.protocol),
         db_dex: dbDex.database,
         db_metadata: dbMetadata.database,
         db_accounts: dbAccounts.database,

--- a/src/routes/swaps/svm.sql
+++ b/src/routes/swaps/svm.sql
@@ -242,8 +242,8 @@ SELECT
     toString(s.output_amount) AS output_amount,
     if(d2.mint != '', s.output_amount / pow(10, d2.decimals), 0) AS output_value,
 
-    /* prices */
-    s.protocol AS protocol,
+    /* prices — map the legacy `meteora_dllm` storage value to the canonical `meteora_dlmm` */
+    if(s.protocol = 'meteora_dllm', 'meteora_dlmm', s.protocol) AS protocol,
 
 
     /* summary */
@@ -258,7 +258,7 @@ SELECT
         if(m2.mint != '', m2.symbol, s.output_mint),
         arrayStringConcat(
             arrayMap(x -> concat(upper(substring(x, 1, 1)), substring(x, 2)),
-                     splitByChar('_', toString(s.protocol))),
+                     splitByChar('_', if(s.protocol = 'meteora_dllm', 'meteora_dlmm', toString(s.protocol)))),
             ' '
         )
     ) AS summary,

--- a/src/routes/swaps/svm.ts
+++ b/src/routes/swaps/svm.ts
@@ -20,6 +20,7 @@ import {
     svmTokenResponseSchema,
     svmTransactionSchema,
     timestampSchema,
+    toSvmProtocolDbValue,
 } from '../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../utils.js';
 
@@ -181,6 +182,7 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
 
     const response = await makeUsageQueryJson(c, [query], {
         ...params,
+        protocol: toSvmProtocolDbValue(params.protocol),
         db_dex: dbDex.database,
         db_metadata: dbMetadata.database,
         db_accounts: dbAccounts.database,

--- a/src/types/zod.spec.ts
+++ b/src/types/zod.spec.ts
@@ -55,6 +55,7 @@ import {
     svmTransaction,
     svmTransactionSchema,
     timestampSchema,
+    toSvmProtocolDbValue,
     tvmAddress,
     tvmAddressSchema,
     tvmContractSchema,
@@ -268,10 +269,24 @@ describe('Protocol Schemas', () => {
     describe('svmProtocolSchema', () => {
         it('should accept valid protocols', () => {
             expect(svmProtocolSchema.parse('raydium_amm_v4')).toBe('raydium_amm_v4');
+            expect(svmProtocolSchema.parse('meteora_dlmm')).toBe('meteora_dlmm');
         });
 
         it('should reject invalid protocols', () => {
             expect(() => svmProtocolSchema.parse('invalid')).toThrow();
+            expect(() => svmProtocolSchema.parse('meteora_dllm')).toThrow();
+        });
+    });
+
+    describe('toSvmProtocolDbValue', () => {
+        it('should map meteora_dlmm to the legacy storage value', () => {
+            expect(toSvmProtocolDbValue('meteora_dlmm')).toBe('meteora_dllm');
+        });
+
+        it('should pass other values through unchanged', () => {
+            expect(toSvmProtocolDbValue('raydium_amm_v4')).toBe('raydium_amm_v4');
+            expect(toSvmProtocolDbValue(undefined)).toBe(undefined);
+            expect(toSvmProtocolDbValue(null)).toBe(null);
         });
     });
 

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -152,7 +152,7 @@ const svmProtocolsWithoutAggregators = [
     'raydium_clmm',
     'raydium_cpmm',
     'raydium_launchpad',
-    'meteora_dllm',
+    'meteora_dlmm',
     'orca_whirlpool',
     'boop',
     'darklake',
@@ -166,6 +166,15 @@ export const svmProtocolWithoutAggregatorSchema = z
     .meta({ description: 'Protocol name', example: 'raydium_amm_v4' });
 
 export const svmProtocolSchema = z.enum(svmProtocols).meta({ description: 'Protocol name', example: 'raydium_amm_v4' });
+
+/**
+ * Canonical SVM protocol → ClickHouse-stored value. `meteora_dlmm` is the
+ * canonical spelling; rows were indexed under the misspelled `meteora_dllm`.
+ */
+export const toSvmProtocolDbValue = <T extends string | null | undefined>(v: T): T | string => {
+    if (v === 'meteora_dlmm') return 'meteora_dllm';
+    return v;
+};
 
 export const tvmProtocolSchema = z
     .enum(['uniswap_v1', 'uniswap_v2', 'uniswap_v3', 'uniswap_v4', 'sunpump'])


### PR DESCRIPTION
## Summary

The SVM protocol enum previously exposed `meteora_dllm` (double L). The canonical spelling is `meteora_dlmm` — Meteora's product is **DLMM** (Dynamic Liquidity Market Maker).

This PR updates the API to use the canonical spelling without breaking lookups against existing data:

- `svmProtocolSchema` / `svmProtocolWithoutAggregatorSchema` accept `meteora_dlmm` only; passing the legacy spelling now returns 400.
- New `toSvmProtocolDbValue` helper translates the canonical filter value to the underlying storage value before SQL execution — the WHERE clause keeps matching existing rows.
- `/v1/svm/swaps` and `/v1/svm/pools` rewrite the `protocol` column in the SELECT projection so the response, and the swap `summary` human-readable string, always surface the canonical spelling regardless of what is stored upstream.

## Changes

- `src/types/zod.ts`: enum renamed, added `toSvmProtocolDbValue`
- `src/types/zod.spec.ts`: updated protocol schema tests, added coverage for the helper
- `src/routes/swaps/svm.ts`, `src/routes/pools/svm.ts`: translate the filter value before calling ClickHouse
- `src/routes/swaps/svm.sql`, `src/routes/pools/svm.sql`: rewrite the `protocol` column in the SELECT projection

Closes #481

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)