### PR TITLE
feat(hyperevm): register native and stablecoin contracts

### DIFF
--- a/src/registry/natives.ts
+++ b/src/registry/natives.ts
@@ -19,6 +19,9 @@ export const natives = new Set([
     // Polygon (Matic)
     '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270', // Polygon: WPOL
 
+    // HyperEVM
+    '0x5555555555555555555555555555555555555555', // HyperEVM: WHYPE
+
     // Solana
     'So11111111111111111111111111111111111111112', // WSOL
 ]);

--- a/src/registry/stables.ts
+++ b/src/registry/stables.ts
@@ -41,6 +41,13 @@ export const stables = new Set([
     '0x078d782b760474a361dda0af3839290b0ef57ad6', // Unichain: USDC
     '0x9151434b16b9763660705744891fA906F660EcC5', // Unichain: USDT0 Tether USD
 
+    // HyperEVM
+    '0xb88339cb7199b77e23db6e890353e22632ba630f', // HyperEVM: USDC
+    '0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb', // HyperEVM: USDT0 (Tether USD)
+    '0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34', // HyperEVM: USDe (Ethena)
+    '0x02c6a2fa58cc01a18b8d9e00ea48d65e4df26c70', // HyperEVM: feUSD (Felix)
+    '0x111111a1a0667d36bd57c0a9f569b98057111111', // HyperEVM: USDH
+
     // Solana
     'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // Solana: USDC (USD Coin)
     'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB', // Solana: USDT (Tether USD)

--- a/src/routes/nft/sales_evm.ts
+++ b/src/routes/nft/sales_evm.ts
@@ -154,7 +154,7 @@ const nativeSymbols = new Map([
     ['polygon', 'POL'],
     ['unichain', 'ETH'],
     ['avalanche', 'AVAX'],
-    ['hyper-evm', 'HYPE'],
+    ['hyperevm', 'HYPE'],
     ['solana', 'SOL'],
 ]);
 

--- a/src/routes/nft/sales_evm.ts
+++ b/src/routes/nft/sales_evm.ts
@@ -154,6 +154,7 @@ const nativeSymbols = new Map([
     ['polygon', 'POL'],
     ['unichain', 'ETH'],
     ['avalanche', 'AVAX'],
+    ['hyper-evm', 'HYPE'],
     ['solana', 'SOL'],
 ]);
 

--- a/src/services/spamScoring.ts
+++ b/src/services/spamScoring.ts
@@ -50,7 +50,7 @@ export const CHAIN_ID_MAP: Record<string, number> = {
     optimism: 10,
     bsc: 56,
     // unichain: 10000,
-    // 'hyper-evm': 999,
+    // hyperevm: 999,
 };
 const TIMEOUT_MS = 60000;
 const STALE_MS = 24 * 60 * 60 * 1000; // 1 day

--- a/src/services/spamScoring.ts
+++ b/src/services/spamScoring.ts
@@ -50,6 +50,7 @@ export const CHAIN_ID_MAP: Record<string, number> = {
     optimism: 10,
     bsc: 56,
     // unichain: 10000,
+    // 'hyper-evm': 999,
 };
 const TIMEOUT_MS = 60000;
 const STALE_MS = 24 * 60 * 60 * 1000; // 1 day


### PR DESCRIPTION
## Summary

Pre-stage the hardcoded per-chain values HyperEVM needs, ahead of a `hyper-evm` network being added to `dbs-config.yaml`. The entries are inert until the network is wired, but having them in place means stablecoin/native classification and NFT sale currency are correct the moment it lands.

- **`src/registry/natives.ts`** — WHYPE (`0x5555…5555`), the canonical wrapped-HYPE system contract.
- **`src/registry/stables.ts`** — five USD-pegged stablecoins, addresses verified on-chain: USDC, USDT0, USDe (Ethena), feUSD (Felix), USDH.
- **`src/routes/nft/sales_evm.ts`** — `nativeSymbols` maps `hyper-evm → HYPE`, so NFT sales report `HYPE` instead of the `Native` fallback.
- **`src/services/spamScoring.ts`** — chain id `999` recorded in `CHAIN_ID_MAP`, commented out like `unichain` until the upstream spam model supports it.

## Why

HyperEVM is being added as a new EVM network. An audit of the hardcoded per-chain symbol/contract maps surfaced exactly these four spots. Everything else — the supported-network lists, `/v1/networks`, OpenAPI examples — is derived from `dbs-config.yaml`, so it needs no change here.

## Network id

Uses `hyper-evm`, the id from [The Graph networks registry](https://thegraph.com/networks) (`eip155:999`), consistent with the existing hyphenated `arbitrum-one`. The two network-keyed entries (`nativeSymbols`, `CHAIN_ID_MAP`) must match whatever key the eventual `dbs-config.yaml` block uses — worth confirming when the network is wired.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)