### PR TITLE
docs: point public links to app.pinax.network

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > Power your apps and AI agents with real-time Token API, prediction market, and perp exchange data.
 
-📚 **[Documentation](https://thegraph.com/docs/en/pinax-api/quick-start/)**
+📚 **[Documentation](https://app.pinax.network/docs)**
 
 ![banner](public/banner.jpg)
 
@@ -283,7 +283,7 @@ The API relies on Substreams data pipelines to populate the ClickHouse database.
 ## Authentication
 
 The API uses Bearer token authentication. For the live endpoint (`https://api.pinax.network`), you can get your API token at [The Graph Market](https://thegraph.market).
-Head over <https://thegraph.com/docs/en/pinax-api/quick-start/#authentication> for more information.
+Head over <https://app.pinax.network/help#authentication> for more information.
 
 For x402 clients, payment enforcement, verification, settlement, and metering are handled by the proxy layer before requests reach this API server. The API server exposes discovery metadata at `GET /.well-known/x402` and keeps request handling independent from x402 payment verification.
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,8 +11,8 @@
 - [OpenAPI specification](https://api.pinax.network/openapi): Authoritative machine-readable contract — use for schemas and parameters.
 - [x402 discovery](https://api.pinax.network/.well-known/x402): Machine-readable payment discovery metadata; x402 enforcement is handled at the proxy layer.
 - [Pinax API skill](https://api.pinax.network/SKILL.md): Endpoint catalog, conventions, and worked examples for agents.
-- [Quick start](https://thegraph.com/docs/en/pinax-api/quick-start/): Setup and first requests.
-- [FAQ](https://thegraph.com/docs/en/pinax-api/faq/): Plans, billing, authentication.
+- [Quick start](https://app.pinax.network/docs): Setup and first requests.
+- [FAQ](https://app.pinax.network/help): Plans, billing, authentication.
 
 ## Free endpoints
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -14,8 +14,8 @@ description: >
 - **Base URL:** `https://api.pinax.network`
 - **OpenAPI spec:** `GET /openapi` — authoritative reference, use for schema details
 - **x402 discovery:** `GET /.well-known/x402` — payment discovery metadata; x402 enforcement is handled at the proxy layer
-- **Docs:** <https://thegraph.com/docs/en/pinax-api/quick-start/>
-- **FAQ:** <https://thegraph.com/docs/en/pinax-api/faq/>
+- **Docs:** <https://app.pinax.network/docs>
+- **FAQ:** <https://app.pinax.network/help>
 - **Canonical skill file:** `GET /SKILL.md`
 
 All responses are JSON: `{ "data": [...], ... }` for data endpoints, or a top-level object for monitoring. Errors follow `{ "status": <code>, "code": "<slug>", "message": "<text>" }`.


### PR DESCRIPTION
## Summary

Swap the public-facing docs links from the legacy `thegraph.com/docs/en/pinax-api/*` URLs to the new Pinax-hosted sites:

- Docs / Quick start → `https://app.pinax.network/docs`
- FAQ → `https://app.pinax.network/help`
- Authentication deep link → `https://app.pinax.network/help#authentication`

Touches `README.md`, `skills/SKILL.md`, `public/llms.txt`.

## Notes

`src/types/zod.ts` still references `https://thegraph.com/networks` — those are pointers to The Graph's network-ID registry, not the docs site, and stay as-is.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)