### PR TITLE
docs(openapi): include Hyperliquid in /llms.txt and /skills.md examples

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -50,7 +50,7 @@ const skillsMarkdownOpenapi = describeRoute({
                         type: 'string',
                         example: `---
 name: Token API
-description: Real-time token, balance, transfer, holder, DEX, NFT, and Polymarket data across EVM, SVM, and TVM networks.
+description: Real-time token, balance, transfer, holder, DEX, NFT, Polymarket, and Hyperliquid data across EVM, SVM, and TVM networks.
 ---
 
 # Token API
@@ -80,7 +80,7 @@ const llmsTextOpenapi = describeRoute({
                         type: 'string',
                         example: `# Token API
 
-> Real-time token, balance, transfer, holder, DEX, NFT, and Polymarket data across EVM, SVM, and TVM networks.
+> Real-time token, balance, transfer, holder, DEX, NFT, Polymarket, and Hyperliquid data across EVM, SVM, and TVM networks.
 
 ...`,
                     },


### PR DESCRIPTION
## Summary

The example strings rendered inside the OpenAPI response schemas for `/llms.txt` and `/SKILLS.md` still listed *"EVM, SVM, and TVM"* without Hyperliquid. The served content was updated in #506; this aligns the OpenAPI examples so the spec UI matches what consumers actually fetch.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)