### PR TITLE
[codex] Rebrand public docs to Pinax API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ IDLE_TIMEOUT=60
 MAX_LIMIT=1000
 
 # OpenAPI (optional)
+# API_URL=https://api.pinax.network
 DISABLE_OPENAPI_SERVERS=false
 
 # HTTP Cache-Control (optional)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# The Graph: Token API
+# Pinax API
 
 [![.github/workflows/bun-test.yml](https://github.com/pinax-network/token-api/actions/workflows/bun-test.yml/badge.svg)](https://github.com/pinax-network/token-api/actions/workflows/bun-test.yml)
 ![license](https://img.shields.io/github/license/pinax-network/token-api)
 
-### <https://thegraph.com/token-api/>
+### <https://api.pinax.network/>
 
-> Power your apps & AI agents with real-time token data.
+> Power your apps and AI agents with real-time Token API, prediction market, and perp exchange data.
 
 📚 **[Documentation](https://thegraph.com/docs/en/token-api/quick-start/)**
 
@@ -13,13 +13,13 @@
 
 ## Overview
 
-The Graph’s Token API lets you access blockchain token information via a GET request. This guide is designed to help you quickly integrate the Token API into your application.
+Pinax API lets you access high-volume blockchain datasets via simple HTTP requests. This guide is designed to help you quickly integrate Pinax API into your application.
 
-The Token API provides access to onchain NFT and fungible token data, including live and historical balances, holders, prices, market data, token metadata, and token transfers. This API also uses the Model Context Protocol (MCP) to allow AI tools such as Claude to enrich raw blockchain data with contextual insights.
+The current Pinax API surface includes Token API data for EVM, SVM, and TVM networks, prediction market data, and perp exchange data. The Token API dataset covers onchain NFT and fungible token data, including live and historical balances, holders, prices, market data, token metadata, and token transfers. Pinax API also exposes agent-friendly discovery files so AI tools can enrich raw blockchain data with contextual insights.
 
 ## Features
 
-### Token Data
+### Token API Dataset
 
 - **Real-time Balances**: Current token holdings for any wallet address
 - **Token Transfers**: Historical transfer events with full transaction details
@@ -38,6 +38,18 @@ The Token API provides access to onchain NFT and fungible token data, including 
 - **DEX Swaps**: Uniswap and Solana DEX swap events with token amounts
 - **Liquidity Pools**: Pool information, token pairs, and trading fees
 - **Historical Data**: Time-series data for portfolio tracking and analytics
+
+### Prediction Markets
+
+- **Market Discovery**: Polymarket market metadata, status, tokens, and outcomes
+- **Market Activity**: Trades, positions, open interest, and OHLC time-series
+- **User Analytics**: User-level positions, PnL, and market participation
+
+### Perp Exchanges
+
+- **Market Discovery**: Hyperliquid perp and spot market metadata
+- **Market Data**: OHLC, open interest, liquidations, and market activity
+- **User Analytics**: User positions, vaults, depositors, and platform metrics
 
 ### Multi-Chain Support
 
@@ -74,7 +86,7 @@ The Token API provides access to onchain NFT and fungible token data, including 
    Create a `dbs-config.yaml` file in the root directory:
 
    ```yaml
-   # Token API Database Configuration
+   # Pinax API Database Configuration
    # This file defines the database mappings for each network and data type
    clusters:
      default:
@@ -252,7 +264,7 @@ Envoy's cache filter respects `Cache-Control` directives including `s-maxage` an
 
 ### ClickHouse Database
 
-The Token API requires a ClickHouse database instance with the following characteristics:
+Pinax API requires a ClickHouse database instance with the following characteristics:
 
 - **Version**: ClickHouse 22.0+ recommended
 - **Memory**: Minimum 4GB RAM for production workloads
@@ -270,7 +282,7 @@ The API relies on Substreams data pipelines to populate the ClickHouse database.
 
 ## Authentication
 
-The API uses Bearer token authentication. For the live endpoint (token-api.thegraph.com), you can get your API token at [The Graph Market](https://thegraph.market).
+The API uses Bearer token authentication. For the live endpoint (`https://api.pinax.network`), you can get your API token at [The Graph Market](https://thegraph.market).
 Head over <https://thegraph.com/docs/en/token-api/quick-start/#authentication> for more information.
 
 ```bash
@@ -427,6 +439,6 @@ This project is licensed under the [Apache License 2.0](LICENSE).
 
 ## Support
 
-- **Documentation**: [API Docs](https://thegraph.com/token-api/)
+- **Documentation**: [API Docs](https://api.pinax.network/)
 - **Issues**: [GitHub Issues](https://github.com/pinax-network/token-api/issues)
 - **Community**: [The Graph Discord](https://discord.gg/thegraph)

--- a/dbs-config.yaml.example
+++ b/dbs-config.yaml.example
@@ -1,4 +1,4 @@
-# Token API Database Configuration
+# Pinax API Database Configuration
 # This file defines the database mappings for each network and data type.
 # Set DBS_CONFIG_PATH environment variable to point to this file.
 #

--- a/index.ts
+++ b/index.ts
@@ -34,8 +34,8 @@ const markdownResponse = (path: string) =>
 
 const skillsMarkdownOpenapi = describeRoute({
     operationId: 'getSkillsMarkdown',
-    summary: 'Agent Skills Reference',
-    description: 'Returns the public Markdown reference for AI agents integrating with Token API.',
+    summary: 'Pinax API Skill',
+    description: 'Returns the public Markdown reference for AI agents integrating with Pinax API.',
     tags: ['Documentation'],
     security: [],
     responses: {
@@ -46,13 +46,13 @@ const skillsMarkdownOpenapi = describeRoute({
                     schema: {
                         type: 'string',
                         example: `---
-name: Token API
-description: Real-time token, balance, transfer, holder, DEX, NFT, Polymarket, and Hyperliquid data across EVM, SVM, and TVM networks.
+name: pinax-api
+description: Query Pinax API datasets including Token API, prediction markets, and perp exchange data.
 ---
 
-# Token API
+# Pinax API
 
-> Quick reference for AI agents using Token API. The authoritative machine-readable contract is \`GET /openapi\`.
+> Quick reference for AI agents using Pinax API. The authoritative machine-readable contract is \`GET /openapi\`.
 
 ...`,
                     },
@@ -65,7 +65,7 @@ description: Real-time token, balance, transfer, holder, DEX, NFT, Polymarket, a
 const llmsTextOpenapi = describeRoute({
     operationId: 'getLlmsText',
     summary: 'LLM Documentation Index',
-    description: 'Returns the public llms.txt documentation index for AI tools discovering Token API.',
+    description: 'Returns the public llms.txt documentation index for AI tools discovering Pinax API.',
     tags: ['Documentation'],
     security: [],
     responses: {
@@ -75,9 +75,9 @@ const llmsTextOpenapi = describeRoute({
                 [contentTypeMarkdown]: {
                     schema: {
                         type: 'string',
-                        example: `# Token API
+                        example: `# Pinax API
 
-> Real-time token, balance, transfer, holder, DEX, NFT, Polymarket, and Hyperliquid data across EVM, SVM, and TVM networks.
+> Real-time Token API, prediction market, and perp exchange data.
 
 ...`,
                     },
@@ -90,7 +90,7 @@ const llmsTextOpenapi = describeRoute({
 const openapiSpecOpenapi = describeRoute({
     operationId: 'getOpenapiSpec',
     summary: 'OpenAPI Specification',
-    description: 'Returns the public OpenAPI specification for Token API.',
+    description: 'Returns the public OpenAPI specification for Pinax API.',
     tags: ['Documentation'],
     security: [],
     responses: {
@@ -115,11 +115,11 @@ const openapiSpecOpenapi = describeRoute({
     },
 });
 
-app.get('/skills/SKILL.md', skillsMarkdownOpenapi, () => markdownResponse(skillsMarkdownFile));
-app.get('/SKILLS.md', () => markdownResponse(skillsMarkdownFile));
-app.get('/skills.md', () => markdownResponse(skillsMarkdownFile));
-app.get('/skill.md', (c) => c.redirect('/skills.md', 301));
-app.get('/SKILL.md', (c) => c.redirect('/SKILLS.md', 301));
+app.get('/SKILL.md', skillsMarkdownOpenapi, () => markdownResponse(skillsMarkdownFile));
+app.get('/skills/SKILL.md', (c) => c.redirect('/SKILL.md', 301));
+app.get('/SKILLS.md', (c) => c.redirect('/SKILL.md', 301));
+app.get('/skills.md', (c) => c.redirect('/SKILL.md', 301));
+app.get('/skill.md', (c) => c.redirect('/SKILL.md', 301));
 app.get('/llms.txt', llmsTextOpenapi, () => markdownResponse('./public/llms.txt'));
 app.get(
     '/openapi',
@@ -127,9 +127,10 @@ app.get(
     openAPIRouteHandler(app, {
         documentation: {
             info: {
-                title: 'Token API',
+                title: 'Pinax API',
                 version: APP_VERSION,
-                description: 'Power your apps & AI agents with real-time token data.',
+                description:
+                    'Power your apps and AI agents with real-time Token API, prediction market, and perp exchange data.',
             },
             servers: config.disableOpenapiServers
                 ? [{ url: `http://${config.hostname}:${config.port}`, description: `${APP_DESCRIPTION} - Local` }]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "token-api",
-    "description": "Token API",
+    "description": "Pinax API",
     "version": "3.18.0",
     "homepage": "https://github.com/pinax-network/token-api",
     "license": "Apache-2.0",

--- a/public/index.html
+++ b/public/index.html
@@ -4,19 +4,19 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="description" content="Power your apps & AI agents with real-time token data." />
+  <meta name="description" content="Power your apps and AI agents with real-time Pinax API data." />
 
   <!-- Open Graph / Facebook -->
-  <meta property="og:title" content="The Graph: Token API" />
-  <meta property="og:description" content="Power your apps & AI agents with real-time token data." />
+  <meta property="og:title" content="Pinax API" />
+  <meta property="og:description" content="Power your apps and AI agents with real-time Pinax API data." />
   <meta property="og:image" content="https://github.com/user-attachments/assets/d22d87ec-2f98-4d44-b30c-932a57ba0a9e" />
 
   <!-- Twitter -->
-  <meta name="twitter:title" content="The Graph: Token API" />
-  <meta name="twitter:description" content="Power your apps & AI agents with real-time token data." />
+  <meta name="twitter:title" content="Pinax API" />
+  <meta name="twitter:description" content="Power your apps and AI agents with real-time Pinax API data." />
   <meta name="twitter:image" content="https://github.com/user-attachments/assets/d22d87ec-2f98-4d44-b30c-932a57ba0a9e" />
 
-  <title>The Graph: Token API</title>
+  <title>Pinax API</title>
   <link href="/favicon.svg" rel="icon" type="image/x-icon">
 </head>
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,15 +1,15 @@
-# Token API
+# Pinax API
 
-> Real-time token, balance, transfer, holder, DEX, NFT, Polymarket, and Hyperliquid data across EVM, SVM, and TVM networks.
+> Real-time Token API, prediction market, and perp exchange data.
 
-- Base URL: https://token-api.thegraph.com
+- Base URL: https://api.pinax.network
 - Most endpoints require `Authorization: Bearer <token>` from The Graph Market, or `X-Api-Key`.
 - Network support is configuration-driven — call `GET /v1/networks` first to see what's indexed.
 
 ## Core references
 
-- [OpenAPI specification](https://token-api.thegraph.com/openapi): Authoritative machine-readable contract — use for schemas and parameters.
-- [Agent skills reference](https://token-api.thegraph.com/skills/SKILL.md): Endpoint catalog, conventions, and worked examples for agents.
+- [OpenAPI specification](https://api.pinax.network/openapi): Authoritative machine-readable contract — use for schemas and parameters.
+- [Pinax API skill](https://api.pinax.network/SKILL.md): Endpoint catalog, conventions, and worked examples for agents.
 - [Quick start](https://thegraph.com/docs/en/token-api/quick-start/): Setup and first requests.
 - [FAQ](https://thegraph.com/docs/en/token-api/faq/): Plans, billing, authentication.
 
@@ -17,14 +17,14 @@
 
 No authentication required, no usage charge.
 
-- [llms.txt](https://token-api.thegraph.com/llms.txt): This file.
-- [skills/SKILL.md](https://token-api.thegraph.com/skills/SKILL.md): Agent skills reference (`/SKILLS.md` and `/skills.md` aliases also work).
-- [Health](https://token-api.thegraph.com/v1/health): Database connectivity status.
-- [Version](https://token-api.thegraph.com/v1/version): Build version, date, commit.
-- [Networks](https://token-api.thegraph.com/v1/networks): Indexed chains and per-category indexing freshness.
-- [EVM DEXes](https://token-api.thegraph.com/v1/evm/dexes): Supported EVM DEX protocols by network.
-- [SVM DEXes](https://token-api.thegraph.com/v1/svm/dexes): Supported SVM DEX protocols by network.
-- [TVM DEXes](https://token-api.thegraph.com/v1/tvm/dexes): Supported TVM DEX protocols by network.
-- [Polymarket markets](https://token-api.thegraph.com/v1/polymarket/markets): Public Polymarket market discovery.
-- [Hyperliquid DEXes](https://token-api.thegraph.com/v1/hyperliquid/dexes): Hyperliquid core perps, spot, and builder-deployed DEXes.
-- [Hyperliquid markets](https://token-api.thegraph.com/v1/hyperliquid/markets): Public Hyperliquid market discovery.
+- [llms.txt](https://api.pinax.network/llms.txt): This file.
+- [SKILL.md](https://api.pinax.network/SKILL.md): Pinax API skill (`/skills/SKILL.md`, `/SKILLS.md`, and `/skills.md` aliases also work).
+- [Health](https://api.pinax.network/v1/health): Database connectivity status.
+- [Version](https://api.pinax.network/v1/version): Build version, date, commit.
+- [Networks](https://api.pinax.network/v1/networks): Indexed chains and per-category indexing freshness.
+- [EVM DEXes](https://api.pinax.network/v1/evm/dexes): Supported EVM DEX protocols by network.
+- [SVM DEXes](https://api.pinax.network/v1/svm/dexes): Supported SVM DEX protocols by network.
+- [TVM DEXes](https://api.pinax.network/v1/tvm/dexes): Supported TVM DEX protocols by network.
+- [Polymarket markets](https://api.pinax.network/v1/polymarket/markets): Public prediction market discovery.
+- [Hyperliquid DEXes](https://api.pinax.network/v1/hyperliquid/dexes): Hyperliquid core perps, spot, and builder-deployed DEXes.
+- [Hyperliquid markets](https://api.pinax.network/v1/hyperliquid/markets): Public perp exchange market discovery.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,21 +1,21 @@
 ---
-name: token-api
+name: pinax-api
 description: >
-  Query The Graph Token API for real-time token, balance, transfer, holder, DEX,
-  NFT, Polymarket, and Hyperliquid data across EVM, SVM, and TVM networks.
-  Use when: integrating with Token API, choosing endpoints, building API
-  requests, handling pagination, or discovering supported networks.
+  Query Pinax API datasets, including Token API for EVM/SVM/TVM token data,
+  prediction markets, and perp exchange data. Use when: integrating with Pinax
+  API, choosing endpoints, building API requests, handling pagination, or
+  discovering supported networks.
 ---
 
-# Token API
+# Pinax API
 
-> Quick reference for AI agents using Token API. The authoritative machine-readable contract is `GET /openapi`.
+> Quick reference for AI agents using Pinax API. The authoritative machine-readable contract is `GET /openapi`.
 
-- **Base URL:** `https://token-api.thegraph.com`
+- **Base URL:** `https://api.pinax.network`
 - **OpenAPI spec:** `GET /openapi` — authoritative reference, use for schema details
 - **Docs:** <https://thegraph.com/docs/en/token-api/quick-start/>
 - **FAQ:** <https://thegraph.com/docs/en/token-api/faq/>
-- **Canonical skill file:** `GET /skills/SKILL.md`
+- **Canonical skill file:** `GET /SKILL.md`
 
 All responses are JSON: `{ "data": [...], ... }` for data endpoints, or a top-level object for monitoring. Errors follow `{ "status": <code>, "code": "<slug>", "message": "<text>" }`.
 
@@ -31,9 +31,10 @@ An `X-Api-Key: <your-api-key>` header is accepted as an alternative.
 
 **Unauthenticated endpoints** (no header required, no usage charge):
 - `GET /llms.txt`
-- `GET /skills/SKILL.md`
-- `GET /SKILLS.md`
-- `GET /skills.md` (lowercase alias)
+- `GET /SKILL.md`
+- `GET /skills/SKILL.md` (alias)
+- `GET /SKILLS.md` (alias)
+- `GET /skills.md` (alias)
 - `GET /v1/health`
 - `GET /v1/version`
 - `GET /v1/networks`
@@ -60,17 +61,17 @@ Common codes: `bad_query_input` (400), `authentication_failed` (401), `route_not
 
 ## Capabilities
 
-Map a goal to the relevant endpoint family:
+Map a goal to the relevant dataset and endpoint family:
 
-- **Look up a wallet's balances and transfer history** — `/v1/{evm,svm,tvm}/balances`, `/v1/{evm,svm,tvm}/transfers`
-- **Track balance changes over time** — `/v1/evm/balances/historical`, `/v1/evm/balances/historical/native`
-- **Resolve token metadata** — `/v1/{evm,svm,tvm}/tokens`, `/v1/{evm,svm,tvm}/tokens/native`
-- **Find holders of a token** — `/v1/{evm,svm}/holders`, `/v1/evm/holders/native`, `/v1/evm/nft/holders`
-- **Trace DEX swaps and liquidity pools** — `/v1/{evm,svm,tvm}/swaps`, `/v1/{evm,svm,tvm}/pools`, `/v1/{evm,svm,tvm}/dexes`
-- **Get OHLC time-series** — `/v1/{evm,svm,tvm}/pools/ohlc`, `/v1/polymarket/markets/ohlc`
-- **List a wallet's NFT holdings and activity** — `/v1/evm/nft/ownerships`, `/v1/evm/nft/transfers`, `/v1/evm/nft/sales`, `/v1/evm/nft/items`, `/v1/evm/nft/collections`
-- **Discover Polymarket markets, OI, and per-user PNL** — `/v1/polymarket/markets`, `/v1/polymarket/markets/oi`, `/v1/polymarket/markets/activity`, `/v1/polymarket/users`, `/v1/polymarket/users/positions`
-- **Discover Hyperliquid markets, OHLC, OI, liquidations, and per-user PnL** — `/v1/hyperliquid/markets`, `/v1/hyperliquid/markets/ohlc`, `/v1/hyperliquid/markets/oi`, `/v1/hyperliquid/markets/liquidations`, `/v1/hyperliquid/users`, `/v1/hyperliquid/users/positions`, `/v1/hyperliquid/vaults`
+- **Token API: look up wallet balances and transfer history** — `/v1/{evm,svm,tvm}/balances`, `/v1/{evm,svm,tvm}/transfers`
+- **Token API: track balance changes over time** — `/v1/evm/balances/historical`, `/v1/evm/balances/historical/native`
+- **Token API: resolve token metadata** — `/v1/{evm,svm,tvm}/tokens`, `/v1/{evm,svm,tvm}/tokens/native`
+- **Token API: find holders of a token** — `/v1/{evm,svm}/holders`, `/v1/evm/holders/native`, `/v1/evm/nft/holders`
+- **Token API: trace DEX swaps and liquidity pools** — `/v1/{evm,svm,tvm}/swaps`, `/v1/{evm,svm,tvm}/pools`, `/v1/{evm,svm,tvm}/dexes`
+- **Token API: get OHLC time-series** — `/v1/{evm,svm,tvm}/pools/ohlc`
+- **Token API: list a wallet's NFT holdings and activity** — `/v1/evm/nft/ownerships`, `/v1/evm/nft/transfers`, `/v1/evm/nft/sales`, `/v1/evm/nft/items`, `/v1/evm/nft/collections`
+- **Prediction Markets: discover markets, OI, and per-user PNL** — `/v1/polymarket/markets`, `/v1/polymarket/markets/ohlc`, `/v1/polymarket/markets/oi`, `/v1/polymarket/markets/activity`, `/v1/polymarket/users`, `/v1/polymarket/users/positions`
+- **Perp Exchanges: discover markets, OHLC, OI, liquidations, and per-user PnL** — `/v1/hyperliquid/markets`, `/v1/hyperliquid/markets/ohlc`, `/v1/hyperliquid/markets/oi`, `/v1/hyperliquid/markets/liquidations`, `/v1/hyperliquid/users`, `/v1/hyperliquid/users/positions`, `/v1/hyperliquid/vaults`
 - **Discover supported chains and protocols** (free) — `/v1/networks`, `/v1/{evm,svm,tvm}/dexes`, `/v1/hyperliquid/dexes`
 
 ## Common patterns

--- a/src/banner.ts
+++ b/src/banner.ts
@@ -12,7 +12,7 @@ export function banner() {
     ░░░██║░░░╚█████╔╝██║░╚██╗███████╗██║░╚███║  ██║░░██║██║░░░░░██║
     ░░░╚═╝░░░░╚════╝░╚═╝░░╚═╝╚══════╝╚═╝░░╚══╝  ╚═╝░░╚═╝╚═╝░░░░░╚═╝
 `;
-    text += `                 Token API v${APP_VERSION}\n`;
+    text += `                 Pinax API v${APP_VERSION}\n`;
     text += `               ${pkg.homepage}\n`;
 
     return text;


### PR DESCRIPTION
## Summary

This rebrands the public-facing docs and OpenAPI metadata from Token API to Pinax API, with Token API described as one dataset under the broader Pinax API product family.

The new product framing is:

- Pinax API is the parent API product.
- Token API is the EVM/SVM/TVM token dataset for balances, transfers, holders, swaps, pools, NFT data, and token metadata.
- Prediction Markets and Perp Exchanges are peer datasets represented by the Polymarket and Hyperliquid endpoint families.

## Changes

- Update README branding and overview copy to Pinax API.
- Add explicit README sections for Token API, Prediction Markets, and Perp Exchanges.
- Update `skills/SKILL.md` frontmatter, heading, base URL, and capability grouping to `pinax-api` / Pinax API.
- Make `/SKILL.md` the canonical public skill URL, with `/skills/SKILL.md`, `/SKILLS.md`, `/skills.md`, and `/skill.md` redirecting to it.
- Update `public/llms.txt` discovery links and endpoint links to `https://api.pinax.network`.
- Update Scalar/Open Graph/Twitter page metadata in `public/index.html`.
- Update OpenAPI route descriptions, examples, title, and info description to Pinax API.
- Keep the default OpenAPI server URL computed from local `HOSTNAME` and `PORT`, so deployments can supply custom domains through `API_URL`.
- Update package description, startup banner label, `.env.example`, and `dbs-config.yaml.example` branding.

## Notes

Domain-level terms such as token transfers, token metadata, and OpenAPI tags like `EVM Tokens` remain unchanged because they describe the Token API dataset rather than the parent product brand.

## Validation

- `bun run lint`
- Smoke-tested app fetches for `/openapi`, `/llms.txt`, `/SKILL.md`, and legacy skill aliases.
- Confirmed `/openapi` reports title `Pinax API` and defaults to `http://localhost:8000` unless `API_URL` is configured.
