### PR TITLE
[codex] Move agent skill file to canonical path

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ token-api/
 ├── scripts/             # Utility scripts (perf, query analysis, stablecoin checks)
 ├── queries/             # SQL breakdown/reference queries used by scripts
 ├── reports/             # Versioned performance and operational reports
+├── skills/              # Canonical agent skill file for publication
 ├── src/
 │   ├── routes/          # API route handlers (colocated .ts + .sql)
 │   ├── config/          # YAML config loader and validators
@@ -401,7 +402,7 @@ token-api/
 │   ├── registry/        # Native/stable token registry helpers
 │   ├── services/        # Shared services (Redis/spam-scoring)
 │   └── sql/             # SQL utilities
-├── public/              # Static assets
+├── public/              # Static assets and documentation indexes
 ├── docs/                # Maintainer navigation and operational docs
 └── index.ts             # Application entry point
 ```

--- a/docs/repo-navigation.md
+++ b/docs/repo-navigation.md
@@ -19,7 +19,8 @@ This document captures stable, tool-agnostic navigation knowledge for the `token
 - `scripts/`: maintenance and analysis scripts (perf, query logs, stablecoins, query breakdown generation).
 - `queries/`: SQL reference breakdowns consumed by script workflows.
 - `reports/`: checked-in analysis/performance reports (documentation artifacts, not runtime code).
-- `public/`: static files served by app (`index.html`, `skills.md`, `llms.txt`, assets).
+- `public/`: static files served by app (`index.html`, `llms.txt`, assets).
+- `skills/SKILL.md`: canonical agent skills file served by app for ClawHub and agent discovery.
 - `.github/workflows/`: CI and release automation entrypoints.
 
 ## 2) Architecture mental model (request/data flow)
