### PR TITLE
fix(hyperliquid): drop redundant unique_users from /markets/oi

### DIFF
--- a/src/routes/hyperliquid/markets_oi.sql
+++ b/src/routes/hyperliquid/markets_oi.sql
@@ -14,17 +14,8 @@ SELECT
     sum(oi.total_funding)                                         AS total_funding,
     sum(oi.positive_funding)                                      AS positive_funding,
     sum(oi.negative_funding)                                      AS negative_funding,
-    sum(oi.funding_events)                                        AS funding_events,
-    coalesce(any(u.uniq_user), 0)                                 AS unique_users
+    sum(oi.funding_events)                                        AS funding_events
 FROM {db_hypercore:Identifier}.state_open_interest AS oi
-LEFT JOIN (
-    SELECT interval_min, coin, timestamp, uniq_user
-    FROM {db_hypercore:Identifier}.state_open_interest_uniq_user FINAL
-    WHERE coin = {coin:String}
-      AND interval_min = {interval:UInt32}
-      AND (isNull({start_time:Nullable(UInt64)}) OR timestamp >= toDateTime({start_time:Nullable(UInt64)}))
-      AND (isNull({end_time:Nullable(UInt64)})   OR timestamp <  toDateTime({end_time:Nullable(UInt64)}))
-) AS u USING (interval_min, coin, timestamp)
 LEFT JOIN {db_hypercore:Identifier}.state_spot_pair_names AS n FINAL ON n.coin = oi.coin
 WHERE oi.coin = {coin:String}
   AND oi.interval_min = {interval:UInt32}

--- a/src/routes/hyperliquid/markets_oi.ts
+++ b/src/routes/hyperliquid/markets_oi.ts
@@ -44,7 +44,6 @@ const responseSchema = apiUsageResponseSchema.extend({
             positive_funding: z.number(),
             negative_funding: z.number(),
             funding_events: z.number().int(),
-            unique_users: z.number().int(),
         })
     ),
 });
@@ -83,7 +82,6 @@ const openapi = describeRoute(
                                             positive_funding: 16482.55,
                                             negative_funding: -16482.55,
                                             funding_events: 30415,
-                                            unique_users: 30415,
                                         },
                                     ],
                                 },


### PR DESCRIPTION
## Summary

Drop the `unique_users` field from the `/v1/hyperliquid/markets/oi` response. It was exactly equal to `funding_events` for any complete hour and showed `0` for the in-progress hour because the side-table backing it lags the live MV — looked like a regression. Clients should use `funding_events` instead; the values are identical by construction.

## Why

Hyperliquid charges funding once per hour to every user with an open position, so the count of funding events ≡ the count of distinct users with positions for any complete bucket. Verified across BTC / ETH / SOL / HYPE: `unique_users == funding_events` in every complete hour.

The side-table (`state_open_interest_uniq_user`, `REFRESH EVERY 1 HOUR APPEND`, `TTL 3h` on the target) lags the in-progress hour; the regular MV that powers `funding_events` doesn't.

This rolls into v3.17.1 alongside [#509](https://github.com/pinax-network/token-api/pull/509).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)