### PR TITLE
fix(hyperliquid): identify liquidations by liquidated_user, not direction

### DIFF
--- a/src/routes/hyperliquid/markets_liquidations.sql
+++ b/src/routes/hyperliquid/markets_liquidations.sql
@@ -18,7 +18,7 @@ SELECT
     sum(f.fee)                                                  AS total_fees
 FROM {db_hypercore:Identifier}.fills_liquidation AS f
 LEFT JOIN {db_hypercore:Identifier}.state_spot_pair_names AS n FINAL ON n.coin = f.coin
-WHERE f.direction LIKE 'LIQUIDATED_%'
+WHERE f.user = f.liquidated_user
   AND (isNull({coin:Nullable(String)})            OR f.coin = {coin:Nullable(String)})
   AND (isNull({dex:Nullable(String)})             OR dex_from_coin(f.coin) = {dex:Nullable(String)})
   AND (isNull({liquidated_user:Nullable(String)}) OR f.liquidated_user = {liquidated_user:Nullable(String)})


### PR DESCRIPTION
## Summary

Replace the `direction LIKE 'LIQUIDATED_%'` filter with `user = liquidated_user` on `/v1/hyperliquid/markets/liquidations`. The previous filter was catching ~0.03% of actual liquidation events.

## Why

Hyperliquid emits regular `Close Long` / `Close Short` direction tags on most liquidated-user fills, with the liquidation signal carried in a separate `liquidation` sub-object. Verified directly against HL's `userFills` endpoint:

```json
{
  "coin": "BTC",
  "dir": "Close Long",
  "hash": "0xda9ab320e54aa325dc14043ac...e635e73a44e7d10",
  "liquidation": {
    "liquidatedUser": "0x5bcb085d...",
    "method": "market"
  }
}
```

Same hash in our DB shows `direction: CLOSE_LONG`, `liquidation_method: market`, `liquidated_user: 0x5bcb085d...`. No translation drift in the pipeline — `direction` is faithfully what HL emits.

The substreams routes a fill into `fills_liquidation` whenever `fill.liquidation.is_some()` regardless of direction, so the table itself already contains only liquidation-related rows (both liquidated-user and counterparty fills). Filtering by `user = liquidated_user` keeps just the liquidated-user's side, dedupes against counterparties, and recovers ~99% of events.

The `LIQUIDATED_*` and `AUTO_DELEVERAGING` direction variants are real edge-case liquidation types (backstop interventions, ADL, borrow liquidations) and are kept faithfully in the enum — they remain visible through the same query because their fills also satisfy `user = liquidated_user`.

## Impact

- Recovers ~99% of liquidation events on the events feed
- Query latency increases from ~30ms to ~110ms (still well under SLA)
- No data reprocessing needed; the source table is correct

## Follow-up

The OHLC endpoint `/v1/hyperliquid/markets/liquidations/ohlc` reads from `state_ohlcv_liquidation`, whose source MV has the same broken filter. Fix lives in the substreams repo and will be addressed separately.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)