### PR TITLE
fix(pools): exclude cow and dodo from /v1/evm/pools

### DIFF
--- a/src/routes/pools/evm.sql
+++ b/src/routes/pools/evm.sql
@@ -17,7 +17,12 @@ pools AS (
         sum(transactions) as transactions
     FROM {db_dex:Identifier}.state_pools_aggregating_by_pool
     WHERE
-        (empty({input_token:Array(String)}) OR pool IN input_pools)
+        /* cow and dodo are decoded from router/aggregator contracts, not liquidity pools —
+           their factory == pool address is a single settlement/routing contract handling
+           thousands of unrelated pairs. They belong in /v1/evm/swaps, not /v1/evm/pools.
+           Tracked at https://github.com/pinax-network/substreams-evm */
+        toString(protocol) NOT IN ('cow', 'dodo')
+    AND (empty({input_token:Array(String)}) OR pool IN input_pools)
     AND (empty({output_token:Array(String)}) OR pool IN output_pools)
     AND (empty({pool:Array(String)}) OR pool IN {pool:Array(String)})
     AND (empty({factory:Array(String)}) OR factory IN {factory:Array(String)})


### PR DESCRIPTION
## Summary

- `cow` and `dodo` are decoded from router/aggregator contracts, not liquidity pools. CoW's settlement contract holds no liquidity — it batches user orders and routes through external solvers. DODO's `RouteProxy` is a smart-routing entry point, not a PMM pool. Both decoders emit `factory == pool == log.address` — a single contract that "touches" thousands of unrelated pairs.
- In `state_pools_aggregating_by_token`, those contracts then map to every token they ever routed, so any `?input_token=X` filter returns the same contract with arbitrary `token0`/`token1` picked from the bag — observable as e.g. `/v1/evm/pools?input_token=GRT` returning rows where neither side is GRT.
- Excludes both protocols from `/v1/evm/pools`. Their swap records stay available via `/v1/evm/swaps` where they belong.

Closes #526, #527.

Proper decoding (CoW solver routes, DODO PMM pools as a separate concept) is tracked at pinax-network/substreams-evm#255.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)