### PR TITLE
feat(openapi): add format and pattern to address and tx schemas

### DIFF
--- a/src/types/zod.spec.ts
+++ b/src/types/zod.spec.ts
@@ -221,6 +221,35 @@ describe('Base Validation Schemas', () => {
     });
 });
 
+describe('OpenAPI metadata projection', () => {
+    const cases: Array<[string, z.ZodType, string, string]> = [
+        ['evmAddress', evmAddress, 'evm-address', '^(0[xX])?[0-9a-fA-F]{40}$'],
+        ['evmTransaction', evmTransaction, 'evm-tx-hash', '^(0[xX])?[0-9a-fA-F]{64}$'],
+        ['svmAddress', svmAddress, 'svm-address', '^[1-9A-HJ-NP-Za-km-z]{32,44}$'],
+        ['svmTransaction', svmTransaction, 'svm-signature', '^[1-9A-HJ-NP-Za-km-z]{87,88}$'],
+        ['tvmAddress', tvmAddress, 'tvm-address', '^T[1-9A-HJ-NP-Za-km-z]{33}$'],
+        ['tvmTransaction', tvmTransaction, 'tvm-tx-hash', '^[0-9a-fA-F]{64}$'],
+    ];
+
+    for (const [name, schema, expectedFormat, expectedPattern] of cases) {
+        it(`${name} projects format and pattern into JSON Schema`, () => {
+            const json = z.toJSONSchema(schema, { io: 'input' }) as Record<string, unknown>;
+            expect(json.type).toBe('string');
+            expect(json.format).toBe(expectedFormat);
+            expect(json.pattern).toBe(expectedPattern);
+        });
+    }
+
+    it('wrapper schemas inherit the base format', () => {
+        const contract = z.toJSONSchema(evmContractSchema, { io: 'input' }) as Record<string, unknown>;
+        expect(contract.format).toBe('evm-address');
+        const mint = z.toJSONSchema(svmMintSchema, { io: 'input' }) as Record<string, unknown>;
+        expect(mint.format).toBe('svm-address');
+        const tvmContract = z.toJSONSchema(tvmContractSchema, { io: 'input' }) as Record<string, unknown>;
+        expect(tvmContract.format).toBe('tvm-address');
+    });
+});
+
 describe('Network Schemas', () => {
     describe('evmNetworkIdSchema', () => {
         it('should accept valid EVM network IDs', () => {

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -39,46 +39,53 @@ export const booleanFromString = z.preprocess((val, ctx) => {
     return z.NEVER;
 }, z.boolean());
 
+const EVM_ADDRESS_RE = /^(0[xX])?[0-9a-fA-F]{40}$/;
+const EVM_TX_RE = /^(0[xX])?[0-9a-fA-F]{64}$/;
+const SVM_ADDRESS_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+const SVM_SIGNATURE_RE = /^[1-9A-HJ-NP-Za-km-z]{87,88}$/;
+const TVM_ADDRESS_RE = /^T[1-9A-HJ-NP-Za-km-z]{33}$/;
+const TVM_TX_RE = /^[0-9a-fA-F]{64}$/;
+
 export const evmAddress = z.coerce
     .string()
-    .refine((val) => /^(0[xX])?[0-9a-fA-F]{40}$/.test(val), 'Invalid EVM address')
+    .refine((val) => EVM_ADDRESS_RE.test(val), 'Invalid EVM address')
     .transform((addr) => addr.toLowerCase())
     .transform((addr) => (addr.length === 40 ? `0x${addr}` : addr))
     .pipe(z.string())
-    .meta({ type: 'string' });
+    .meta({ type: 'string', format: 'evm-address', pattern: EVM_ADDRESS_RE.source });
 
 export const evmTransaction = z.coerce
     .string()
-    .refine((val) => /^(0[xX])?[0-9a-fA-F]{64}$/.test(val), 'Invalid EVM transaction')
+    .refine((val) => EVM_TX_RE.test(val), 'Invalid EVM transaction')
     .transform((addr) => addr.toLowerCase())
     .transform((addr) => (addr.length === 64 ? `0x${addr}` : addr))
     .pipe(z.string())
-    .meta({ type: 'string' });
+    .meta({ type: 'string', format: 'evm-tx-hash', pattern: EVM_TX_RE.source });
 
 export const svmAddress = z.coerce
     .string()
-    .refine((val) => /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(val), 'Invalid SVM address')
+    .refine((val) => SVM_ADDRESS_RE.test(val), 'Invalid SVM address')
     .pipe(z.string())
-    .meta({ type: 'string' });
+    .meta({ type: 'string', format: 'svm-address', pattern: SVM_ADDRESS_RE.source });
 
 export const svmTransaction = z.coerce
     .string()
-    .refine((val) => /^[1-9A-HJ-NP-Za-km-z]{87,88}$/.test(val), 'Invalid SVM transaction')
+    .refine((val) => SVM_SIGNATURE_RE.test(val), 'Invalid SVM transaction')
     .pipe(z.string())
-    .meta({ type: 'string' });
+    .meta({ type: 'string', format: 'svm-signature', pattern: SVM_SIGNATURE_RE.source });
 
 export const tvmAddress = z.coerce
     .string()
-    .refine((val) => /^T[1-9A-HJ-NP-Za-km-z]{33}$/.test(val), 'Invalid TVM address')
+    .refine((val) => TVM_ADDRESS_RE.test(val), 'Invalid TVM address')
     .pipe(z.string())
-    .meta({ type: 'string' });
+    .meta({ type: 'string', format: 'tvm-address', pattern: TVM_ADDRESS_RE.source });
 
 export const tvmTransaction = z.coerce
     .string()
-    .refine((val) => /^[0-9a-fA-F]{64}$/.test(val), 'Invalid TVM transaction hash')
+    .refine((val) => TVM_TX_RE.test(val), 'Invalid TVM transaction hash')
     .transform((hash) => hash.toLowerCase())
     .pipe(z.string())
-    .meta({ type: 'string' });
+    .meta({ type: 'string', format: 'tvm-tx-hash', pattern: TVM_TX_RE.source });
 
 export const version = z.coerce.string().regex(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
 export const commit = z.coerce.string().regex(/^[0-9a-f]{7}$/);


### PR DESCRIPTION
## Summary

Surface chain-specific semantics on address and transaction query parameters so OpenAPI consumers (typed client generators, agents, validators) can distinguish EVM addresses, SVM base58 pubkeys, and TVM T-prefixed addresses without parsing descriptions.

Each base schema in \`src/types/zod.ts\` now projects both \`format\` and \`pattern\` into its JSON Schema output:

| Schema | \`format\` | \`pattern\` |
|--------|----------|-----------|
| \`evmAddress\` | \`evm-address\` | \`^(0[xX])?[0-9a-fA-F]{40}\$\` |
| \`evmTransaction\` | \`evm-tx-hash\` | \`^(0[xX])?[0-9a-fA-F]{64}\$\` |
| \`svmAddress\` | \`svm-address\` | \`^[1-9A-HJ-NP-Za-km-z]{32,44}\$\` |
| \`svmTransaction\` | \`svm-signature\` | \`^[1-9A-HJ-NP-Za-km-z]{87,88}\$\` |
| \`tvmAddress\` | \`tvm-address\` | \`^T[1-9A-HJ-NP-Za-km-z]{33}\$\` |
| \`tvmTransaction\` | \`tvm-tx-hash\` | \`^[0-9a-fA-F]{64}\$\` |

Wrapper schemas (\`evmContractSchema\`, \`svmMintSchema\`, \`svmAmmPoolSchema\`, \`tvmContractSchema\`, …) inherit the format automatically, so every address-shaped query parameter across EVM, SVM, and TVM endpoints picks this up without touching the route files.

## Implementation notes

- Regex literals hoisted to named constants (\`EVM_ADDRESS_RE\`, \`SVM_ADDRESS_RE\`, …) so the \`.refine()\` validation and the OpenAPI \`pattern\` share one source of truth.
- Custom \`format\` values (e.g. \`evm-address\`) degrade gracefully in generators that don't recognize them — they remain plain strings, no client breakage.

## Tests

Added a new \`OpenAPI metadata projection\` describe block in \`src/types/zod.spec.ts\` asserting the projection for all six base schemas plus an inheritance check for a wrapper from each chain. Existing sample-value tests (156 pass) continue to cover input validation for every schema.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)