@@ -60,8 +61,9 @@ This document captures stable, tool-agnostic navigation knowledge for the `token
   - Connection/auth/cluster routing: `src/clickhouse/client.ts`.
   - Streaming, stats, query error handling: `src/clickhouse/makeQuery.ts` and `src/handleQuery.ts`.
 
-- Change static docs or landing assets:
-  - Edit `public/index.html`, `public/skills.md`, `public/llms.txt`, and media in `public/`.
+- Change static docs, agent skill references, or landing assets:
+  - Edit `skills/SKILL.md` for the canonical agent skills file.
+  - Edit `public/index.html`, `public/llms.txt`, and media in `public/`.
 
 - Update CI/release behavior:
   - Edit `.github/workflows/*.yml`.
@@ -90,7 +92,7 @@ CI anchors:
 
 Primary source-of-truth directories:
 
-- `src/`, `scripts/`, `queries/`, `public/`, `.github/workflows/`, `docs/`.
+- `src/`, `scripts/`, `queries/`, `public/`, `skills/`, `.github/workflows/`, `docs/`.
 
 Generated or install/build artifacts:
 

--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,9 @@ app.get('/favicon.svg', () => new Response(Bun.file('./public/favicon.svg')));
 app.get('/banner.jpg', () => new Response(Bun.file('./public/banner.jpg')));
 
 const contentTypeMarkdown = 'text/markdown; charset=UTF-8';
+const skillsMarkdownFile = './skills/SKILL.md';
+const markdownResponse = (path: string) =>
+    new Response(Bun.file(path), { headers: { 'Content-Type': contentTypeMarkdown } });
 
 const skillsMarkdownOpenapi = describeRoute({
     operationId: 'getSkillsMarkdown',
@@ -112,22 +115,12 @@ const openapiSpecOpenapi = describeRoute({
     },
 });
 
-app.get(
-    '/SKILLS.md',
-    skillsMarkdownOpenapi,
-    () => new Response(Bun.file('./public/skills.md'), { headers: { 'Content-Type': contentTypeMarkdown } })
-);
-app.get(
-    '/skills.md',
-    () => new Response(Bun.file('./public/skills.md'), { headers: { 'Content-Type': contentTypeMarkdown } })
-);
+app.get('/skills/SKILL.md', skillsMarkdownOpenapi, () => markdownResponse(skillsMarkdownFile));
+app.get('/SKILLS.md', () => markdownResponse(skillsMarkdownFile));
+app.get('/skills.md', () => markdownResponse(skillsMarkdownFile));
 app.get('/skill.md', (c) => c.redirect('/skills.md', 301));
 app.get('/SKILL.md', (c) => c.redirect('/SKILLS.md', 301));
-app.get(
-    '/llms.txt',
-    llmsTextOpenapi,
-    () => new Response(Bun.file('./public/llms.txt'), { headers: { 'Content-Type': contentTypeMarkdown } })
-);
+app.get('/llms.txt', llmsTextOpenapi, () => markdownResponse('./public/llms.txt'));
 app.get(
     '/openapi',
     openapiSpecOpenapi,

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@
 ## Core references
 
 - [OpenAPI specification](https://token-api.thegraph.com/openapi): Authoritative machine-readable contract — use for schemas and parameters.
-- [Agent skills reference](https://token-api.thegraph.com/SKILLS.md): Endpoint catalog, conventions, and worked examples for agents.
+- [Agent skills reference](https://token-api.thegraph.com/skills/SKILL.md): Endpoint catalog, conventions, and worked examples for agents.
 - [Quick start](https://thegraph.com/docs/en/token-api/quick-start/): Setup and first requests.
 - [FAQ](https://thegraph.com/docs/en/token-api/faq/): Plans, billing, authentication.
 
@@ -18,7 +18,7 @@
 No authentication required, no usage charge.
 
 - [llms.txt](https://token-api.thegraph.com/llms.txt): This file.
-- [SKILLS.md](https://token-api.thegraph.com/SKILLS.md): Agent skills reference (`/skills.md` lowercase alias also works).
+- [skills/SKILL.md](https://token-api.thegraph.com/skills/SKILL.md): Agent skills reference (`/SKILLS.md` and `/skills.md` aliases also work).
 - [Health](https://token-api.thegraph.com/v1/health): Database connectivity status.
 - [Version](https://token-api.thegraph.com/v1/version): Build version, date, commit.
 - [Networks](https://token-api.thegraph.com/v1/networks): Indexed chains and per-category indexing freshness.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,10 @@
 ---
-name: Token API
-description: Real-time token, balance, transfer, holder, DEX, NFT, Polymarket, and Hyperliquid data across EVM, SVM, and TVM networks.
+name: token-api
+description: >
+  Query The Graph Token API for real-time token, balance, transfer, holder, DEX,
+  NFT, Polymarket, and Hyperliquid data across EVM, SVM, and TVM networks.
+  Use when: integrating with Token API, choosing endpoints, building API
+  requests, handling pagination, or discovering supported networks.
 ---
 
 # Token API
@@ -11,6 +15,7 @@ description: Real-time token, balance, transfer, holder, DEX, NFT, Polymarket, a
 - **OpenAPI spec:** `GET /openapi` — authoritative reference, use for schema details
 - **Docs:** <https://thegraph.com/docs/en/token-api/quick-start/>
 - **FAQ:** <https://thegraph.com/docs/en/token-api/faq/>
+- **Canonical skill file:** `GET /skills/SKILL.md`
 
 All responses are JSON: `{ "data": [...], ... }` for data endpoints, or a top-level object for monitoring. Errors follow `{ "status": <code>, "code": "<slug>", "message": "<text>" }`.
 
@@ -26,6 +31,7 @@ An `X-Api-Key: <your-api-key>` header is accepted as an alternative.
 
 **Unauthenticated endpoints** (no header required, no usage charge):
 - `GET /llms.txt`
+- `GET /skills/SKILL.md`
 - `GET /SKILLS.md`
 - `GET /skills.md` (lowercase alias)
 - `GET /v1/health`


### PR DESCRIPTION
## Summary

This moves the Token API agent skill from `public/skills.md` to the canonical `skills/SKILL.md` layout so it can be published as a ClawHub/OpenClaw-style skill package.

The previous implementation served the skill reference from `./public/skills.md`. That made sense for static web docs, but ClawHub expects a skill directory centered on a `SKILL.md` file, with optional support folders only when the skill needs scripts, references, or assets.

## Changes

- Rename `public/skills.md` to `skills/SKILL.md`.
- Update the API server to read `./skills/SKILL.md` as the source of truth.
- Add canonical `GET /skills/SKILL.md` route.
- Keep backwards-compatible routes for existing consumers:
  - `GET /SKILLS.md`
  - `GET /skills.md`
  - `GET /skill.md` -> `/skills.md`
  - `GET /SKILL.md` -> `/SKILLS.md`
- Update `llms.txt`, README, and repo navigation docs to point at the new canonical path.
- Normalize skill frontmatter to a lowercase hyphenated `name: token-api` and a more discoverable `Use when:` description.

## Structure rationale

A single `skills/SKILL.md` is the most efficient structure for now. The skill has no bundled scripts, assets, or long secondary references, so adding nested folders would only create packaging noise. If the skill grows later, we can add conventional sibling folders such as `skills/references/`, `skills/scripts/`, or `skills/assets/` and link to them from `SKILL.md`.

## Validation

- `bun run lint`
- Smoke-tested app fetches for:
  - `/skills/SKILL.md`
  - `/SKILLS.md`
  - `/skills.md`
  - `/skill.md`
  - `/SKILL.md`
  - `/llms.txt`
