### PR TITLE
docs(schema): clarify value field is decimal-scaled, not USD

### DIFF
--- a/src/routes/balances/evm.ts
+++ b/src/routes/balances/evm.ts
@@ -42,7 +42,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             address: evmAddressSchema,
             contract: evmContractSchema,
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- contract --
             name: z.string().nullable(),

--- a/src/routes/balances/evm_native.ts
+++ b/src/routes/balances/evm_native.ts
@@ -34,7 +34,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             // -- balance --
             address: evmAddressSchema,
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- contract --
             name: z.string().nullable(),

--- a/src/routes/balances/svm.ts
+++ b/src/routes/balances/svm.ts
@@ -46,7 +46,7 @@ const responseSchema = apiUsageResponseSchema.extend({
 
             // -- amount --
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
             decimals: z.number().nullable(),
 
             // -- mint metadata --

--- a/src/routes/balances/svm_native.ts
+++ b/src/routes/balances/svm_native.ts
@@ -43,7 +43,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             mint: svmMintSchema,
 
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
             decimals: z.number().nullable(),
 
             name: z.string().nullable(),

--- a/src/routes/balances/tvm.ts
+++ b/src/routes/balances/tvm.ts
@@ -42,7 +42,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             address: evmAddressSchema,
             contract: evmContractSchema,
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- contract --
             name: z.string().nullable(),

--- a/src/routes/balances/tvm_native.ts
+++ b/src/routes/balances/tvm_native.ts
@@ -36,7 +36,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             // -- balance --
             address: evmAddressSchema,
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- contract --
             name: z.string().nullable(),

--- a/src/routes/holders/evm.ts
+++ b/src/routes/holders/evm.ts
@@ -35,7 +35,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             address: evmAddressSchema,
             contract: evmContractSchema,
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- contract --
             name: z.string().nullable(),

--- a/src/routes/holders/evm_native.ts
+++ b/src/routes/holders/evm_native.ts
@@ -30,7 +30,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             // -- contract --
             address: evmAddressSchema,
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- contract --
             name: z.string().nullable(),

--- a/src/routes/holders/svm.ts
+++ b/src/routes/holders/svm.ts
@@ -42,7 +42,7 @@ const responseSchema = apiUsageResponseSchema.extend({
 
             // -- amount --
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
             decimals: z.number(),
 
             // -- metadata --

--- a/src/routes/holders/svm_native.ts
+++ b/src/routes/holders/svm_native.ts
@@ -38,7 +38,7 @@ const responseSchema = apiUsageResponseSchema.extend({
 
             // -- amount --
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
             decimals: z.number(),
 
             // -- metadata --

--- a/src/routes/holders/tvm.ts
+++ b/src/routes/holders/tvm.ts
@@ -34,7 +34,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             address: evmAddressSchema,
             contract: evmContractSchema,
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- contract --
             name: z.string().nullable(),

--- a/src/routes/holders/tvm_native.ts
+++ b/src/routes/holders/tvm_native.ts
@@ -30,7 +30,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             // -- contract --
             address: evmAddressSchema,
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- contract --
             name: z.string().nullable(),

--- a/src/routes/transfers/evm.ts
+++ b/src/routes/transfers/evm.ts
@@ -63,7 +63,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             decimals: z.number().nullable(),
 
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- chain --
             network: evmNetworkIdSchema,

--- a/src/routes/transfers/evm_native.ts
+++ b/src/routes/transfers/evm_native.ts
@@ -59,7 +59,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             decimals: z.number().nullable(),
 
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- chain --
             network: evmNetworkIdSchema,

--- a/src/routes/transfers/svm.ts
+++ b/src/routes/transfers/svm.ts
@@ -111,7 +111,7 @@ const responseSchema = apiUsageResponseSchema.extend({
 
             // -- amount --
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
             decimals: z.number().nullable(),
 
             // -- token metadata --

--- a/src/routes/transfers/svm_native.ts
+++ b/src/routes/transfers/svm_native.ts
@@ -90,7 +90,7 @@ const responseSchema = apiUsageResponseSchema.extend({
 
             // -- amounts --
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
             decimals: z.number().nullable(),
 
             // -- metadata --

--- a/src/routes/transfers/tvm.ts
+++ b/src/routes/transfers/tvm.ts
@@ -78,7 +78,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             to: tvmAddressSchema,
 
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- contract --
             name: z.string().nullable(),

--- a/src/routes/transfers/tvm_native.ts
+++ b/src/routes/transfers/tvm_native.ts
@@ -68,7 +68,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             to: tvmAddressSchema,
 
             amount: z.string(),
-            value: z.number(),
+            value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- contract --
             name: z.string().nullable(),


### PR DESCRIPTION
## Summary

- The `value` field on balances, holders, and transfers endpoints (EVM/SVM/TVM, regular and native) is computed as `amount / 10^decimals` — the human-readable token amount, not a USD valuation. The label was previously undocumented, leading consumers to interpret a large balance as a dollar value (e.g. reading "value: 2.95e9" on a GRT holder as ~$2.95B).
- Adds an inline `.describe(...)` on each schema so the OpenAPI export and downstream SDK types make the semantics explicit.
- No behavioural change. Same numbers, just documented.
- Polymarket `markets/activity` intentionally excluded — its `value` is USDC and genuinely is a dollar amount given USDC's 6 decimals.

Closes #525.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)