### PR TITLE
[codex] Expose skills.md in OpenAPI

### DIFF
--- a/docs/repo-navigation.md
+++ b/docs/repo-navigation.md
@@ -19,7 +19,7 @@ This document captures stable, tool-agnostic navigation knowledge for the `token
 - `scripts/`: maintenance and analysis scripts (perf, query logs, stablecoins, query breakdown generation).
 - `queries/`: SQL reference breakdowns consumed by script workflows.
 - `reports/`: checked-in analysis/performance reports (documentation artifacts, not runtime code).
-- `public/`: static files served by app (`index.html`, `skills.md`, assets).
+- `public/`: static files served by app (`index.html`, `skills.md`, `llms.txt`, assets).
 - `.github/workflows/`: CI and release automation entrypoints.
 
 ## 2) Architecture mental model (request/data flow)
@@ -61,7 +61,7 @@ This document captures stable, tool-agnostic navigation knowledge for the `token
   - Streaming, stats, query error handling: `src/clickhouse/makeQuery.ts` and `src/handleQuery.ts`.
 
 - Change static docs or landing assets:
-  - Edit `public/index.html`, `public/skills.md`, and media in `public/`.
+  - Edit `public/index.html`, `public/skills.md`, `public/llms.txt`, and media in `public/`.
 
 - Update CI/release behavior:
   - Edit `.github/workflows/*.yml`.

--- a/index.ts
+++ b/index.ts
@@ -53,10 +53,36 @@ const skillsMarkdownOpenapi = describeRoute({
     },
 });
 
