### PR TITLE
[codex] Add proxy-layer x402 discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ The API relies on Substreams data pipelines to populate the ClickHouse database.
 The API uses Bearer token authentication. For the live endpoint (`https://api.pinax.network`), you can get your API token at [The Graph Market](https://thegraph.market).
 Head over <https://thegraph.com/docs/en/token-api/quick-start/#authentication> for more information.
 
+For x402 clients, payment enforcement, verification, settlement, and metering are handled by the proxy layer before requests reach this API server. The API server exposes discovery metadata at `GET /.well-known/x402` and keeps request handling independent from x402 payment verification.
+
 ```bash
 curl -H "Authorization: Bearer <YOUR_API_TOKEN>" \
   "..."

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import { APP_DESCRIPTION, APP_VERSION, config } from './src/config.js';
 import { logger } from './src/logger.js';
 import routes from './src/routes/index.js';
 import { APIErrorResponse } from './src/utils.js';
+import { createX402Discovery } from './src/x402/discovery.js';
 
 const app = new Hono();
 
@@ -28,6 +29,7 @@ app.get('/favicon.svg', () => new Response(Bun.file('./public/favicon.svg')));
 app.get('/banner.jpg', () => new Response(Bun.file('./public/banner.jpg')));
 
 const contentTypeMarkdown = 'text/markdown; charset=UTF-8';
+const contentTypeJson = 'application/json; charset=UTF-8';
 const skillsMarkdownFile = './skills/SKILL.md';
 const markdownResponse = (path: string) =>
     new Response(Bun.file(path), { headers: { 'Content-Type': contentTypeMarkdown } });
@@ -115,12 +117,49 @@ const openapiSpecOpenapi = describeRoute({
     },
 });
 
+const x402DiscoveryOpenapi = describeRoute({
+    operationId: 'getX402Discovery',
+    summary: 'x402 Discovery',
+    description:
+        'Returns the public x402 discovery document. Payment enforcement, verification, settlement, and metering are handled by the proxy layer.',
+    tags: ['Documentation'],
+    security: [],
+    responses: {
+        200: {
+            description: 'Successful Response',
+            content: {
+                [contentTypeJson]: {
+                    schema: {
+                        type: 'object',
+                        example: {
+                            x402Version: 2,
+                            name: 'Pinax API',
+                            resourceServer: 'https://api.pinax.network',
+                            payment: {
+                                enforcement: 'proxy',
+                            },
+                            discovery: {
+                                openapi: 'https://api.pinax.network/openapi',
+                                llms: 'https://api.pinax.network/llms.txt',
+                                skill: 'https://api.pinax.network/SKILL.md',
+                            },
+                            datasets: [],
+                        },
+                    },
+                },
+            },
+        },
+    },
+});
+
 app.get('/SKILL.md', skillsMarkdownOpenapi, () => markdownResponse(skillsMarkdownFile));
 app.get('/skills/SKILL.md', (c) => c.redirect('/SKILL.md', 301));
 app.get('/SKILLS.md', (c) => c.redirect('/SKILL.md', 301));
 app.get('/skills.md', (c) => c.redirect('/SKILL.md', 301));
 app.get('/skill.md', (c) => c.redirect('/SKILL.md', 301));
 app.get('/llms.txt', llmsTextOpenapi, () => markdownResponse('./public/llms.txt'));
+app.get('/.well-known/x402', x402DiscoveryOpenapi, (c) => c.json(createX402Discovery()));
+app.get('/x402.json', (c) => c.redirect('/.well-known/x402', 301));
 app.get(
     '/openapi',
     openapiSpecOpenapi,

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,6 +9,7 @@
 ## Core references
 
 - [OpenAPI specification](https://api.pinax.network/openapi): Authoritative machine-readable contract — use for schemas and parameters.
+- [x402 discovery](https://api.pinax.network/.well-known/x402): Machine-readable payment discovery metadata; x402 enforcement is handled at the proxy layer.
 - [Pinax API skill](https://api.pinax.network/SKILL.md): Endpoint catalog, conventions, and worked examples for agents.
 - [Quick start](https://thegraph.com/docs/en/token-api/quick-start/): Setup and first requests.
 - [FAQ](https://thegraph.com/docs/en/token-api/faq/): Plans, billing, authentication.
@@ -18,6 +19,7 @@
 No authentication required, no usage charge.
 
 - [llms.txt](https://api.pinax.network/llms.txt): This file.
+- [x402 discovery](https://api.pinax.network/.well-known/x402): Proxy-layer x402 payment discovery metadata.
 - [SKILL.md](https://api.pinax.network/SKILL.md): Pinax API skill (`/skills/SKILL.md`, `/SKILLS.md`, and `/skills.md` aliases also work).
 - [Health](https://api.pinax.network/v1/health): Database connectivity status.
 - [Version](https://api.pinax.network/v1/version): Build version, date, commit.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -13,6 +13,7 @@ description: >
 
 - **Base URL:** `https://api.pinax.network`
 - **OpenAPI spec:** `GET /openapi` — authoritative reference, use for schema details
+- **x402 discovery:** `GET /.well-known/x402` — payment discovery metadata; x402 enforcement is handled at the proxy layer
 - **Docs:** <https://thegraph.com/docs/en/token-api/quick-start/>
 - **FAQ:** <https://thegraph.com/docs/en/token-api/faq/>
 - **Canonical skill file:** `GET /SKILL.md`
@@ -31,6 +32,8 @@ An `X-Api-Key: <your-api-key>` header is accepted as an alternative.
 
 **Unauthenticated endpoints** (no header required, no usage charge):
 - `GET /llms.txt`
+- `GET /.well-known/x402`
+- `GET /x402.json` (alias)
 - `GET /SKILL.md`
 - `GET /skills/SKILL.md` (alias)
 - `GET /SKILLS.md` (alias)

--- a/src/x402/discovery.ts
+++ b/src/x402/discovery.ts
@@ -1,0 +1,66 @@
+import { config } from '../config.js';
+
+const freeRoutes = [
+    '/.well-known/x402',
+    '/x402.json',
+    '/llms.txt',
+    '/SKILL.md',
+    '/openapi',
+    '/v1/health',
+    '/v1/version',
+    '/v1/networks',
+    '/v1/evm/dexes',
+    '/v1/svm/dexes',
+    '/v1/tvm/dexes',
+    '/v1/polymarket/markets',
+    '/v1/hyperliquid/dexes',
+    '/v1/hyperliquid/markets',
+] as const;
+
+const datasets = [
+    {
+        name: 'Token API',
+        description: 'EVM, SVM, and TVM token balances, transfers, holders, swaps, pools, NFT data, and metadata.',
+        routePatterns: ['/v1/evm/*', '/v1/svm/*', '/v1/tvm/*'],
+    },
+    {
+        name: 'Prediction Markets',
+        description: 'Polymarket market discovery, OHLC, open interest, activity, users, and positions.',
+        routePatterns: ['/v1/polymarket/*'],
+    },
+    {
+        name: 'Perp Exchanges',
+        description:
+            'Hyperliquid markets, OHLC, open interest, liquidations, user positions, vaults, and platform data.',
+        routePatterns: ['/v1/hyperliquid/*'],
+    },
+] as const;
+
+export function createX402Discovery() {
+    const baseUrl = config.apiUrl.replace(/\/$/, '');
+
+    return {
+        x402Version: 2,
+        name: 'Pinax API',
+        description: 'Real-time Token API, prediction market, and perp exchange data.',
+        resourceServer: baseUrl,
+        payment: {
+            enforcement: 'proxy',
+            note: 'x402 authentication, verification, settlement, and metering are handled before requests reach the API server.',
+        },
+        discovery: {
+            openapi: `${baseUrl}/openapi`,
+            llms: `${baseUrl}/llms.txt`,
+            skill: `${baseUrl}/SKILL.md`,
+        },
+        freeRoutes: freeRoutes.map((path) => ({
+            method: 'GET',
+            path,
+            resource: `${baseUrl}${path}`,
+        })),
+        datasets: datasets.map((dataset) => ({
+            ...dataset,
+            metering: 'proxy',
+        })),
+    };
+}


### PR DESCRIPTION
## Summary

This replaces the app-layer x402 middleware approach from #496 with the bare minimum the API server needs now that x402 authentication, verification, settlement, and metering are handled at the proxy layer.

## Changes

- Add `GET /.well-known/x402` as a public machine-readable discovery document.
- Add `GET /x402.json` as a compatibility alias that redirects to `/.well-known/x402`.
- Describe x402 payment handling as proxy-enforced instead of API-enforced.
- Link the discovery document from `llms.txt`, `SKILL.md`, and README.
- Include dataset-level discovery metadata for Token API, Prediction Markets, and Perp Exchanges.
- Avoid adding `@x402/*` dependencies, API middleware, app-layer payment verification, access-pass caching, cache-control changes, or protected route blockers.

## Rationale

The API server should not duplicate payment enforcement that happens before requests reach it. The proxy is the right layer for 402 responses, payment verification, settlement, metering, and any Bazaar integration tied to successful settlements. The API layer only needs to advertise how clients and agents can discover Pinax API resources and understand that x402 is handled upstream.

## Validation

- `bun run lint`
- Smoke-tested:
  - `GET /.well-known/x402`
  - `GET /x402.json`
  - `GET /openapi`
  - `GET /llms.txt`
  - `GET /SKILL.md`

Supersedes #496.
