### PR TITLE
[codex] Rename skill identity to Pinax API

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -34,8 +34,8 @@ const markdownResponse = (path: string) =>
 
 const skillsMarkdownOpenapi = describeRoute({
     operationId: 'getSkillsMarkdown',
-    summary: 'Agent Skills Reference',
-    description: 'Returns the public Markdown reference for AI agents integrating with Token API.',
+    summary: 'Pinax API Skill',
+    description: 'Returns the public Markdown reference for AI agents integrating with Pinax API.',
     tags: ['Documentation'],
     security: [],
     responses: {
@@ -46,13 +46,13 @@ const skillsMarkdownOpenapi = describeRoute({
                     schema: {
                         type: 'string',
                         example: `---
-name: Token API
-description: Real-time token, balance, transfer, holder, DEX, NFT, Polymarket, and Hyperliquid data across EVM, SVM, and TVM networks.
+name: pinax-api
+description: Query Pinax API data products, including Token API, prediction markets, and perp exchange data across EVM, SVM, and TVM networks.
 ---
 
-# Token API
+# Pinax API
 
-> Quick reference for AI agents using Token API. The authoritative machine-readable contract is \`GET /openapi\`.
+> Quick reference for AI agents using Pinax API. The authoritative machine-readable contract is \`GET /openapi\`.
 
 ...`,
                     },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@
 ## Core references
 
 - [OpenAPI specification](https://token-api.thegraph.com/openapi): Authoritative machine-readable contract — use for schemas and parameters.
-- [Agent skills reference](https://token-api.thegraph.com/skills/SKILL.md): Endpoint catalog, conventions, and worked examples for agents.
+- [Pinax API skill](https://token-api.thegraph.com/skills/SKILL.md): Endpoint catalog, conventions, and worked examples for agents.
 - [Quick start](https://thegraph.com/docs/en/token-api/quick-start/): Setup and first requests.
 - [FAQ](https://thegraph.com/docs/en/token-api/faq/): Plans, billing, authentication.
 
@@ -18,7 +18,7 @@
 No authentication required, no usage charge.
 
 - [llms.txt](https://token-api.thegraph.com/llms.txt): This file.
-- [skills/SKILL.md](https://token-api.thegraph.com/skills/SKILL.md): Agent skills reference (`/SKILLS.md` and `/skills.md` aliases also work).
+- [skills/SKILL.md](https://token-api.thegraph.com/skills/SKILL.md): Pinax API skill (`/SKILLS.md` and `/skills.md` aliases also work).
 - [Health](https://token-api.thegraph.com/v1/health): Database connectivity status.
 - [Version](https://token-api.thegraph.com/v1/version): Build version, date, commit.
 - [Networks](https://token-api.thegraph.com/v1/networks): Indexed chains and per-category indexing freshness.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,15 +1,15 @@
 ---
-name: token-api
+name: pinax-api
 description: >
-  Query The Graph Token API for real-time token, balance, transfer, holder, DEX,
-  NFT, Polymarket, and Hyperliquid data across EVM, SVM, and TVM networks.
-  Use when: integrating with Token API, choosing endpoints, building API
-  requests, handling pagination, or discovering supported networks.
+  Query Pinax API data products, including Token API, prediction markets, and
+  perp exchange data across EVM, SVM, and TVM networks. Use when: integrating
+  with Pinax API, choosing endpoints, building API requests, handling
+  pagination, or discovering supported networks.
 ---
 
-# Token API
+# Pinax API
 
-> Quick reference for AI agents using Token API. The authoritative machine-readable contract is `GET /openapi`.
+> Quick reference for AI agents using Pinax API. The authoritative machine-readable contract is `GET /openapi`.
 
 - **Base URL:** `https://token-api.thegraph.com`
 - **OpenAPI spec:** `GET /openapi` — authoritative reference, use for schema details


### PR DESCRIPTION
## Summary

This updates the newly added skill package identity from Token API to Pinax API, so the ClawHub slug and marketplace display can represent the broader Pinax API direction while the current skill content still documents the existing Token API endpoints.

## Changes

- Change `skills/SKILL.md` frontmatter name from `token-api` to `pinax-api`.
- Update the skill title and opening description to `Pinax API`.
- Update the OpenAPI docs example for the skill route.
- Update `llms.txt` references from a generic agent skills reference to the Pinax API skill.

## Rationale

`pinax-api` is the better long-term slug if Token API is becoming one data subset under a larger Pinax API family alongside prediction markets and perp exchange data. A single `skills/SKILL.md` remains the right structure for now because there are no supporting scripts, assets, or long references to split out.

## Validation

- `bun run lint`
- Smoke-tested `GET /skills/SKILL.md` via the app fetch handler and confirmed it serves the Pinax API skill frontmatter.
