### PR TITLE
[codex] Rename repository identifiers to Pinax API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,23 @@
 
 ### Minor Changes
 
-- Added batch query support and `total_transfers` field to `/tokens` endpoint for EVM/TVM ([#337](https://github.com/pinax-network/token-api/pull/337))
-- Added `indexed_to` per DB category to `/networks` response and simplified `/health` to DB connection verification ([#381](https://github.com/pinax-network/token-api/pull/381))
-- Refactored routes to flatten structure, colocate SQL files, and use single router ([#346](https://github.com/pinax-network/token-api/pull/346))
-- Added server init logging for clusters, networks, databases, and supported routes ([#352](https://github.com/pinax-network/token-api/pull/352), [#366](https://github.com/pinax-network/token-api/pull/366))
-- Replaced `readSQL` with Bun native text imports for SQL files ([#355](https://github.com/pinax-network/token-api/pull/355))
-- Added SQL route tests with `DB_TESTS` flag and performance testing script ([#356](https://github.com/pinax-network/token-api/pull/356), [#368](https://github.com/pinax-network/token-api/pull/368))
-- Removed inject logic (except Web3icons), moved stables/natives to `src/registry/` ([#353](https://github.com/pinax-network/token-api/pull/353))
-- Removed Changesets tooling ([#344](https://github.com/pinax-network/token-api/pull/344))
+- Added batch query support and `total_transfers` field to `/tokens` endpoint for EVM/TVM ([#337](https://github.com/pinax-network/pinax-api/pull/337))
+- Added `indexed_to` per DB category to `/networks` response and simplified `/health` to DB connection verification ([#381](https://github.com/pinax-network/pinax-api/pull/381))
+- Refactored routes to flatten structure, colocate SQL files, and use single router ([#346](https://github.com/pinax-network/pinax-api/pull/346))
+- Added server init logging for clusters, networks, databases, and supported routes ([#352](https://github.com/pinax-network/pinax-api/pull/352), [#366](https://github.com/pinax-network/pinax-api/pull/366))
+- Replaced `readSQL` with Bun native text imports for SQL files ([#355](https://github.com/pinax-network/pinax-api/pull/355))
+- Added SQL route tests with `DB_TESTS` flag and performance testing script ([#356](https://github.com/pinax-network/pinax-api/pull/356), [#368](https://github.com/pinax-network/pinax-api/pull/368))
+- Removed inject logic (except Web3icons), moved stables/natives to `src/registry/` ([#353](https://github.com/pinax-network/pinax-api/pull/353))
+- Removed Changesets tooling ([#344](https://github.com/pinax-network/pinax-api/pull/344))
 
 ### Patch Changes
 
-- Fixed wrong CTE alias in EVM tokens query ORDER BY ([#342](https://github.com/pinax-network/token-api/pull/342))
-- Replaced sentinel default values with NULL in SQL query parameters ([#364](https://github.com/pinax-network/token-api/pull/364))
-- Reuse EVM SQL for identical TVM routes ([#372](https://github.com/pinax-network/token-api/pull/372))
-- Removed all references to `injectSymbol` ([#338](https://github.com/pinax-network/token-api/pull/338))
-- Removed maximum bar rate limits from plans ([#340](https://github.com/pinax-network/token-api/pull/340))
-- Added Bun cache to test workflow ([#358](https://github.com/pinax-network/token-api/pull/358))
+- Fixed wrong CTE alias in EVM tokens query ORDER BY ([#342](https://github.com/pinax-network/pinax-api/pull/342))
+- Replaced sentinel default values with NULL in SQL query parameters ([#364](https://github.com/pinax-network/pinax-api/pull/364))
+- Reuse EVM SQL for identical TVM routes ([#372](https://github.com/pinax-network/pinax-api/pull/372))
+- Removed all references to `injectSymbol` ([#338](https://github.com/pinax-network/pinax-api/pull/338))
+- Removed maximum bar rate limits from plans ([#340](https://github.com/pinax-network/pinax-api/pull/340))
+- Added Bun cache to test workflow ([#358](https://github.com/pinax-network/pinax-api/pull/358))
 
 ## 3.9.0
 
@@ -124,40 +124,40 @@
 
 ### Fixed
 
-- Fix tron order by, include `block_hash` ([#265](https://github.com/pinax-network/token-api/pull/265))
+- Fix tron order by, include `block_hash` ([#265](https://github.com/pinax-network/pinax-api/pull/265))
 
 ## [3.5.2] - 2024-11-06
 
 ### Fixed
 
-- Fix TVM ORDER BY for swaps and transfers ([#263](https://github.com/pinax-network/token-api/pull/263))
+- Fix TVM ORDER BY for swaps and transfers ([#263](https://github.com/pinax-network/pinax-api/pull/263))
 
 ## [3.5.1] - 2024-11-05
 
 ### Added
 
-- Add indexes to TVM endpoint responses ([#262](https://github.com/pinax-network/token-api/pull/262))
+- Add indexes to TVM endpoint responses ([#262](https://github.com/pinax-network/pinax-api/pull/262))
 
 ## [3.5.0] - 2024-11-04
 
 ### Added
 
-- Add TVM endpoints ([#256](https://github.com/pinax-network/token-api/pull/256))
+- Add TVM endpoints ([#256](https://github.com/pinax-network/pinax-api/pull/256))
 
 ### Changed
 
-- Optimize query time windows to use latest ingested timestamp ([#258](https://github.com/pinax-network/token-api/pull/258))
-- Refactor spam scoring ([#259](https://github.com/pinax-network/token-api/pull/259))
+- Optimize query time windows to use latest ingested timestamp ([#258](https://github.com/pinax-network/pinax-api/pull/258))
+- Refactor spam scoring ([#259](https://github.com/pinax-network/pinax-api/pull/259))
 
 ## [3.4.1] - 2024-10-31
 
 ### Fixed
 
-- Fix sorting in `/evm/holders` ([#255](https://github.com/pinax-network/token-api/pull/255))
+- Fix sorting in `/evm/holders` ([#255](https://github.com/pinax-network/pinax-api/pull/255))
 
 ### Changed
 
-- Optimize `/evm/holders` ([#257](https://github.com/pinax-network/token-api/pull/257))
+- Optimize `/evm/holders` ([#257](https://github.com/pinax-network/pinax-api/pull/257))
 
 ## [3.4.0] - 2024-10-30
 
@@ -165,13 +165,13 @@
 
 ### Added
 
-- Add version mismatch check for GH release action ([#252](https://github.com/pinax-network/token-api/pull/252))
+- Add version mismatch check for GH release action ([#252](https://github.com/pinax-network/pinax-api/pull/252))
 
 ### Changed
 
-- Optimize `/evm/transfers` ([#250](https://github.com/pinax-network/token-api/pull/250))
-- Optimize `/svm/swaps` ([#253](https://github.com/pinax-network/token-api/pull/253))
-- Optimize `/evm/swaps` ([#254](https://github.com/pinax-network/token-api/pull/254))
+- Optimize `/evm/transfers` ([#250](https://github.com/pinax-network/pinax-api/pull/250))
+- Optimize `/svm/swaps` ([#253](https://github.com/pinax-network/pinax-api/pull/253))
+- Optimize `/evm/swaps` ([#254](https://github.com/pinax-network/pinax-api/pull/254))
 
 ## [3.3.3] - 2024-10-28
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ If you then still feel the need to ask a question and need clarification, we rec
 
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help fix any potential bug as fast as possible.
 
-- Make sure that you are using the [latest version](/releases). If you're using the binary, you can check with `token-api --version`.
+- Make sure that you are using the [latest version](/releases). If you're using the binary, you can check with `pinax-api --version`.
 - Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (make sure that you have read the [documentation](README.md). If you are looking for support, you might want to check [this section](#asking-questions)).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](/issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside the GitHub community have discussed the issue.
@@ -73,7 +73,7 @@ This section guides you through submitting an enhancement suggestion, **includin
 
 #### Before Submitting an Enhancement
 
-- Make sure that you are using the [latest version](/releases). If you're using the binary, you can check with `token-api --version`.
+- Make sure that you are using the [latest version](/releases). If you're using the binary, you can check with `pinax-api --version`.
 - Read the [documentation](README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
 - Perform a [search](/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. Keep in mind that features should be useful to the majority of users and not just a small subset.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Pinax API
 
-[![.github/workflows/bun-test.yml](https://github.com/pinax-network/token-api/actions/workflows/bun-test.yml/badge.svg)](https://github.com/pinax-network/token-api/actions/workflows/bun-test.yml)
-![license](https://img.shields.io/github/license/pinax-network/token-api)
+[![.github/workflows/bun-test.yml](https://github.com/pinax-network/pinax-api/actions/workflows/bun-test.yml/badge.svg)](https://github.com/pinax-network/pinax-api/actions/workflows/bun-test.yml)
+![license](https://img.shields.io/github/license/pinax-network/pinax-api)
 
 ### <https://api.pinax.network/>
 
 > Power your apps and AI agents with real-time Token API, prediction market, and perp exchange data.
 
-📚 **[Documentation](https://thegraph.com/docs/en/token-api/quick-start/)**
+📚 **[Documentation](https://thegraph.com/docs/en/pinax-api/quick-start/)**
 
 ![banner](public/banner.jpg)
 
@@ -71,8 +71,8 @@ The current Pinax API surface includes Token API data for EVM, SVM, and TVM netw
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/pinax-network/token-api.git
-   cd token-api
+   git clone https://github.com/pinax-network/pinax-api.git
+   cd pinax-api
    ```
 
 2. **Install dependencies**
@@ -239,7 +239,7 @@ When a client sends `Cache-Control: no-cache`, the API skips emitting cache head
     cache
 }
 
-token-api.example.com {
+pinax-api.example.com {
     cache
     reverse_proxy localhost:8000
 }
@@ -283,7 +283,7 @@ The API relies on Substreams data pipelines to populate the ClickHouse database.
 ## Authentication
 
 The API uses Bearer token authentication. For the live endpoint (`https://api.pinax.network`), you can get your API token at [The Graph Market](https://thegraph.market).
-Head over <https://thegraph.com/docs/en/token-api/quick-start/#authentication> for more information.
+Head over <https://thegraph.com/docs/en/pinax-api/quick-start/#authentication> for more information.
 
 For x402 clients, payment enforcement, verification, settlement, and metering are handled by the proxy layer before requests reach this API server. The API server exposes discovery metadata at `GET /.well-known/x402` and keeps request handling independent from x402 payment verification.
 
@@ -326,34 +326,34 @@ Supported networks are derived from `dbs-config.yaml` (`networks.*`) at startup.
 **Latest stable release:**
 
 ```bash
-docker pull ghcr.io/pinax-network/token-api:latest
+docker pull ghcr.io/pinax-network/pinax-api:latest
 docker run -it --rm \
   -v $(pwd)/dbs-config.yaml:/dbs-config.yaml \
   -e DBS_CONFIG_PATH=/dbs-config.yaml \
   -p 8000:8000 \
-  ghcr.io/pinax-network/token-api:latest
+  ghcr.io/pinax-network/pinax-api:latest
 ```
 
 **Development build:**
 
 ```bash
-docker pull ghcr.io/pinax-network/token-api:develop
+docker pull ghcr.io/pinax-network/pinax-api:develop
 docker run -it --rm \
   -v $(pwd)/dbs-config.yaml:/dbs-config.yaml \
   -e DBS_CONFIG_PATH=/dbs-config.yaml \
   -p 8000:8000 \
-  ghcr.io/pinax-network/token-api:develop
+  ghcr.io/pinax-network/pinax-api:develop
 ```
 
 ### Building from Source
 
 ```bash
-docker build -t token-api .
+docker build -t pinax-api .
 docker run -it --rm \
   -v $(pwd)/dbs-config.yaml:/dbs-config.yaml \
   -e DBS_CONFIG_PATH=/dbs-config.yaml \
   -p 8000:8000 \
-  token-api
+  pinax-api
 ```
 
 ## Development
@@ -401,7 +401,7 @@ AND (isNull({start_time:Nullable(UInt64)}) OR timestamp >= {start_time:Nullable(
 ### Project Structure
 
 ```
-token-api/
+pinax-api/
 ├── .github/workflows/   # CI/CD pipelines (test, release, docker publish)
 ├── scripts/             # Utility scripts (perf, query analysis, stablecoin checks)
 ├── queries/             # SQL breakdown/reference queries used by scripts
@@ -442,5 +442,5 @@ This project is licensed under the [Apache License 2.0](LICENSE).
 ## Support
 
 - **Documentation**: [API Docs](https://api.pinax.network/)
-- **Issues**: [GitHub Issues](https://github.com/pinax-network/token-api/issues)
+- **Issues**: [GitHub Issues](https://github.com/pinax-network/pinax-api/issues)
 - **Community**: [The Graph Discord](https://discord.gg/thegraph)

--- a/RELEASE-NOTES-v3.10.0.md
+++ b/RELEASE-NOTES-v3.10.0.md
@@ -2,9 +2,9 @@
 
 ## Highlights
 
-- 🏗️ **Major route refactor** — Flattened the entire `src/routes/` directory structure, colocated SQL files next to route handlers, and consolidated ~30 intermediate router files into a single router ([#346](https://github.com/pinax-network/token-api/pull/346))
-- 🔍 **`/networks` now includes `indexed_to`** — Each network entry returns per-category sync status (block number, datetime, version) for transfers, balances, and dexes databases ([#381](https://github.com/pinax-network/token-api/pull/381))
-- 📦 **Batch support for `/tokens`** — The `/tokens` endpoint now accepts batched contract/mint queries and returns `total_transfers` for EVM/TVM ([#337](https://github.com/pinax-network/token-api/pull/337))
+- 🏗️ **Major route refactor** — Flattened the entire `src/routes/` directory structure, colocated SQL files next to route handlers, and consolidated ~30 intermediate router files into a single router ([#346](https://github.com/pinax-network/pinax-api/pull/346))
+- 🔍 **`/networks` now includes `indexed_to`** — Each network entry returns per-category sync status (block number, datetime, version) for transfers, balances, and dexes databases ([#381](https://github.com/pinax-network/pinax-api/pull/381))
+- 📦 **Batch support for `/tokens`** — The `/tokens` endpoint now accepts batched contract/mint queries and returns `total_transfers` for EVM/TVM ([#337](https://github.com/pinax-network/pinax-api/pull/337))
 
 ---
 
@@ -12,19 +12,19 @@
 
 ### New Features
 
-- **Batch queries on `/tokens`** — Added batched `contract`/`mint` query params and new `circulating_supply`, `holders`, and `total_transfers` response fields for EVM, SVM, and TVM token endpoints ([#337](https://github.com/pinax-network/token-api/pull/337))
-- **`indexed_to` in `/networks` response** — Each network object now includes an `indexed_to` array with sync status per DB category (transfers, balances, dexes), including `version`, `block_num`, `datetime`, and `timestamp` ([#381](https://github.com/pinax-network/token-api/pull/381))
-- **Network filter on `/networks`** — Added optional batched `network` query param to filter results by network ID ([#381](https://github.com/pinax-network/token-api/pull/381))
-- **Removed rate limit maximums** — Removed maximum bar rate limits from API plans ([#340](https://github.com/pinax-network/token-api/pull/340))
+- **Batch queries on `/tokens`** — Added batched `contract`/`mint` query params and new `circulating_supply`, `holders`, and `total_transfers` response fields for EVM, SVM, and TVM token endpoints ([#337](https://github.com/pinax-network/pinax-api/pull/337))
+- **`indexed_to` in `/networks` response** — Each network object now includes an `indexed_to` array with sync status per DB category (transfers, balances, dexes), including `version`, `block_num`, `datetime`, and `timestamp` ([#381](https://github.com/pinax-network/pinax-api/pull/381))
+- **Network filter on `/networks`** — Added optional batched `network` query param to filter results by network ID ([#381](https://github.com/pinax-network/pinax-api/pull/381))
+- **Removed rate limit maximums** — Removed maximum bar rate limits from API plans ([#340](https://github.com/pinax-network/pinax-api/pull/340))
 
 ### Bug Fixes
 
-- **Fixed EVM tokens ORDER BY** — Corrected wrong CTE alias in EVM tokens query causing incorrect sort order ([#342](https://github.com/pinax-network/token-api/pull/342))
-- **NULL defaults for SQL params** — Replaced sentinel default values (`-1`, `0x0000...`) with `NULL` in SQL query parameters, improving correctness of optional filters ([#364](https://github.com/pinax-network/token-api/pull/364))
+- **Fixed EVM tokens ORDER BY** — Corrected wrong CTE alias in EVM tokens query causing incorrect sort order ([#342](https://github.com/pinax-network/pinax-api/pull/342))
+- **NULL defaults for SQL params** — Replaced sentinel default values (`-1`, `0x0000...`) with `NULL` in SQL query parameters, improving correctness of optional filters ([#364](https://github.com/pinax-network/pinax-api/pull/364))
 
 ### Improvements
 
-- **Reuse EVM SQL for TVM routes** — Identical TVM routes now share EVM SQL queries, reducing duplication ([#372](https://github.com/pinax-network/token-api/pull/372))
+- **Reuse EVM SQL for TVM routes** — Identical TVM routes now share EVM SQL queries, reducing duplication ([#372](https://github.com/pinax-network/pinax-api/pull/372))
 
 ---
 
@@ -32,27 +32,27 @@
 
 ### Architecture
 
-- **Flattened route structure** — Restructured `src/routes/` from deeply nested `v1/evm/svm/tvm` hierarchy to flat feature-based folders with all chain variants colocated. Eliminated ~30 intermediate `index.ts` router files in favor of a single route registration file ([#346](https://github.com/pinax-network/token-api/pull/346))
-- **Colocated SQL files** — Moved SQL files from centralized `src/sql/` directory to sit next to their route handlers (e.g., `tokens/evm.ts` + `tokens/evm.sql`) ([#346](https://github.com/pinax-network/token-api/pull/346))
-- **Bun native SQL imports** — Replaced `readSQL()` file loading with Bun's native text imports for SQL files ([#355](https://github.com/pinax-network/token-api/pull/355))
+- **Flattened route structure** — Restructured `src/routes/` from deeply nested `v1/evm/svm/tvm` hierarchy to flat feature-based folders with all chain variants colocated. Eliminated ~30 intermediate `index.ts` router files in favor of a single route registration file ([#346](https://github.com/pinax-network/pinax-api/pull/346))
+- **Colocated SQL files** — Moved SQL files from centralized `src/sql/` directory to sit next to their route handlers (e.g., `tokens/evm.ts` + `tokens/evm.sql`) ([#346](https://github.com/pinax-network/pinax-api/pull/346))
+- **Bun native SQL imports** — Replaced `readSQL()` file loading with Bun's native text imports for SQL files ([#355](https://github.com/pinax-network/pinax-api/pull/355))
 
 ### Health & Monitoring
 
-- **Simplified `/health` endpoint** — Stripped down to simple DB connection verification (ping each ClickHouse cluster), removing degraded/skipped status logic and API endpoint self-testing ([#381](https://github.com/pinax-network/token-api/pull/381))
-- **Server init logging** — Added structured logging at startup for configured clusters, networks, databases, and routes ([#352](https://github.com/pinax-network/token-api/pull/352))
-- **Supported vs unsupported route logging** — Server init now logs which routes are supported/unsupported based on the current DB configuration ([#366](https://github.com/pinax-network/token-api/pull/366))
+- **Simplified `/health` endpoint** — Stripped down to simple DB connection verification (ping each ClickHouse cluster), removing degraded/skipped status logic and API endpoint self-testing ([#381](https://github.com/pinax-network/pinax-api/pull/381))
+- **Server init logging** — Added structured logging at startup for configured clusters, networks, databases, and routes ([#352](https://github.com/pinax-network/pinax-api/pull/352))
+- **Supported vs unsupported route logging** — Server init now logs which routes are supported/unsupported based on the current DB configuration ([#366](https://github.com/pinax-network/pinax-api/pull/366))
 
 ### Code Cleanup
 
-- **Removed inject modules** — Deleted unused `injectPrices`, `injectSymbol`, and associated code. Kept only Web3icons injection. Moved stablecoin/native token registries to `src/registry/` ([#353](https://github.com/pinax-network/token-api/pull/353), [#338](https://github.com/pinax-network/token-api/pull/338))
-- **Removed Changesets** — Removed changeset tooling entirely from the project ([#344](https://github.com/pinax-network/token-api/pull/344))
+- **Removed inject modules** — Deleted unused `injectPrices`, `injectSymbol`, and associated code. Kept only Web3icons injection. Moved stablecoin/native token registries to `src/registry/` ([#353](https://github.com/pinax-network/pinax-api/pull/353), [#338](https://github.com/pinax-network/pinax-api/pull/338))
+- **Removed Changesets** — Removed changeset tooling entirely from the project ([#344](https://github.com/pinax-network/pinax-api/pull/344))
 
 ### Testing & Performance
 
-- **SQL route tests** — Added basic SQL tests per route with a `DB_TESTS` flag for opt-in database integration testing ([#356](https://github.com/pinax-network/token-api/pull/356))
-- **Performance testing script** — Added `scripts/perf.ts` for benchmarking all API routes, with multi-network support, `Cache-Control: no-cache` headers, and zero-row detection ([#368](https://github.com/pinax-network/token-api/pull/368), [#374](https://github.com/pinax-network/token-api/pull/374), [#376](https://github.com/pinax-network/token-api/pull/376), [#378](https://github.com/pinax-network/token-api/pull/378))
-- **CI caching** — Added Bun cache to the test workflow for faster CI runs ([#358](https://github.com/pinax-network/token-api/pull/358))
+- **SQL route tests** — Added basic SQL tests per route with a `DB_TESTS` flag for opt-in database integration testing ([#356](https://github.com/pinax-network/pinax-api/pull/356))
+- **Performance testing script** — Added `scripts/perf.ts` for benchmarking all API routes, with multi-network support, `Cache-Control: no-cache` headers, and zero-row detection ([#368](https://github.com/pinax-network/pinax-api/pull/368), [#374](https://github.com/pinax-network/pinax-api/pull/374), [#376](https://github.com/pinax-network/pinax-api/pull/376), [#378](https://github.com/pinax-network/pinax-api/pull/378))
+- **CI caching** — Added Bun cache to the test workflow for faster CI runs ([#358](https://github.com/pinax-network/pinax-api/pull/358))
 
 ---
 
-**Full Changelog**: https://github.com/pinax-network/token-api/compare/v3.9.0...v3.10.0
+**Full Changelog**: https://github.com/pinax-network/pinax-api/compare/v3.9.0...v3.10.0

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 0,
   "workspaces": {
     "": {
-      "name": "token-api",
+      "name": "pinax-api",
       "dependencies": {
         "@clickhouse/client": "^1.12.0",
         "@clickhouse/client-web": "^1.12.0",

--- a/docs/repo-navigation.md
+++ b/docs/repo-navigation.md
@@ -1,6 +1,6 @@
 # Repo Navigation Guide
 
-This document captures stable, tool-agnostic navigation knowledge for the `token-api` codebase.
+This document captures stable, tool-agnostic navigation knowledge for the `pinax-api` codebase.
 
 ## 1) Workspace layout
 
@@ -74,7 +74,7 @@ From `package.json` scripts:
 
 - `bun dev`: start local API with watch mode.
 - `bun start`: start API once (no watch).
-- `bun build`: compile standalone binary (`token-api`).
+- `bun build`: compile standalone binary (`pinax-api`).
 - `bun test`: unit/integration tests with coverage.
 - `bun test:db`: DB-backed test run (`DB_TESTS=true`).
 - `bun lint`: TypeScript check + Biome check.
@@ -97,7 +97,7 @@ Primary source-of-truth directories:
 Generated or install/build artifacts:
 
 - `node_modules/`: dependency install artifact.
-- `token-api`: compiled binary output from `bun build`.
+- `pinax-api`: compiled binary output from `bun build`.
 - `coverage/` (when tests run with coverage): generated report artifact.
 - `dist/` (TypeScript outDir in config, if generated locally).
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "private": true,
-    "name": "token-api",
+    "name": "pinax-api",
     "description": "Pinax API",
     "version": "3.18.0",
-    "homepage": "https://github.com/pinax-network/token-api",
+    "homepage": "https://github.com/pinax-network/pinax-api",
     "license": "Apache-2.0",
     "type": "module",
     "authors": [
@@ -31,7 +31,7 @@
     "scripts": {
         "dev": "bun --watch index.ts",
         "start": "bun index.ts",
-        "build": "bun build --compile index.ts --outfile token-api",
+        "build": "bun build --compile index.ts --outfile pinax-api",
         "test": "bun test --coverage",
         "test:sql": "DB_TESTS=true bun test $(find src/routes -name '*.sql.spec.ts' | sort) --timeout 30000",
         "test:perf": "DB_TESTS=true bun test $(find src/routes -name '*.perf.spec.ts' | sort) --timeout 30000",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,8 +11,8 @@
 - [OpenAPI specification](https://api.pinax.network/openapi): Authoritative machine-readable contract — use for schemas and parameters.
 - [x402 discovery](https://api.pinax.network/.well-known/x402): Machine-readable payment discovery metadata; x402 enforcement is handled at the proxy layer.
 - [Pinax API skill](https://api.pinax.network/SKILL.md): Endpoint catalog, conventions, and worked examples for agents.
-- [Quick start](https://thegraph.com/docs/en/token-api/quick-start/): Setup and first requests.
-- [FAQ](https://thegraph.com/docs/en/token-api/faq/): Plans, billing, authentication.
+- [Quick start](https://thegraph.com/docs/en/pinax-api/quick-start/): Setup and first requests.
+- [FAQ](https://thegraph.com/docs/en/pinax-api/faq/): Plans, billing, authentication.
 
 ## Free endpoints
 

--- a/reports/2026-02-27-http-cache-control-refactor.md
+++ b/reports/2026-02-27-http-cache-control-refactor.md
@@ -1,8 +1,8 @@
 # HTTP Cache-Control Refactor Report
 
 **Date:** 2026-02-27
-**PR:** [#414](https://github.com/pinax-network/token-api/pull/414)
-**Issue:** [#413](https://github.com/pinax-network/token-api/issues/413)
+**PR:** [#414](https://github.com/pinax-network/pinax-api/pull/414)
+**Issue:** [#413](https://github.com/pinax-network/pinax-api/issues/413)
 
 ## Summary
 
@@ -102,7 +102,7 @@ This eliminates latency spikes on cache misses — the user always gets a fast r
     cache
 }
 
-token-api.example.com {
+pinax-api.example.com {
     cache
     reverse_proxy localhost:8000
 }

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -14,8 +14,8 @@ description: >
 - **Base URL:** `https://api.pinax.network`
 - **OpenAPI spec:** `GET /openapi` — authoritative reference, use for schema details
 - **x402 discovery:** `GET /.well-known/x402` — payment discovery metadata; x402 enforcement is handled at the proxy layer
-- **Docs:** <https://thegraph.com/docs/en/token-api/quick-start/>
-- **FAQ:** <https://thegraph.com/docs/en/token-api/faq/>
+- **Docs:** <https://thegraph.com/docs/en/pinax-api/quick-start/>
+- **FAQ:** <https://thegraph.com/docs/en/pinax-api/faq/>
 - **Canonical skill file:** `GET /SKILL.md`
 
 All responses are JSON: `{ "data": [...], ... }` for data endpoints, or a top-level object for monitoring. Errors follow `{ "status": <code>, "code": "<slug>", "message": "<text>" }`.

--- a/src/middleware/nativeContractRedirect.spec.ts
+++ b/src/middleware/nativeContractRedirect.spec.ts
@@ -144,7 +144,7 @@ describe('nativeContractRedirect middleware', () => {
 
     describe('redirect URL format', () => {
         it('should use relative path (no scheme/host) for redirect behind reverse proxy', async () => {
-            const url = `http://token-api-http-svc:80/v1/evm/transfers?network=mainnet&contract=${EVM_CONTRACT_NATIVE_EXAMPLE}`;
+            const url = `http://pinax-api-http-svc:80/v1/evm/transfers?network=mainnet&contract=${EVM_CONTRACT_NATIVE_EXAMPLE}`;
             const ctx = createMockContext(url);
             const next = createMockNext();
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -239,29 +239,35 @@ describe('validatorHook', () => {
             });
         });
 
-        describe('x-token-api-items-returned', () => {
+        describe('x-pinax-api-items-returned', () => {
             it('should allow limit within bounds', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-items-returned': '15' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-items-returned': '15' } });
                 const parseResult = { success: true as const, data: { limit: 15 } };
                 expect(validatorHook(parseResult, ctx)).toBeUndefined();
             });
 
             it('should reject limit exceeding header cap', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-items-returned': '15' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-items-returned': '15' } });
                 const parseResult = { success: true as const, data: { limit: 16 } };
                 expect(validatorHook(parseResult, ctx)).toBeDefined();
             });
 
             it('should treat 0 as unlimited', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-items-returned': '0' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-items-returned': '0' } });
                 const parseResult = { success: true as const, data: { limit: 100_000 } };
                 expect(validatorHook(parseResult, ctx)).toBeUndefined();
             });
+
+            it('should accept the legacy x-token-api-items-returned header', () => {
+                const ctx = createMockContext({ headers: { 'x-token-api-items-returned': '15' } });
+                const parseResult = { success: true as const, data: { limit: 16 } };
+                expect(validatorHook(parseResult, ctx)).toBeDefined();
+            });
         });
 
-        describe('x-token-api-batch-size', () => {
+        describe('x-pinax-api-batch-size', () => {
             it('should allow batched parameters within bounds', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-batch-size': '3' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-batch-size': '3' } });
                 const parseResult = {
                     success: true as const,
                     data: { limit: 10, addresses: ['0x1', '0x2', '0x3'] },
@@ -270,7 +276,7 @@ describe('validatorHook', () => {
             });
 
             it('should reject batched parameters exceeding header cap', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-batch-size': '3' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-batch-size': '3' } });
                 const parseResult = {
                     success: true as const,
                     data: { limit: 10, addresses: ['0x1', '0x2', '0x3', '0x4'] },
@@ -279,7 +285,7 @@ describe('validatorHook', () => {
             });
 
             it('should report all exceeded batched parameters', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-batch-size': '3' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-batch-size': '3' } });
                 const parseResult = {
                     success: true as const,
                     data: {
@@ -292,7 +298,7 @@ describe('validatorHook', () => {
             });
 
             it('should treat 0 as unlimited', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-batch-size': '0' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-batch-size': '0' } });
                 const parseResult = {
                     success: true as const,
                     data: { addresses: new Array(500).fill('0x1') },
@@ -301,33 +307,33 @@ describe('validatorHook', () => {
             });
         });
 
-        describe('x-token-api-lowest-time-parameter', () => {
+        describe('x-pinax-api-lowest-time-parameter', () => {
             it('should allow interval equal to threshold', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-lowest-time-parameter': '4h' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-lowest-time-parameter': '4h' } });
                 const parseResult = { success: true as const, data: { interval: 240 } };
                 expect(validatorHook(parseResult, ctx)).toBeUndefined();
             });
 
             it('should allow coarser interval than threshold', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-lowest-time-parameter': '4h' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-lowest-time-parameter': '4h' } });
                 const parseResult = { success: true as const, data: { interval: 1440 } };
                 expect(validatorHook(parseResult, ctx)).toBeUndefined();
             });
 
             it('should reject finer interval than threshold', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-lowest-time-parameter': '4h' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-lowest-time-parameter': '4h' } });
                 const parseResult = { success: true as const, data: { interval: 60 } };
                 expect(validatorHook(parseResult, ctx)).toBeDefined();
             });
 
             it('should ignore invalid header values', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-lowest-time-parameter': 'bogus' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-lowest-time-parameter': 'bogus' } });
                 const parseResult = { success: true as const, data: { interval: 1 } };
                 expect(validatorHook(parseResult, ctx)).toBeUndefined();
             });
 
             it('should not check threshold when interval is absent', () => {
-                const ctx = createMockContext({ headers: { 'x-token-api-lowest-time-parameter': '1d' } });
+                const ctx = createMockContext({ headers: { 'x-pinax-api-lowest-time-parameter': '1d' } });
                 const parseResult = { success: true as const, data: { limit: 10 } };
                 expect(validatorHook(parseResult, ctx)).toBeUndefined();
             });
@@ -337,9 +343,9 @@ describe('validatorHook', () => {
             it('should enforce all three limits together', () => {
                 const ctx = createMockContext({
                     headers: {
-                        'x-token-api-items-returned': '100',
-                        'x-token-api-batch-size': '10',
-                        'x-token-api-lowest-time-parameter': '1h',
+                        'x-pinax-api-items-returned': '100',
+                        'x-pinax-api-batch-size': '10',
+                        'x-pinax-api-lowest-time-parameter': '1h',
                     },
                 });
                 const parseResult = {
@@ -355,7 +361,7 @@ describe('validatorHook', () => {
 
             it('should merge validatedData with existing context data', () => {
                 const ctx = createMockContext({
-                    headers: { 'x-token-api-items-returned': '50' },
+                    headers: { 'x-pinax-api-items-returned': '50' },
                     validatedData: { existing: 'data' },
                 });
                 const parseResult = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,9 +15,12 @@ import {
 // Plan limits are injected by the upstream gateway on every authenticated
 // request. Requests without these headers (e.g. local development) bypass
 // enforcement.
-const HEADER_BATCH_SIZE = 'x-token-api-batch-size';
-const HEADER_ITEMS_RETURNED = 'x-token-api-items-returned';
-const HEADER_LOWEST_TIME_PARAMETER = 'x-token-api-lowest-time-parameter';
+const HEADER_BATCH_SIZE = 'x-pinax-api-batch-size';
+const HEADER_BATCH_SIZE_LEGACY = 'x-token-api-batch-size';
+const HEADER_ITEMS_RETURNED = 'x-pinax-api-items-returned';
+const HEADER_ITEMS_RETURNED_LEGACY = 'x-token-api-items-returned';
+const HEADER_LOWEST_TIME_PARAMETER = 'x-pinax-api-lowest-time-parameter';
+const HEADER_LOWEST_TIME_PARAMETER_LEGACY = 'x-token-api-lowest-time-parameter';
 
 function parseLimitHeader(raw: string | undefined): number | null {
     if (!raw) return null;
@@ -71,6 +74,10 @@ export function now() {
     return Math.floor(Date.now() / 1000);
 }
 
+function getGatewayHeader(ctx: Context, header: string, legacyHeader: string) {
+    return ctx.req.header(header) ?? ctx.req.header(legacyHeader);
+}
+
 export function validatorHook(
     parseResult:
         | {
@@ -89,9 +96,9 @@ export function validatorHook(
 ) {
     if (!parseResult.success) return APIErrorResponse(ctx, 400, 'bad_query_input', parseResult.error);
 
-    const maxItems = parseLimitHeader(ctx.req.header(HEADER_ITEMS_RETURNED));
-    const maxBatch = parseLimitHeader(ctx.req.header(HEADER_BATCH_SIZE));
-    const lowestInterval = ctx.req.header(HEADER_LOWEST_TIME_PARAMETER);
+    const maxItems = parseLimitHeader(getGatewayHeader(ctx, HEADER_ITEMS_RETURNED, HEADER_ITEMS_RETURNED_LEGACY));
+    const maxBatch = parseLimitHeader(getGatewayHeader(ctx, HEADER_BATCH_SIZE, HEADER_BATCH_SIZE_LEGACY));
+    const lowestInterval = getGatewayHeader(ctx, HEADER_LOWEST_TIME_PARAMETER, HEADER_LOWEST_TIME_PARAMETER_LEGACY);
     const data = parseResult.data;
 
     // `items-returned`: cap on `limit`. 0 = unlimited.


### PR DESCRIPTION
## Summary

This finishes the lowercase `token-api` to `pinax-api` identifier rename ahead of the GitHub repository rename.

## Changes

- Rename package identity from `token-api` to `pinax-api` in `package.json` and `bun.lock`.
- Update build output from `token-api` to `pinax-api`.
- Update README clone commands, Docker image examples, local image names, badges, issue links, and project tree label.
- Update contributor and repo navigation docs to reference the `pinax-api` binary/codebase.
- Update historical GitHub links in changelog/release notes/report docs to the future `pinax-api` repository path.
- Rename gateway plan-limit headers to `x-pinax-api-*` while keeping `x-token-api-*` as legacy aliases for compatibility.
- Update related tests and a service-host test fixture.

## Notes

Uppercase `Token API` remains where it refers to the token dataset under the Pinax API product family. The only lowercase `token-api` strings left are explicit legacy gateway header aliases.

## Validation

- `bun run lint`
- `bun test src/utils.spec.ts src/middleware/nativeContractRedirect.spec.ts --coverage`
