### PR TITLE
fix(evm): null-fallback for is_contract and NFT creation fields

### DIFF
--- a/src/routes/holders/evm.sql
+++ b/src/routes/holders/evm.sql
@@ -10,6 +10,13 @@ WITH rows_arr AS (
         ORDER BY balance DESC, address
         LIMIT {limit:UInt64} OFFSET {offset:UInt64}
     )
+),
+/* Chains extracted via the firehose RPC poller produce DETAILLEVEL_BASE blocks
+   with no Create-call records, so the contracts table is empty. Probe once
+   to decide whether is_contract can be answered. */
+has_contracts AS (
+    SELECT count() > 0 AS available
+    FROM (SELECT 1 FROM {db_contracts:Identifier}.contracts LIMIT 1)
 )
 SELECT
     /* timestamps */
@@ -25,13 +32,16 @@ SELECT
     toString(t.2) AS amount,
     t.2 / pow(10, m.decimals) AS value,
 
-    /* holder type */
-    toBool(t.1 IN (
-        SELECT address FROM {db_contracts:Identifier}.contracts
-        WHERE address IN (
-            SELECT arrayJoin(arrayMap(x -> x.1, (SELECT r FROM rows_arr)))
-        )
-    )) AS is_contract,
+    /* holder type — null when the chain has no contract-deployment data */
+    if((SELECT available FROM has_contracts),
+        toBool(t.1 IN (
+            SELECT address FROM {db_contracts:Identifier}.contracts
+            WHERE address IN (
+                SELECT arrayJoin(arrayMap(x -> x.1, (SELECT r FROM rows_arr)))
+            )
+        )),
+        NULL
+    ) AS is_contract,
 
     /* decimals and metadata */
     nullIf(m.name, '') AS name,

