### PR TITLE
Expose OpenAPI route in documentation spec

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -90,6 +90,34 @@ const llmsTextOpenapi = describeRoute({
     },
 });
 
+const openapiSpecOpenapi = describeRoute({
+    operationId: 'getOpenapiSpec',
+    summary: 'OpenAPI Specification',
+    description: 'Returns the public OpenAPI specification for Token API.',
+    tags: ['Documentation'],
+    security: [],
+    responses: {
+        200: {
+            description: 'Successful Response',
+            content: {
+                'application/json': {
+                    schema: {
+                        type: 'object',
+                        example: {
+                            openapi: '3.1.0',
+                            info: {},
+                            servers: [],
+                            paths: {},
+                            components: {},
+                            tags: [],
+                        },
+                    },
+                },
+            },
+        },
+    },
+});
+
 app.get(
     '/SKILLS.md',
     skillsMarkdownOpenapi,
@@ -106,6 +134,7 @@ app.get(
 );
 app.get(
     '/openapi',
+    openapiSpecOpenapi,
     openAPIRouteHandler(app, {
         documentation: {
             info: {


### PR DESCRIPTION
## Summary
- add OpenAPI documentation metadata for GET /openapi
- document the response as application/json under the Documentation tag

## Tests
- bun lint
- bun -e "const app = (await import('./index.ts')).default; const res = await app.fetch(new Request('http://localhost/openapi')); const spec = await res.json(); console.log(JSON.stringify({ status: res.status, content: Object.keys(spec.paths['/openapi'].get.responses['200'].content), operationId: spec.paths['/openapi'].get.operationId }));"