### PR TITLE
fix(hyperliquid): dedupe liquidations rows from doubled direction tagging

### DIFF
--- a/src/routes/hyperliquid/markets_liquidations.sql
+++ b/src/routes/hyperliquid/markets_liquidations.sql
@@ -18,7 +18,7 @@ SELECT
     sum(f.fee)                                                  AS total_fees
 FROM {db_hypercore:Identifier}.fills_liquidation AS f
 LEFT JOIN {db_hypercore:Identifier}.state_spot_pair_names AS n FINAL ON n.coin = f.coin
-WHERE (f.direction LIKE 'LIQUIDATED_%' OR f.direction = 'AUTO_DELEVERAGING')
+WHERE f.direction LIKE 'LIQUIDATED_%'
   AND (isNull({coin:Nullable(String)})            OR f.coin = {coin:Nullable(String)})
   AND (isNull({dex:Nullable(String)})             OR dex_from_coin(f.coin) = {dex:Nullable(String)})
   AND (isNull({liquidated_user:Nullable(String)}) OR f.liquidated_user = {liquidated_user:Nullable(String)})


### PR DESCRIPTION
## Summary

`/v1/hyperliquid/markets/liquidations` was returning every event twice — once tagged `LIQUIDATED_*` and once tagged `AUTO_DELEVERAGING`, with identical `event_hash`, `liquidated_user`, `size`, `price`, and `notional`. The duplication was introduced by [#491](https://github.com/pinax-network/token-api/pull/491) and reinforced by [4490eb0](https://github.com/pinax-network/token-api/commit/4490eb0), which broadened the WHERE clause to include `AUTO_DELEVERAGING` on the assumption that those rows represented independent forced-close events. They don't — each fill is emitted twice into the source table with both direction tags.

Filter back to `LIQUIDATED_*` only. The `liquidation_kind` SELECT branch handling `'AUTO_DELEVERAGING'` is left in place defensively.

## Scope

Only `/v1/hyperliquid/markets/liquidations` is fixable in token-api SQL. Other endpoints reading downstream MVs from the same table (`/markets/liquidations/ohlc`, `/platform` liquidation slice) inherit related upstream issues that need substreams-side fixes — tracked separately.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)