### PR TITLE
Remove Meteora DLMM legacy protocol mapping

### DIFF
--- a/src/routes/pools/svm.sql
+++ b/src/routes/pools/svm.sql
@@ -44,8 +44,7 @@ SELECT
     /* DEX */
     p.program_id AS program_id,
     program_names(p.program_id) AS program_name,
-    /* map the legacy `meteora_dllm` storage value to the canonical `meteora_dlmm` */
-    if(p.protocol = 'meteora_dllm', 'meteora_dlmm', p.protocol) AS protocol,
+    p.protocol AS protocol,
     p.amm as amm,
     program_names(p.amm) as amm_name,
     p.amm_pool AS amm_pool,

--- a/src/routes/pools/svm.ts
+++ b/src/routes/pools/svm.ts
@@ -14,7 +14,6 @@ import {
     svmNetworkIdSchema,
     svmProgramIdSchema,
     svmProtocolWithoutAggregatorSchema,
-    toSvmProtocolDbValue,
 } from '../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../utils.js';
 
@@ -105,7 +104,6 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
 
     const response = await makeUsageQueryJson(c, [query], {
         ...params,
-        protocol: toSvmProtocolDbValue(params.protocol),
         db_dex: dbDex.database,
         db_metadata: dbMetadata.database,
         db_accounts: dbAccounts.database,

--- a/src/routes/swaps/svm.sql
+++ b/src/routes/swaps/svm.sql
@@ -242,8 +242,8 @@ SELECT
     toString(s.output_amount) AS output_amount,
     if(d2.mint != '', s.output_amount / pow(10, d2.decimals), 0) AS output_value,
 
-    /* prices — map the legacy `meteora_dllm` storage value to the canonical `meteora_dlmm` */
-    if(s.protocol = 'meteora_dllm', 'meteora_dlmm', s.protocol) AS protocol,
+    /* prices */
+    s.protocol AS protocol,
 
 
     /* summary */
@@ -258,7 +258,7 @@ SELECT
         if(m2.mint != '', m2.symbol, s.output_mint),
         arrayStringConcat(
             arrayMap(x -> concat(upper(substring(x, 1, 1)), substring(x, 2)),
-                     splitByChar('_', if(s.protocol = 'meteora_dllm', 'meteora_dlmm', toString(s.protocol)))),
+                     splitByChar('_', toString(s.protocol))),
             ' '
         )
     ) AS summary,

--- a/src/routes/swaps/svm.ts
+++ b/src/routes/swaps/svm.ts
@@ -20,7 +20,6 @@ import {
     svmTokenResponseSchema,
     svmTransactionSchema,
     timestampSchema,
-    toSvmProtocolDbValue,
 } from '../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../utils.js';
 
@@ -182,7 +181,6 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
 
     const response = await makeUsageQueryJson(c, [query], {
         ...params,
-        protocol: toSvmProtocolDbValue(params.protocol),
         db_dex: dbDex.database,
         db_metadata: dbMetadata.database,
         db_accounts: dbAccounts.database,

--- a/src/types/zod.spec.ts
+++ b/src/types/zod.spec.ts
@@ -55,7 +55,6 @@ import {
     svmTransaction,
     svmTransactionSchema,
     timestampSchema,
-    toSvmProtocolDbValue,
     tvmAddress,
     tvmAddressSchema,
     tvmContractSchema,
@@ -325,19 +324,6 @@ describe('Protocol Schemas', () => {
 
         it('should reject invalid protocols', () => {
             expect(() => svmProtocolSchema.parse('invalid')).toThrow();
-            expect(() => svmProtocolSchema.parse('meteora_dllm')).toThrow();
-        });
-    });
-
-    describe('toSvmProtocolDbValue', () => {
-        it('should map meteora_dlmm to the legacy storage value', () => {
-            expect(toSvmProtocolDbValue('meteora_dlmm')).toBe('meteora_dllm');
-        });
-
-        it('should pass other values through unchanged', () => {
-            expect(toSvmProtocolDbValue('raydium_amm_v4')).toBe('raydium_amm_v4');
-            expect(toSvmProtocolDbValue(undefined)).toBe(undefined);
-            expect(toSvmProtocolDbValue(null)).toBe(null);
         });
     });
 

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -179,15 +179,6 @@ export const svmProtocolWithoutAggregatorSchema = z
 
 export const svmProtocolSchema = z.enum(svmProtocols).meta({ description: 'Protocol name', example: 'raydium_amm_v4' });
 
-/**
- * Canonical SVM protocol → ClickHouse-stored value. `meteora_dlmm` is the
- * canonical spelling; rows were indexed under the misspelled `meteora_dllm`.
- */
-export const toSvmProtocolDbValue = <T extends string | null | undefined>(v: T): T | string => {
-    if (v === 'meteora_dlmm') return 'meteora_dllm';
-    return v;
-};
-
 export const tvmProtocolSchema = z
     .enum(['uniswap_v1', 'uniswap_v2', 'uniswap_v3', 'uniswap_v4', 'sunpump'])
     .meta({ description: 'Protocol name', example: 'uniswap_v2' });


### PR DESCRIPTION
Fixes: https://github.com/pinax-network/token-api/issues/484
## Summary
- remove the SVM protocol DB-value mapper for Meteora DLMM
- pass SVM protocol query parameters through directly for pools and swaps
- return SVM pools/swaps protocol values directly from ClickHouse and simplify swap summary formatting

## Tests
- bun test src/types/zod.spec.ts
- bun lint
- bun test