--- a/src/routes/holders/evm.ts
+++ b/src/routes/holders/evm.ts
@@ -38,7 +38,12 @@ const responseSchema = apiUsageResponseSchema.extend({
             value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- holder type --
-            is_contract: z.boolean(),
+            is_contract: z
+                .boolean()
+                .nullable()
+                .describe(
+                    'Whether the address is a smart contract. Returns null on chains where contract-deployment data is unavailable (currently hyperevm and avalanche, which are extracted via the firehose RPC poller).'
+                ),
 
             // -- contract --
             name: z.string().nullable(),

--- a/src/routes/holders/evm_native.sql
+++ b/src/routes/holders/evm_native.sql
@@ -38,6 +38,13 @@ rows_arr AS (
         ORDER BY balance DESC, address
         LIMIT {limit:UInt64} OFFSET {offset:UInt64}
     )
+),
+/* Chains extracted via the firehose RPC poller produce DETAILLEVEL_BASE blocks
+   with no Create-call records, so the contracts table is empty. Probe once
+   to decide whether is_contract can be answered. */
+has_contracts AS (
+    SELECT count() > 0 AS available
+    FROM (SELECT 1 FROM {db_contracts:Identifier}.contracts LIMIT 1)
 )
 SELECT
     /* timestamps */
@@ -52,13 +59,16 @@ SELECT
     toString(t.2) AS amount,
     t.2 / pow(10, m.decimals) AS value,
 
-    /* holder type */
-    toBool(t.1 IN (
-        SELECT address FROM {db_contracts:Identifier}.contracts
-        WHERE address IN (
-            SELECT arrayJoin(arrayMap(x -> x.1, (SELECT r FROM rows_arr)))
-        )
-    )) AS is_contract,
+    /* holder type — null when the chain has no contract-deployment data */
+    if((SELECT available FROM has_contracts),
+        toBool(t.1 IN (
+            SELECT address FROM {db_contracts:Identifier}.contracts
+            WHERE address IN (
+                SELECT arrayJoin(arrayMap(x -> x.1, (SELECT r FROM rows_arr)))
+            )
+        )),
+        NULL
+    ) AS is_contract,
 
     /* decimals and metadata */
     nullIf(m.name, '') AS name,

--- a/src/routes/holders/evm_native.ts
+++ b/src/routes/holders/evm_native.ts
@@ -33,7 +33,12 @@ const responseSchema = apiUsageResponseSchema.extend({
             value: z.number().describe('Decimal-scaled token amount (= amount / 10^decimals). Not a USD value.'),
 
             // -- holder type --
-            is_contract: z.boolean(),
+            is_contract: z
+                .boolean()
+                .nullable()
+                .describe(
+                    'Whether the address is a smart contract. Returns null on chains where contract-deployment data is unavailable (currently hyperevm and avalanche, which are extracted via the firehose RPC poller).'
+                ),
 
             // -- contract --
             name: z.string().nullable(),

--- a/src/routes/nft/collections_evm.sql
+++ b/src/routes/nft/collections_evm.sql
@@ -108,6 +108,9 @@ contract_creation AS (
     PREWHERE address = {contract: String}
 )
 SELECT
+    /* join_use_nulls = 1 (below) promotes these to NULL when the contracts
+       table has no row — chains extracted via the firehose RPC poller
+       (DETAILLEVEL_BASE) have no Create-call records. */
     timestamp AS contract_creation,
     creator AS contract_creator,
     contract,
@@ -121,3 +124,4 @@ SELECT
     network
 FROM combined
 LEFT JOIN contract_creation USING (contract)
+SETTINGS join_use_nulls = 1

--- a/src/routes/nft/collections_evm.ts
+++ b/src/routes/nft/collections_evm.ts
@@ -25,8 +25,16 @@ const querySchema = createQuerySchema({
 const responseSchema = apiUsageResponseSchema.extend({
     data: z.array(
         z.object({
-            contract_creation: dateTimeSchema,
-            contract_creator: evmAddressSchema,
+            contract_creation: dateTimeSchema
+                .nullable()
+                .describe(
+                    'Block timestamp when the contract was deployed. Returns null on chains where contract-deployment data is unavailable (currently hyperevm and avalanche, which are extracted via the firehose RPC poller).'
+                ),
+            contract_creator: evmAddressSchema
+                .nullable()
+                .describe(
+                    'Address that deployed the contract. Returns null on chains where contract-deployment data is unavailable (currently hyperevm and avalanche, which are extracted via the firehose RPC poller).'
+                ),
             contract: evmContractSchema,
             name: z.string().nullable(),
             symbol: z.string().nullable(),

--- a/src/routes/routes.sql.spec.ts
+++ b/src/routes/routes.sql.spec.ts
@@ -470,6 +470,40 @@ describe.skipIf(!DB_TESTS)('SQL queries', () => {
         expect(body.data.length).toBeGreaterThan(0);
     });
 
+    it('GET /v1/evm/holders is_contract is null when contracts table is empty', async () => {
+        const { response, body } = await fetchRoute(
+            `/v1/evm/holders?network=hyperevm&contract=0x5555555555555555555555555555555555555555&limit=1`
+        );
+        if (response.status === 400) return;
+        expect(response.status).toBe(200);
+        expect(body.data).toBeArray();
+        if (body.data.length > 0) {
+            expect(body.data[0].is_contract).toBeNull();
+        }
+    });
+
+    it('GET /v1/evm/holders is_contract is a boolean when contracts table is populated', async () => {
+        if (!hasEvmBalances || !hasEvmContracts) return;
+        const { response, body } = await fetchRoute(
+            `/v1/evm/holders?network=${evmNetwork}&contract=${EVM_CONTRACT_USDT_EXAMPLE}&limit=1`
+        );
+        expect(response.status).toBe(200);
+        expect(body.data).toBeArray();
+        if (body.data.length > 0) {
+            expect(typeof body.data[0].is_contract).toBe('boolean');
+        }
+    });
+
+    it('GET /v1/evm/holders/native is_contract is null when contracts table is empty', async () => {
+        const { response, body } = await fetchRoute(`/v1/evm/holders/native?network=hyperevm&limit=1`);
+        if (response.status === 400) return;
+        expect(response.status).toBe(200);
+        expect(body.data).toBeArray();
+        if (body.data.length > 0) {
+            expect(body.data[0].is_contract).toBeNull();
+        }
+    });
+
     // --- SVM Holders ---
     it('GET /v1/svm/holders', async () => {
         if (!hasSvmBalances) return;
@@ -639,6 +673,23 @@ describe.skipIf(!DB_TESTS)('SQL queries', () => {
         expect(response.status).toBe(200);
         expect(body.data).toBeArray();
         expect(body.data.length).toBeGreaterThan(0);
+        if (body.data.length > 0) {
+            expect(body.data[0].contract_creation).not.toBeNull();
+            expect(body.data[0].contract_creator).not.toBeNull();
+        }
+    });
+
+    it('GET /v1/evm/nft/collections contract_creation+creator are null when contracts table is empty', async () => {
+        const { response, body } = await fetchRoute(
+            `/v1/evm/nft/collections?network=avalanche&contract=0x3fed017ec0f5517cdf2e8a9a4156c64d74252146`
+        );
+        if (response.status === 400) return;
+        expect(response.status).toBe(200);
+        expect(body.data).toBeArray();
+        if (body.data.length > 0) {
+            expect(body.data[0].contract_creation).toBeNull();
+            expect(body.data[0].contract_creator).toBeNull();
+        }
     });
 
     it('GET /v1/evm/nft/holders', async () => {


### PR DESCRIPTION
## Summary

`/v1/evm/holders`, `/v1/evm/holders/native`, and `/v1/evm/nft/collections` previously returned misleading defaults on chains where the substreams `contracts` table is empty (currently **hyperevm** and **avalanche**, which are extracted via the firehose RPC poller in DETAILLEVEL_BASE mode):

- `is_contract` was `false` for every holder, mis-classifying actual contracts as EOAs.
- `contract_creation` was `1970-01-01 00:00:00` (epoch zero), and `contract_creator` was a 42-byte string of null bytes.

## Fix

- `holders/evm.sql`, `holders/evm_native.sql` — add a small `has_contracts` CTE that probes the table; the `is_contract` expression returns `NULL` when the probe is empty, real boolean otherwise.
- `nft/collections_evm.sql` — `SETTINGS join_use_nulls = 1` so the `LEFT JOIN contract_creation` returns proper `NULL` for missing rows.
- Zod response schemas updated: `is_contract`, `contract_creation`, `contract_creator` are now `.nullable()` with descriptions explaining the per-chain semantics.
- Auto-detection: no per-chain config to maintain; any future chain whose contracts table is empty inherits the same fallback.

## Verification

Tested end-to-end against the local dev server pointed at cluster c:

| Endpoint | mainnet | hyperevm / avalanche |
|---|---|---|
| `/v1/evm/holders` | `is_contract: false` (bool) | `is_contract: null` |
| `/v1/evm/holders/native` | `is_contract: true` (bool) | `is_contract: null` |
| `/v1/evm/nft/collections` | `contract_creation: "2021-07-22 12:26:01"`, `contract_creator: "0xe9da25..."` | both `null` |

New `routes.sql.spec.ts` cases assert the null behavior on hyperevm/avalanche and the preserved boolean/string behavior on mainnet.

Refs the firehose extraction limitation discussed with infra (RPC-poller chains are DETAILLEVEL_BASE, same situation as avalanche).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)