### PR TITLE
fix(svm): order /pools/ohlc by datetime DESC and JOIN decimals_state

### DIFF
--- a/src/routes/ohlcv/svm.sql
+++ b/src/routes/ohlcv/svm.sql
@@ -24,23 +24,26 @@ WITH ohlc AS
     AND (isNull({start_time:Nullable(UInt64)}) OR timestamp >= toDateTime({start_time:Nullable(UInt64)}))
     AND (isNull({end_time:Nullable(UInt64)}) OR timestamp <= toDateTime({end_time:Nullable(UInt64)}))
     GROUP BY token0, token1, amm, amm_pool, datetime
+    ORDER BY datetime DESC
     LIMIT {limit: UInt64}
     OFFSET {offset: UInt64}
+),
+decs AS
+(
+    SELECT mint, any(decimals) AS dec_value
+    FROM {db_accounts:Identifier}.decimals_state
+    WHERE mint IN (SELECT token0 FROM ohlc UNION ALL SELECT token1 FROM ohlc)
+      AND decimals != 0
+    GROUP BY mint
 )
 SELECT
-    datetime,
-    amm,
-    amm_pool,
-    token0,
-    coalesce(
-        (SELECT decimals FROM {db_accounts:Identifier}.decimals_state WHERE mint IN (SELECT token0 FROM ohlc) AND decimals != 0),
-        9
-    ) AS token0_decimals,
-    token1,
-    coalesce(
-        (SELECT decimals FROM {db_accounts:Identifier}.decimals_state WHERE mint IN (SELECT token1 FROM ohlc) AND decimals != 0),
-        9
-    ) AS token1_decimals,
+    o.datetime AS datetime,
+    o.amm AS amm,
+    o.amm_pool AS amm_pool,
+    o.token0 AS token0,
+    coalesce(d0.dec_value, 9) AS token0_decimals,
+    o.token1 AS token1,
+    coalesce(d1.dec_value, 9) AS token1_decimals,
     pow(10, -(token1_decimals - token0_decimals)) * if(is_stablecoin, 1/open_raw, open_raw) AS open,
     pow(10, -(token1_decimals - token0_decimals)) * if(is_stablecoin, 1/low_raw, high_raw) AS high,
     pow(10, -(token1_decimals - token0_decimals)) * if(is_stablecoin, 1/high_raw, low_raw) AS low,
@@ -49,4 +52,6 @@ SELECT
     uaw,
     transactions
 FROM ohlc AS o
+LEFT JOIN decs AS d0 ON d0.mint = o.token0
+LEFT JOIN decs AS d1 ON d1.mint = o.token1
 ORDER BY datetime DESC;


### PR DESCRIPTION
## Summary

Two bugs in `src/routes/ohlcv/svm.sql` that both surface from data-shape issues the substreams `svm-dex v0.5.0` release will resolve. The SQL itself has independent assumptions that don't hold and need fixing here regardless.

## Bugs fixed

### `LIMIT` inside the CTE had no `ORDER BY`

`?limit=N` returned N arbitrary rows from the pool's full OHLC history, then sorted them at the outer level. For pools with months of data, callers asking for the latest 5 / 10 / 50 typically saw old random rows instead of recent ones.

Fix: moved `ORDER BY datetime DESC` inside the CTE immediately before the `LIMIT`.

### Scalar `decimals_state` subqueries 500'd on multi-pair pools

```sql
coalesce(
    (SELECT decimals FROM decimals_state WHERE mint IN (SELECT token0 FROM ohlc) AND decimals != 0),
    9
) AS token0_decimals
```

This pattern returns `500 "Scalar subquery returned more than one row"` whenever the inner CTE holds more than one distinct `token0` (or `token1`) — which happens for any pool where the substreams writes multiple `(mint0, mint1)` pairs.

Fix: replaced with a `decs` CTE that pre-aggregates `decimals_state` to one `(mint, decimals)` row per relevant mint, plus two LEFT JOINs. The pre-aggregation matters: `decimals_state` holds tens of millions of rows on the production cluster, so a naïve `LEFT JOIN` against the full table regresses badly.

## Performance

Warm-cache median across 5 iterations against the production cluster:

| query | pre-fix | post-fix | delta |
|---|---|---|---|
| clean pool, 1m, limit=100 | 161 ms | 224 ms | +39% |
| pumpfun_amm pool, 1d, limit=10 | 280 ms | 326 ms | +16% |
| multi-pair pool, 1m, limit=200 | 500 error | 506 ms | now succeeds |

The +16–39% on warm queries is the cost of hitting `decimals_state` via JOIN where the pre-fix scalar subquery did a single point lookup. The trade-off is correct data: pre-fix returned objectively wrong rows for sorted queries and 500'd entirely on multi-pair pools.

## Test plan covered locally

- [x] Clean pool returns rows sorted by `datetime DESC`, latest first (was: random subset spanning months)
- [x] Multi-pair pool no longer 500s at `limit ≥ 100`
- [x] Open / high / low / close / volume / transactions values match the pre-fix values for time windows where the pre-fix actually returned data, within the known limitations from upstream substreams data shape
- [x] Built and ran the local server against the production read replica

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)