### PR TITLE
fix(svm): join /pools on (amm_pool, protocol) to prevent cross-protocol mint bleed

### DIFF
--- a/src/routes/pools/svm.sql
+++ b/src/routes/pools/svm.sql
@@ -55,5 +55,5 @@ SELECT
     /* Network */
     {network: String} AS network
 FROM pools AS p
-JOIN pools_with_tokens AS pt ON p.amm_pool = pt.amm_pool
+JOIN pools_with_tokens AS pt ON p.amm_pool = pt.amm_pool AND p.protocol = pt.protocol
 ORDER BY p.transactions DESC


### PR DESCRIPTION
## Summary

The JOIN in \`/v1/svm/pools\` between \`pools\` and \`pools_with_tokens\` matched only on \`amm_pool\`. When the same pool appears under multiple protocols in \`state_pools_aggregating_by_mint\` (common: a native AMM plus aggregators routing through it), the cross-product yielded N×M rows where each pool's row carried another protocol's view of the mints.

## Example

For a Raydium CLMM USDC/USDT pool also routed by Jupiter, before the fix \`/v1/svm/pools?amm_pool=<pool>\` returned both the canonical \`(USDC, USDT)\` row **and** rows with mints picked alphabetically from Jupiter's per-route mint set — e.g. \`(2VhjJ9…, 3NZ9JMVB…)\` — incorrectly tagged as \`raydium_clmm\`, \`jupiter_v6\`, etc.

After the fix, each protocol's row shows only the mints recorded under its own \`(amm_pool, protocol)\` aggregation.

## Validation

Tested locally against \`solana:svm-dex@v0.5.0\` for several pools:

| Pool | Before | After |
|---|---|---|
| \`BZtgQEyS…\` (Raydium CLMM USDC/USDT) | 8 unique rows (4 protocols × 2 mint pairs) | 4 rows (1 per protocol, correct canonical pair) |
| \`38deSidd…\` (Orca SOL/pump token) | mixed protocols, mixed mints | 2 rows (orca_whirlpool + jupiter_v6), both \`(EfPoo…pump, SOL)\` |
| \`4qryQZJ1UK8…\` (PumpSwap HANTA/SOL) | mixed | 2 rows (pumpfun_amm + jupiter_v6), both \`(2tXpgu…, SOL)\` |
| \`J6hybSEs…\` (PumpSwap UAP/SOL) | mixed | 2 rows (pumpfun_amm + jupiter_v6), both \`(3jG3vjwb…, SOL)\` |

No performance regression — query stats unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)