+const llmsTextOpenapi = describeRoute({
+    operationId: 'getLlmsText',
+    summary: 'LLM Documentation Index',
+    description: 'Returns the public llms.txt documentation index for AI tools discovering Token API.',
+    tags: ['Documentation'],
+    security: [],
+    responses: {
+        200: {
+            description: 'Successful Response',
+            content: {
+                'text/plain': {
+                    schema: {
+                        type: 'string',
+                        example: '# Token API',
+                    },
+                },
+            },
+        },
+    },
+});
+
 app.get(
     '/skills.md',
     skillsMarkdownOpenapi,
     () => new Response(Bun.file('./public/skills.md'), { headers: { 'Content-Type': 'text/markdown; charset=UTF-8' } })
+);
+app.get(
+    '/llms.txt',
+    llmsTextOpenapi,
+    () => new Response(Bun.file('./public/llms.txt'), { headers: { 'Content-Type': 'text/plain; charset=UTF-8' } })
 );
 app.get(
     '/openapi',

--- a/index.ts
+++ b/index.ts
@@ -75,8 +75,12 @@ const llmsTextOpenapi = describeRoute({
 });
 
 app.get(
-    '/skills.md',
+    '/SKILLS.md',
     skillsMarkdownOpenapi,
+    () => new Response(Bun.file('./public/skills.md'), { headers: { 'Content-Type': 'text/markdown; charset=UTF-8' } })
+);
+app.get(
+    '/skills.md',
     () => new Response(Bun.file('./public/skills.md'), { headers: { 'Content-Type': 'text/markdown; charset=UTF-8' } })
 );
 app.get(

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import { type Context, Hono } from 'hono';
 import './src/banner.js';
-import { openAPIRouteHandler } from 'hono-openapi';
+import { describeRoute, openAPIRouteHandler } from 'hono-openapi';
 import { logServerInit } from './src/banner.js';
 import { APP_DESCRIPTION, APP_VERSION, config } from './src/config.js';
 import { logger } from './src/logger.js';
@@ -32,8 +32,30 @@ app.route('/', routes);
 app.get('/', () => new Response(Bun.file('./public/index.html')));
 app.get('/favicon.svg', () => new Response(Bun.file('./public/favicon.svg')));
 app.get('/banner.jpg', () => new Response(Bun.file('./public/banner.jpg')));
+const skillsMarkdownOpenapi = describeRoute({
+    operationId: 'getSkillsMarkdown',
+    summary: 'Agent Skills Reference',
+    description: 'Returns the public Markdown reference for AI agents integrating with Token API.',
+    tags: ['Documentation'],
+    security: [],
+    responses: {
+        200: {
+            description: 'Successful Response',
+            content: {
+                'text/markdown': {
+                    schema: {
+                        type: 'string',
+                        example: '# Token API',
+                    },
+                },
+            },
+        },
+    },
+});
+
 app.get(
     '/skills.md',
+    skillsMarkdownOpenapi,
     () => new Response(Bun.file('./public/skills.md'), { headers: { 'Content-Type': 'text/markdown; charset=UTF-8' } })
 );
 app.get(
@@ -49,6 +71,8 @@ app.get(
                 ? [{ url: `http://${config.hostname}:${config.port}`, description: `${APP_DESCRIPTION} - Local` }]
                 : [{ url: config.apiUrl, description: `${APP_DESCRIPTION} - Remote` }],
             tags: [
+                // Documentation
+                { name: 'Documentation' },
                 // SVM
                 { name: 'SVM Tokens' },
                 { name: 'SVM Tokens (Native)' },
@@ -84,6 +108,7 @@ app.get(
                 },
             },
         },
+        excludeStaticFile: false,
     })
 );
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,35 @@
+# Token API
+
+> Token API provides real-time token, balance, transfer, holder, DEX, liquidity pool, NFT, and Polymarket market data across EVM, SVM, and TVM networks.
+
+Use this file as a compact documentation index for AI tools. For exact request parameters, response schemas, authentication, and security requirements, prefer the OpenAPI document. For agent-oriented workflows and capability guidance, use the skills reference.
+
+Important notes:
+- Base URL: https://token-api.thegraph.com
+- Most data endpoints require `Authorization: Bearer <token>` from The Graph Market or `X-Api-Key`.
+- Free unauthenticated endpoints include documentation, health/version/network discovery, DEX discovery, and Polymarket market discovery.
+- Runtime network support is configuration-driven; call `GET /v1/networks` before assuming a network is indexed.
+
+## Core references
+
+- [OpenAPI specification](https://token-api.thegraph.com/openapi): Authoritative machine-readable API contract.
+- [Agent skills reference](https://token-api.thegraph.com/skills.md): Capability summary, workflows, constraints, and endpoint overview for AI agents.
+- [Token API quick start](https://thegraph.com/docs/en/token-api/quick-start/): Human-readable setup and first requests.
+- [Token API FAQ](https://thegraph.com/docs/en/token-api/faq/): Plan, billing, authentication, and usage notes.
+
+## Free endpoints
+
+- [Health check](https://token-api.thegraph.com/v1/health): Database connectivity status.
+- [Version](https://token-api.thegraph.com/v1/version): API build version, date, and commit.
+- [Supported networks](https://token-api.thegraph.com/v1/networks): Indexed chains and per-category indexing freshness.
+- [EVM DEXes](https://token-api.thegraph.com/v1/evm/dexes): Supported EVM DEX protocols by network.
+- [SVM DEXes](https://token-api.thegraph.com/v1/svm/dexes): Supported SVM DEX protocols by network.
+- [TVM DEXes](https://token-api.thegraph.com/v1/tvm/dexes): Supported TVM DEX protocols by network.
+- [Polymarket markets](https://token-api.thegraph.com/v1/polymarket/markets): Public Polymarket market discovery.
+
+## API families
+
+- [EVM endpoints](https://token-api.thegraph.com/openapi): ERC-20 tokens, native tokens, balances, transfers, holders, swaps, DEXes, pools, OHLC, and NFTs.
+- [SVM endpoints](https://token-api.thegraph.com/openapi): SPL tokens, native SOL, balances, transfers, holders, swaps, DEXes, pools, OHLC, and account owner lookup.
+- [TVM endpoints](https://token-api.thegraph.com/openapi): TRC-20 tokens, native TRX, transfers, swaps, DEXes, pools, and OHLC.
+- [Polymarket endpoints](https://token-api.thegraph.com/openapi): Markets, OHLC, open interest, activity, platform stats, users, and positions.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -13,7 +13,7 @@ Important notes:
 ## Core references
 
 - [OpenAPI specification](https://token-api.thegraph.com/openapi): Authoritative machine-readable API contract.
-- [Agent skills reference](https://token-api.thegraph.com/skills.md): Capability summary, workflows, constraints, and endpoint overview for AI agents.
+- [Agent skills reference](https://token-api.thegraph.com/SKILLS.md): Capability summary, workflows, constraints, and endpoint overview for AI agents.
 - [Token API quick start](https://thegraph.com/docs/en/token-api/quick-start/): Human-readable setup and first requests.
 - [Token API FAQ](https://thegraph.com/docs/en/token-api/faq/): Plan, billing, authentication, and usage notes.
 

--- a/public/skills.md
+++ b/public/skills.md
@@ -25,6 +25,8 @@ Authorization: Bearer <your-token>
 An `X-Api-Key: <your-api-key>` header is accepted as an alternative.
 
 **Unauthenticated endpoints** (no header required, no usage charge):
+- `GET /llms.txt`
+- `GET /skills.md`
 - `GET /v1/health`
 - `GET /v1/version`
 - `GET /v1/networks`

--- a/public/skills.md
+++ b/public/skills.md
@@ -26,7 +26,8 @@ An `X-Api-Key: <your-api-key>` header is accepted as an alternative.
 
 **Unauthenticated endpoints** (no header required, no usage charge):
 - `GET /llms.txt`
-- `GET /skills.md`
+- `GET /SKILLS.md`
+- `GET /skills.md` (lowercase alias)
 - `GET /v1/health`
 - `GET /v1/version`
 - `GET /v1/networks`


### PR DESCRIPTION
## Summary

Expose the public agent documentation endpoints in the generated OpenAPI document and add a new public `GET /llms.txt` documentation index for AI tools.

## Issue

`/skills.md` was already served by the application, but it did not have OpenAPI route metadata. Since `hono-openapi` also filters static-looking paths by default, dotted documentation paths such as `/SKILLS.md` and `/llms.txt` would be absent from `GET /openapi` without explicit route metadata and generator configuration.

## Fix

- Added `describeRoute` metadata for canonical `GET /SKILLS.md` with a `text/markdown` response schema.
- Kept lowercase `GET /skills.md` as a supported alias that serves the same file, while leaving uppercase as the OpenAPI default.
- Added `public/llms.txt` as a concise LLM documentation index linking to the OpenAPI spec, skills reference, docs, and free endpoints.
- Added `describeRoute` metadata for `GET /llms.txt` with a `text/plain` response schema.
- Marked both documented operations with `security: []` so they are represented as free endpoints.
- Added a `Documentation` OpenAPI tag and allowed static-looking paths through OpenAPI generation so the documented text routes are included.
- Updated `public/skills.md`, `public/llms.txt`, and `docs/repo-navigation.md` to mention the new documentation endpoint/file.

## Notes

`llms.txt` is a proposed Markdown-based discovery/index file for LLM tools. It is closer to an AI-readable sitemap or curated documentation index. `SKILLS.md` is more specific: it describes agent capabilities, workflows, inputs, and constraints. They complement each other rather than replacing each other.

## Validation

- `bun --print "const app = (await import('./index.ts')).default; const spec = await (await app.request('/openapi')).json(); console.log(Object.keys(spec.paths).filter((path) => path.toLowerCase().includes('skills') || path.includes('llms')).join('\\n')); console.log(JSON.stringify(spec.paths['/SKILLS.md'], null, 2)); console.log('lowercase in spec:', Boolean(spec.paths['/skills.md']));"`
- `bun --print "const app = (await import('./index.ts')).default; const upper = await app.request('/SKILLS.md'); const lower = await app.request('/skills.md'); console.log(JSON.stringify({ upper: { status: upper.status, contentType: upper.headers.get('content-type'), prefix: (await upper.text()).slice(0, 12) }, lower: { status: lower.status, contentType: lower.headers.get('content-type'), prefix: (await lower.text()).slice(0, 12) } }, null, 2));"`
- `bun lint`
- `bun test`
