### PR TITLE
fix(polymarket): read state_user with FINAL

### DIFF
--- a/src/routes/polymarket/users.sql
+++ b/src/routes/polymarket/users.sql
@@ -11,6 +11,6 @@ SELECT
     total_pnl,
     first_trade,
     last_trade
-FROM {db_polymarket:Identifier}.state_user
+FROM {db_polymarket:Identifier}.state_user FINAL
 WHERE interval_min = {interval_min:UInt32}
   AND (isNull({user:Nullable(String)}) OR user = {user:Nullable(String)})


### PR DESCRIPTION
## Summary

Add `FINAL` to the `state_user` read in `users.sql` so that the
`/v1/polymarket/users` leaderboard returns the latest snapshot once
the underlying table is migrated to a `Replicated*ReplacingMergeTree`
engine for cross-replica consistency.

## Why

`state_user` is the target of an hourly refresh MV. Migrating it to
a Replicated engine on an Atomic database requires APPEND-mode
refreshes, which leave multiple snapshot rows per
`(interval_min, user)` until merges collapse them. `FINAL` is the
read-side dedup mechanism that picks the row with the highest
`refresh_time`.

`FINAL` is a no-op against the current non-replicated engine, so
this change can ship ahead of the schema migration without affecting
behavior.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)