### PR TITLE
feat(polymarket): support batched filter parameters on 3 endpoints

### DIFF
--- a/src/routes/polymarket/markets.sql
+++ b/src/routes/polymarket/markets.sql
@@ -1,11 +1,8 @@
-WITH resolved_token AS (
-    SELECT condition_id
+WITH token_condition_ids AS (
+    SELECT DISTINCT condition_id
     FROM {db_scraper:Identifier}.polymarket_markets_by_asset_id
-    WHERE isNull({condition_id:Nullable(String)})
-      AND isNull({market_slug:Nullable(String)})
-      AND isNotNull({token_id:Nullable(String)})
-      AND asset_id = toUInt256({token_id:Nullable(String)})
-    LIMIT 1
+    WHERE notEmpty({token_id:Array(String)})
+      AND asset_id IN (SELECT toUInt256(arrayJoin({token_id:Array(String)})))
 )
 SELECT
     m.condition_id,
@@ -26,19 +23,11 @@ SELECT
 FROM {db_scraper:Identifier}.polymarket_markets m FINAL
 LEFT JOIN {db_scraper:Identifier}.polymarket_events e FINAL
     ON e.condition_id = m.condition_id
-WHERE
-    CASE
-        WHEN isNotNull({condition_id:Nullable(String)})
-            THEN m.condition_id = {condition_id:Nullable(String)}
-        WHEN isNotNull({market_slug:Nullable(String)})
-            THEN m.market_slug = {market_slug:Nullable(String)}
-        WHEN isNotNull({token_id:Nullable(String)})
-            THEN m.condition_id = (SELECT condition_id FROM resolved_token)
-        WHEN isNotNull({event_slug:Nullable(String)})
-            THEN e.slug = {event_slug:Nullable(String)}
-        ELSE 1 = 1
-    END
-  AND (isNull({closed:Nullable(UInt8)}) OR m.closed = {closed:Nullable(UInt8)})
+WHERE (empty({condition_id:Array(String)}) OR m.condition_id IN {condition_id:Array(String)})
+  AND (empty({market_slug:Array(String)})  OR m.market_slug  IN {market_slug:Array(String)})
+  AND (empty({token_id:Array(String)})     OR m.condition_id IN (SELECT condition_id FROM token_condition_ids))
+  AND (empty({event_slug:Array(String)})   OR e.slug         IN {event_slug:Array(String)})
+  AND (isNull({closed:Nullable(UInt8)})    OR m.closed = {closed:Nullable(UInt8)})
 ORDER BY m.volume_num DESC
 LIMIT {limit:UInt64}
 OFFSET {offset:UInt64}

--- a/src/routes/polymarket/markets.ts
+++ b/src/routes/polymarket/markets.ts
@@ -18,10 +18,10 @@ import { validatorHook, withErrorResponses } from '../../utils.js';
 import baseQuery from './markets.sql' with { type: 'text' };
 
 const querySchema = createQuerySchema({
-    condition_id: { schema: polymarketConditionIdSchema, optional: true },
-    market_slug: { schema: polymarketSlugSchema, optional: true },
-    token_id: { schema: polymarketTokenIdSchema, optional: true },
-    event_slug: { schema: polymarketSlugSchema, optional: true },
+    condition_id: { schema: polymarketConditionIdSchema, batched: true, optional: true },
+    market_slug: { schema: polymarketSlugSchema, batched: true, optional: true },
+    token_id: { schema: polymarketTokenIdSchema, batched: true, optional: true },
+    event_slug: { schema: polymarketSlugSchema, batched: true, optional: true },
     closed: { schema: booleanFromString, optional: true },
     sort_by: { schema: polymarketMarketSortBySchema, prefault: 'volume' },
 });

--- a/src/routes/polymarket/positions.sql
+++ b/src/routes/polymarket/positions.sql
@@ -22,8 +22,8 @@ LEFT JOIN {db_scraper:Identifier}.polymarket_markets_by_asset_id a
 LEFT JOIN {db_polymarket:Identifier}.state_latest_price lp FINAL
     ON lp.asset_id = p.token_id
 WHERE p.interval_min = 0
-  AND p.user = {user:String}
-  AND (isNull({token_id:Nullable(String)}) OR p.token_id = toUInt256({token_id:Nullable(String)}))
-  AND (isNull({condition_id:Nullable(String)}) OR a.condition_id = {condition_id:Nullable(String)})
-  AND (isNull({market_slug:Nullable(String)}) OR a.market_slug = {market_slug:Nullable(String)})
+  AND p.user IN {user:Array(String)}
+  AND (empty({token_id:Array(String)})     OR p.token_id IN (SELECT toUInt256(arrayJoin({token_id:Array(String)}))))
+  AND (empty({condition_id:Array(String)}) OR a.condition_id IN {condition_id:Array(String)})
+  AND (empty({market_slug:Array(String)})  OR a.market_slug  IN {market_slug:Array(String)})
 GROUP BY p.user, p.token_id, a.condition_id, a.market_slug, a.outcome_label, a.closed, lp.close

--- a/src/routes/polymarket/positions.ts
+++ b/src/routes/polymarket/positions.ts
@@ -19,10 +19,10 @@ import { validatorHook, withErrorResponses } from '../../utils.js';
 import baseQuery from './positions.sql' with { type: 'text' };
 
 const querySchema = createQuerySchema({
-    user: { schema: evmAddress },
-    token_id: { schema: polymarketTokenIdSchema, optional: true },
-    condition_id: { schema: polymarketConditionIdSchema, optional: true },
-    market_slug: { schema: polymarketSlugSchema, optional: true },
+    user: { schema: evmAddress, batched: true },
+    token_id: { schema: polymarketTokenIdSchema, batched: true, optional: true },
+    condition_id: { schema: polymarketConditionIdSchema, batched: true, optional: true },
+    market_slug: { schema: polymarketSlugSchema, batched: true, optional: true },
     closed: { schema: booleanFromString, optional: true },
     sort_by: { schema: polymarketPositionSortBySchema, prefault: 'position_value' },
 });

--- a/src/routes/polymarket/users.sql
+++ b/src/routes/polymarket/users.sql
@@ -13,4 +13,4 @@ SELECT
     last_trade
 FROM {db_polymarket:Identifier}.state_user FINAL
 WHERE interval_min = {interval_min:UInt32}
-  AND (isNull({user:Nullable(String)}) OR user = {user:Nullable(String)})
+  AND (empty({user:Array(String)}) OR user IN {user:Array(String)})

--- a/src/routes/polymarket/users.ts
+++ b/src/routes/polymarket/users.ts
@@ -16,7 +16,7 @@ import { validatorHook, withErrorResponses } from '../../utils.js';
 import baseQuery from './users.sql' with { type: 'text' };
 
 const querySchema = createQuerySchema({
-    user: { schema: evmAddress, optional: true },
+    user: { schema: evmAddress, batched: true, optional: true },
     interval: { schema: userLookbackIntervalSchema, optional: true },
     sort_by: { schema: polymarketUserSortBySchema, prefault: 'total_volume' },
 });


### PR DESCRIPTION
## Summary

- Flip filter parameters to **batched** on `/markets`, `/users`, `/users/positions` — `?condition_id=A,B`, repeated `?condition_id=A&condition_id=B`, and single `?condition_id=A` all parse, matching the convention on `/v1/{evm,svm,tvm}/*` and the new Hyperliquid batched routes (#532).
- Refactor `/markets` SQL from CASE-dispatch (first non-null filter wins) to **additive AND filters**, which both enables batching and aligns the endpoint with the rest of the codebase.
- Remaining Polymarket endpoints intentionally stay scalar (see *Deferred* below).

## Endpoints / params

| Endpoint | Batched params |
| --- | --- |
| `/markets` | `condition_id`, `market_slug`, `token_id`, `event_slug` |
| `/users` | `user` |
| `/users/positions` | `user`, `token_id`, `condition_id`, `market_slug` |

### Deferred

- `/markets/activity` — UNION ALL fan-out across 5 ledger tables; needs perf review.
- `/markets/oi` — keeps its "exactly one of condition_id or market_slug" contract; multi-value support would change response semantics.
- `/markets/ohlc` and `/markets/positions` — per-token time series / leaderboard. Mirrors scalar-only OHLC contracts elsewhere.

## Behavior change on `/markets`

Previous SQL used a `CASE WHEN isNotNull(...)` dispatch where the first non-null filter wins and the rest are silently ignored. After this PR, `/markets` composes filters additively (AND): every passed filter must match. Callers that relied on the implicit drop-the-others behavior — e.g. `?condition_id=A&market_slug=B` — will now see filters interact, with mismatched combinations correctly returning an empty result. Single-filter calls (the documented usage) are unchanged.

## Test plan

- [x] `bun run tsc --noEmit` clean
- [x] Local sweep against dev cluster — 21 functional scenarios (single, CSV, array, mismatch, error) pass
- [x] **4 correctness checks pass**: each batched call's identifier set is a subset of the requested batch and a superset of the per-value single-call sets (pagination-aware semantics — see harness)
- [x] Performance against `main` baseline on the same cluster — single-value calls match within variance; batched calls scale 1.5–2.5× per added value
- [ ] Smoke-check staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)