### PR TITLE
docs(skills): tighten llms.txt and restructure skills.md

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -50,12 +50,12 @@ const skillsMarkdownOpenapi = describeRoute({
                         type: 'string',
                         example: `---
 name: Token API
-description: Real-time token data across EVM (Ethereum, Base, BSC, Polygon, Arbitrum, ...), SVM (Solana), and TVM (TRON). Query balances, transfers, holders, DEX swaps, liquidity pools with OHLC, NFTs, and Polymarket markets.
+description: Real-time token, balance, transfer, holder, DEX, NFT, and Polymarket data across EVM, SVM, and TVM networks.
 ---
 
 # Token API
 
-> Power your apps & AI agents with real-time token data across EVM, SVM, and TVM blockchains. This file is a quick reference for agents; the full machine-readable contract is at \`GET /openapi\`.
+> Quick reference for AI agents using Token API. The authoritative machine-readable contract is \`GET /openapi\`.
 
 ...`,
                     },
@@ -80,9 +80,7 @@ const llmsTextOpenapi = describeRoute({
                         type: 'string',
                         example: `# Token API
 
-> Token API provides real-time token, balance, transfer, holder, DEX, liquidity pool, NFT, and Polymarket market data across EVM, SVM, and TVM networks.
-
-Use this file as a compact documentation index for AI tools. For exact request parameters, response schemas, authentication, and security requirements, prefer the OpenAPI document. For agent-oriented workflows and capability guidance, use the skills reference.
+> Real-time token, balance, transfer, holder, DEX, NFT, and Polymarket data across EVM, SVM, and TVM networks.
 
 ...`,
                     },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,35 +1,28 @@
 # Token API
 
-> Token API provides real-time token, balance, transfer, holder, DEX, liquidity pool, NFT, and Polymarket market data across EVM, SVM, and TVM networks.
+> Real-time token, balance, transfer, holder, DEX, NFT, and Polymarket data across EVM, SVM, and TVM networks.
 
-Use this file as a compact documentation index for AI tools. For exact request parameters, response schemas, authentication, and security requirements, prefer the OpenAPI document. For agent-oriented workflows and capability guidance, use the skills reference.
-
-Important notes:
 - Base URL: https://token-api.thegraph.com
-- Most data endpoints require `Authorization: Bearer <token>` from The Graph Market or `X-Api-Key`.
-- Free unauthenticated endpoints include documentation, health/version/network discovery, DEX discovery, and Polymarket market discovery.
-- Runtime network support is configuration-driven; call `GET /v1/networks` before assuming a network is indexed.
+- Most endpoints require `Authorization: Bearer <token>` from The Graph Market, or `X-Api-Key`.
+- Network support is configuration-driven — call `GET /v1/networks` first to see what's indexed.
 
 ## Core references
 
-- [OpenAPI specification](https://token-api.thegraph.com/openapi): Authoritative machine-readable API contract.
-- [Agent skills reference](https://token-api.thegraph.com/SKILLS.md): Capability summary, workflows, constraints, and endpoint overview for AI agents.
-- [Token API quick start](https://thegraph.com/docs/en/token-api/quick-start/): Human-readable setup and first requests.
-- [Token API FAQ](https://thegraph.com/docs/en/token-api/faq/): Plan, billing, authentication, and usage notes.
+- [OpenAPI specification](https://token-api.thegraph.com/openapi): Authoritative machine-readable contract — use for schemas and parameters.
+- [Agent skills reference](https://token-api.thegraph.com/SKILLS.md): Endpoint catalog, conventions, and worked examples for agents.
+- [Quick start](https://thegraph.com/docs/en/token-api/quick-start/): Setup and first requests.
+- [FAQ](https://thegraph.com/docs/en/token-api/faq/): Plans, billing, authentication.
 
 ## Free endpoints
 
-- [Health check](https://token-api.thegraph.com/v1/health): Database connectivity status.
-- [Version](https://token-api.thegraph.com/v1/version): API build version, date, and commit.
-- [Supported networks](https://token-api.thegraph.com/v1/networks): Indexed chains and per-category indexing freshness.
+No authentication required, no usage charge.
+
+- [llms.txt](https://token-api.thegraph.com/llms.txt): This file.
+- [SKILLS.md](https://token-api.thegraph.com/SKILLS.md): Agent skills reference (`/skills.md` lowercase alias also works).
+- [Health](https://token-api.thegraph.com/v1/health): Database connectivity status.
+- [Version](https://token-api.thegraph.com/v1/version): Build version, date, commit.
+- [Networks](https://token-api.thegraph.com/v1/networks): Indexed chains and per-category indexing freshness.
 - [EVM DEXes](https://token-api.thegraph.com/v1/evm/dexes): Supported EVM DEX protocols by network.
 - [SVM DEXes](https://token-api.thegraph.com/v1/svm/dexes): Supported SVM DEX protocols by network.
 - [TVM DEXes](https://token-api.thegraph.com/v1/tvm/dexes): Supported TVM DEX protocols by network.
 - [Polymarket markets](https://token-api.thegraph.com/v1/polymarket/markets): Public Polymarket market discovery.
-
-## API families
-
-- [EVM endpoints](https://token-api.thegraph.com/openapi): ERC-20 tokens, native tokens, balances, transfers, holders, swaps, DEXes, pools, OHLC, and NFTs.
-- [SVM endpoints](https://token-api.thegraph.com/openapi): SPL tokens, native SOL, balances, transfers, holders, swaps, DEXes, pools, OHLC, and account owner lookup.
-- [TVM endpoints](https://token-api.thegraph.com/openapi): TRC-20 tokens, native TRX, transfers, swaps, DEXes, pools, and OHLC.
-- [Polymarket endpoints](https://token-api.thegraph.com/openapi): Markets, OHLC, open interest, activity, platform stats, users, and positions.

--- a/public/skills.md
+++ b/public/skills.md
@@ -1,11 +1,11 @@
 ---
 name: Token API
-description: Real-time token data across EVM (Ethereum, Base, BSC, Polygon, Arbitrum, ...), SVM (Solana), and TVM (TRON). Query balances, transfers, holders, DEX swaps, liquidity pools with OHLC, NFTs, and Polymarket markets.
+description: Real-time token, balance, transfer, holder, DEX, NFT, and Polymarket data across EVM, SVM, and TVM networks.
 ---
 
 # Token API
 
-> Power your apps & AI agents with real-time token data across EVM, SVM, and TVM blockchains. This file is a quick reference for agents; the full machine-readable contract is at `GET /openapi`.
+> Quick reference for AI agents using Token API. The authoritative machine-readable contract is `GET /openapi`.
 
 - **Base URL:** `https://token-api.thegraph.com`
 - **OpenAPI spec:** `GET /openapi` — authoritative reference, use for schema details
@@ -36,6 +36,34 @@ An `X-Api-Key: <your-api-key>` header is accepted as an alternative.
 - `GET /v1/tvm/dexes`
 - `GET /v1/polymarket/markets`
 
+## Errors
+
+Error responses share a common envelope:
+
+```json
+{
+  "status": 400,
+  "code": "bad_query_input",
+  "message": "Invalid network ID"
+}
+```
+
+Common codes: `bad_query_input` (400), `authentication_failed` (401), `route_not_found` (404), `bad_database_response` (500), `database_connection_failed` (503).
+
+## Capabilities
+
+Map a goal to the relevant endpoint family:
+
+- **Look up a wallet's balances and transfer history** — `/v1/{evm,svm,tvm}/balances`, `/v1/{evm,svm,tvm}/transfers`
+- **Track balance changes over time** — `/v1/evm/balances/historical`, `/v1/evm/balances/historical/native`
+- **Resolve token metadata** — `/v1/{evm,svm,tvm}/tokens`, `/v1/{evm,svm,tvm}/tokens/native`
+- **Find holders of a token** — `/v1/{evm,svm}/holders`, `/v1/evm/holders/native`, `/v1/evm/nft/holders`
+- **Trace DEX swaps and liquidity pools** — `/v1/{evm,svm,tvm}/swaps`, `/v1/{evm,svm,tvm}/pools`, `/v1/{evm,svm,tvm}/dexes`
+- **Get OHLC time-series** — `/v1/{evm,svm,tvm}/pools/ohlc`, `/v1/polymarket/markets/ohlc`
+- **List a wallet's NFT holdings and activity** — `/v1/evm/nft/ownerships`, `/v1/evm/nft/transfers`, `/v1/evm/nft/sales`, `/v1/evm/nft/items`, `/v1/evm/nft/collections`
+- **Discover Polymarket markets, OI, and per-user PNL** — `/v1/polymarket/markets`, `/v1/polymarket/markets/oi`, `/v1/polymarket/markets/activity`, `/v1/polymarket/users`, `/v1/polymarket/users/positions`
+- **Discover supported chains and protocols** (free) — `/v1/networks`, `/v1/{evm,svm,tvm}/dexes`
+
 ## Common patterns
 
 These conventions apply across the data endpoints unless overridden.
@@ -60,7 +88,7 @@ Event and historical endpoints accept either block or time windows:
 
 ### Intervals
 
-Historical and OHLC endpoints use an `interval` enum: `1h`, `4h`, `1d` (default), `1w`.
+Historical and OHLC endpoints use an `interval` enum: `1h`, `4h`, `1d` (default), `1w`. A few endpoints accept additional values (e.g. `/v1/polymarket/users` supports `30d`); the OpenAPI per-endpoint schema is authoritative.
 
 ### Network discovery
 
@@ -269,19 +297,3 @@ Prediction-market data for the Polygon-based Polymarket CTF exchange. Outcome to
 | `GET /v1/polymarket/platform` | — | `interval`, `start_time`, `end_time` |
 
 Aggregate volume, open interest, and fees across all Polymarket markets.
-
----
-
-## Errors
-
-Error responses share a common envelope:
-
-```json
-{
-  "status": 400,
-  "code": "bad_query_input",
-  "message": "Invalid network ID"
-}
-```
-
-Common codes: `bad_query_input` (400), `authentication_failed` (401), `route_not_found` (404), `bad_database_response` (500), `database_connection_failed` (503).


### PR DESCRIPTION
## Summary

Review pass on the two AI-facing documentation files exposed by the Token API (`/llms.txt` and `/SKILLS.md`).

### `public/llms.txt`
- Drops the "API families" section that linked all four bullets to the same `/openapi` URL.
- Mirrors the free-endpoint list in `skills.md`, including the `/llms.txt` and `/SKILLS.md` doc paths so agents can discover the public surface from this one file.
- Tightens the summary blockquote and trims the meta-paragraph about how to use the file.

### `public/skills.md`
- Frontmatter description tightened to a single declarative sentence.
- New `## Capabilities` section near the top, mapping common goals to endpoint families.
- `## Errors` moved up next to its sibling cross-cutting section so both are visible before the endpoint tables.
- `### Intervals` notes that some endpoints accept extra enum values (e.g. `/v1/polymarket/users` supports `30d`) and points to the OpenAPI per-endpoint schema as authoritative.
- All endpoint tables and the worked example are unchanged.

### `index.ts`
- Syncs the OpenAPI `example` strings for the `/llms.txt` and `/SKILLS.md` routes so they match the new file content. No functional changes; route wiring and content types are unchanged.

Closes #498

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)