### PR TITLE
fix(nft): return amount as string on /v1/evm/nft/transfers

### DIFF
--- a/src/routes/nft/transfers_evm.sql
+++ b/src/routes/nft/transfers_evm.sql
@@ -162,7 +162,7 @@ SELECT
     token_standard,
     from,
     to,
-    amount,
+    toString(amount) AS amount,
     {network:String} as network
 FROM limit_combined AS c
 LEFT JOIN erc721_metadata_by_contract AS m USING (contract)

--- a/src/routes/nft/transfers_evm.ts
+++ b/src/routes/nft/transfers_evm.ts
@@ -97,7 +97,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             token_standard: nftTokenStandardSchema,
             from: evmAddressSchema,
             to: evmAddressSchema,
-            amount: z.number(),
+            amount: z.string(),
             network: evmNetworkIdSchema,
         })
     ),
@@ -135,7 +135,7 @@ const openapi = describeRoute(
                                             token_standard: 'ERC721',
                                             from: '0x355062b5d0e324815290b96370e87607a71d613d',
                                             to: '0x7ccde43632b3287fda060719d802b2c4cb6f769b',
-                                            amount: 1,
+                                            amount: '1',
                                             network: 'mainnet',
                                         },
                                     ],


### PR DESCRIPTION
## Summary

- The underlying `erc1155_transfers.amount` column is `UInt256`. The endpoint previously declared and serialized `amount` as a JSON number, silently losing precision for any value above `Number.MAX_SAFE_INTEGER` (2^53).
- Casts `amount` to a string in SQL and updates the Zod response schema and example accordingly.
- ERC-721 amounts remain `"1"` — values below 2^53 round-trip safely either way, so this is a precision fix for the long tail rather than a behavioural change for typical NFTs.

Related to the audit in #524.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)