### PR TITLE
feat(svm): add spl_token_swap and okx_dex protocols (svm-dex v0.4.4)

### DIFF
--- a/dbs-config.yaml.example
+++ b/dbs-config.yaml.example
@@ -33,7 +33,7 @@ networks:
     balances: solana:svm-balances@v0.3.2
     accounts: solana:svm-accounts@v0.3.0
     metadata: solana:svm-metadata@v0.3.1
-    dexes: solana:svm-dex@v0.4.0
+    dexes: solana:svm-dex@v0.4.4
 
   # TVM Networks
   tron:

--- a/src/types/zod.spec.ts
+++ b/src/types/zod.spec.ts
@@ -315,6 +315,8 @@ describe('Protocol Schemas', () => {
                 'byreal',
                 'moonshot',
                 'pancakeswap',
+                'spl_token_swap',
+                'okx_dex',
             ] as const;
 
             for (const protocol of protocols) {

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -169,6 +169,8 @@ const svmProtocolsWithoutAggregators = [
     'dumpfun',
     'moonshot',
     'pancakeswap',
+    'spl_token_swap',
+    'okx_dex',
 ] as const;
 
 const svmProtocols = ['jupiter_v4', 'jupiter_v6', ...svmProtocolsWithoutAggregators] as const;


### PR DESCRIPTION
## Summary
[`pinax-network/substreams-svm` svm-dex v0.4.4](https://github.com/pinax-network/substreams-svm/releases/tag/svm-dex-v0.4.4) ships two new normalized DEX protocols. This adds them to the `svmProtocolsWithoutAggregators` enum so `/v1/svm/swaps?protocol=…` and `/v1/svm/pools?protocol=…` accept the new values.

| Protocol | Enum | Notes |
|---|---|---|
| `spl_token_swap` | 19 | SPL Token Swap-compatible fallback decoding — covers programs that reuse the SPL Token Swap layout without dedicated program IDs (e.g. Orca Token Swap V2) |
| `okx_dex` | 20 | OKX DEX V2 SwapV3 routes — DEX aggregator similar to Jupiter. Single-hop routes populate `amm_pool`; multi-hop routes emit an aggregate row with empty pool |

## Validation
Local server pointing at `solana:svm-dex@v0.4.4` on cluster B:

- `GET /v1/svm/swaps?network=solana&protocol=spl_token_swap&limit=1&start_time=…&end_time=…` returns Orca-via-SPL trades, e.g. \`Swap 49.87 USDC for 0 ORCA on Spl Token Swap\`
- `GET /v1/svm/swaps?network=solana&protocol=okx_dex&limit=1&…` returns OKX aggregator routes, e.g. \`Swap 0.37 JitoSOL for 0.47 SOL on Okx Dex\`

Both protocols pass Zod validation; the existing summary formatter (`splitByChar('_', toString(protocol))`) renders the new names cleanly.

## Files
- `src/types/zod.ts` — add `spl_token_swap`, `okx_dex` to `svmProtocolsWithoutAggregators`
- `src/types/zod.spec.ts` — extend the protocol enum test fixture
- `dbs-config.yaml.example` — bump example to `solana:svm-dex@v0.4.4` (real runtime config managed separately; staging already bumped)

## Notes
The `/v1/svm/dexes` endpoint enumerates protocols from `state_pools_aggregating_by_pool`, so it picks up the new programs automatically once the live DB has data — no code change needed there.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)