### PR TITLE
fix(ohlcv): FINAL the metadata.metadata joins on /pools/ohlc

### DIFF
--- a/src/routes/ohlcv/evm.sql
+++ b/src/routes/ohlcv/evm.sql
@@ -31,8 +31,8 @@ WITH ohlc AS (
         /* extra fields */
         p.token0 IN {stablecoin_contracts: Array(String)} AS is_stablecoin
     FROM {db_dex:Identifier}.ohlc_prices p
-    LEFT JOIN metadata.metadata m0 ON {network: String} = m0.network AND p.token0 = m0.contract
-    LEFT JOIN metadata.metadata m1 ON {network: String} = m1.network AND p.token1 = m1.contract
+    LEFT JOIN metadata.metadata AS m0 FINAL ON {network: String} = m0.network AND p.token0 = m0.contract
+    LEFT JOIN metadata.metadata AS m1 FINAL ON {network: String} = m1.network AND p.token1 = m1.contract
     WHERE
             p.interval_min = {interval: UInt64}
         AND p.pool = {pool: String}


### PR DESCRIPTION
## Summary

Add `FINAL` to the two `LEFT JOIN metadata.metadata` joins in `src/routes/ohlcv/evm.sql` so the OHLCV endpoint stops cross-multiplying candle rows by the number of un-merged metadata versions per token.

Closes #504.

## Why

`metadata.metadata` is a `ReplicatedReplacingMergeTree` (`ORDER BY (network, contract)`). Without `FINAL`, a `LEFT JOIN` on `(network, contract)` returns one row per un-merged version. For e.g. mainnet USDC there are currently 2 versions on disk and WETH has 1; the cross product on a USDC/WETH pool's candles yields **2× duplication** per row.

Every other route that joins this table uses `FINAL` to deduplicate:

| route | line |
| --- | --- |
| `tokens/evm.sql` | 54 |
| `balances/evm.sql` | 40 |
| `holders/evm.sql` | 32 |
| `holders/evm_native.sql` | 55 |
| `balances/evm_historical.sql` | 21 |
| `balances/evm_historical_native.sql` | 20 |
| `balances/evm_native.sql` | 22 |
| `tokens/tvm.sql` | 31 |
| `tokens/tvm_native.sql` | 21 |
| `tokens/evm_native.sql` | 27 |
| `transfers/evm_native.sql` | 127 |

The OHLCV SQL was the only outlier.

`routes/ohlcv/tvm.ts` imports the same `evm.sql`, so TVM gets the fix for free.

## Performance

Warm-cache benchmark on the customer's reproducer pool (USDC/WETH mainnet, `0x88e6a0c2dd…f5640`), `interval=1m`, 24 h window, `limit=1000`:

| variant | rows read | bytes read | elapsed |
| --- | --- | --- | --- |
| current (no FINAL) | 3.17 M | 144 MB | ~90 ms |
| **with FINAL (this PR)** | 4.42 M | 260 MB | ~130 ms |
| `ANY LEFT JOIN` (alt) | 76 M | 3.4 GB | ~350-560 ms ⚠️ |

The `FINAL` variant adds ~1.4× rows scanned and ~1.5× wall time, sub-second on a popular pool, well under the existing `s-maxage=600` cache TTL on `/v1/*/pools/ohlc`. `ANY LEFT JOIN` is much worse — confirmed not viable.

## Correctness

Verified on the customer's pool, `interval=1m`, 24 h window:

| query | rows | unique\_timestamps | ratio |
| --- | --- | --- | --- |
| no FINAL (current) | 5044 | 1261 | **4.0×** |
| **with FINAL (this PR)** | 2522 | 1261 | **2.0×** |

The remaining 2× is **not** a Token API bug — it's an upstream substreams-evm issue where the same Uniswap V3 swap is emitted twice (once as `uniswap_v3`, once as `kyber_elastic`) because the two protocols share the `Swap(address,address,int256,int256,uint160,uint128,int24)` event ABI signature on Pool contracts (topic0 `0xc42079f9…cca67`). Tracked in [pinax-network/substreams-evm#248](https://github.com/pinax-network/substreams-evm/issues/248). Once that lands and a new `evm-dex` is rolled out, the customer-facing duplication on `/v1/evm/pools/ohlc` drops from 4× → 2× (this PR) → 1×.

## Test plan

- [x] SQL diff is two-line, mirrors `AS … FINAL` form already used in 11 other routes.
- [x] Manual ClickHouse benchmark on prod data — see correctness + performance tables above.
- [ ] Existing `routes.sql.spec.ts` `GET /v1/evm/pools/ohlc` smoke test continues to pass when run against a DB.

## Out of scope

Eliminating the remaining 2× (`uniswap_v3` ↔ `kyber_elastic` dual-protocol pollution) — needs a substreams-evm fix per [pinax-network/substreams-evm#248](https://github.com/pinax-network/substreams-evm/issues/248).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)