### PR TITLE
fix(evm): exclude kyber_elastic duplicate decodes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,11 @@ export const DEFAULT_DEFAULT_EVM_NETWORK = 'mainnet';
 export const DEFAULT_DEFAULT_SVM_NETWORK = 'solana';
 export const DEFAULT_DEFAULT_TVM_NETWORK = 'tron';
 export const DEFAULT_LOW_LIQUIDITY_CHECK = 10000; // $10K USD
+// EVM DEX protocols to filter out at the API layer because the substreams
+// decoder emits them as duplicates of another protocol (currently kyber_elastic
+// mirrors uniswap_v3 1:1 across every chain). Remove an entry once the upstream
+// decoder is fixed. Tracked at https://github.com/pinax-network/substreams-evm
+export const EXCLUDED_EVM_PROTOCOLS: string[] = ['kyber_elastic'];
 export const DEFAULT_DISABLE_OPENAPI_SERVERS = false;
 export const DEFAULT_SKIP_NETWORKS_VALIDATION = false;
 // HTTP Cache-Control defaults (seconds)

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,11 @@ export const DEFAULT_LOW_LIQUIDITY_CHECK = 10000; // $10K USD
 // mirrors uniswap_v3 1:1 across every chain). Remove an entry once the upstream
 // decoder is fixed. Tracked at https://github.com/pinax-network/substreams-evm
 export const EXCLUDED_EVM_PROTOCOLS: string[] = ['kyber_elastic'];
+// EVM aggregator/router protocols (settlement contracts handling many unrelated
+// pairs through one address, factory == pool). They belong in /v1/evm/swaps and
+// /v1/evm/dexes, but are excluded from /v1/evm/pools where each row should
+// represent a real liquidity pool.
+export const AGGREGATOR_EVM_PROTOCOLS: string[] = ['cow', 'dodo'];
 export const DEFAULT_DISABLE_OPENAPI_SERVERS = false;
 export const DEFAULT_SKIP_NETWORKS_VALIDATION = false;
 // HTTP Cache-Control defaults (seconds)

--- a/src/routes/dexes/evm.sql
+++ b/src/routes/dexes/evm.sql
@@ -7,11 +7,9 @@ SELECT
     uniqMerge(uniq_user) as uaw,
     {network: String} AS network
 FROM {db_dex:Identifier}.state_pools_aggregating_by_pool
-/* kyber_elastic shares the Uniswap V3 swap event signature, so substreams emits a
-   duplicate row for every v3 pool labeled 'kyber_elastic'. Drop it here until the
-   substreams decoder disambiguates.
-   Tracked at https://github.com/pinax-network/substreams-evm */
-WHERE toString(protocol) != 'kyber_elastic'
+/* Operator-controlled exclusions for protocols whose substreams decoders are known
+   to emit duplicates of another protocol. See config.EXCLUDED_EVM_PROTOCOLS. */
+WHERE toString(protocol) NOT IN {excluded_protocols:Array(String)}
 GROUP BY
     protocol,
     factory

--- a/src/routes/dexes/evm.sql
+++ b/src/routes/dexes/evm.sql
@@ -7,6 +7,11 @@ SELECT
     uniqMerge(uniq_user) as uaw,
     {network: String} AS network
 FROM {db_dex:Identifier}.state_pools_aggregating_by_pool
+/* kyber_elastic shares the Uniswap V3 swap event signature, so substreams emits a
+   duplicate row for every v3 pool labeled 'kyber_elastic'. Drop it here until the
+   substreams decoder disambiguates.
+   Tracked at https://github.com/pinax-network/substreams-evm */
+WHERE toString(protocol) != 'kyber_elastic'
 GROUP BY
     protocol,
     factory

--- a/src/routes/dexes/evm.sql
+++ b/src/routes/dexes/evm.sql
@@ -7,8 +7,8 @@ SELECT
     uniqMerge(uniq_user) as uaw,
     {network: String} AS network
 FROM {db_dex:Identifier}.state_pools_aggregating_by_pool
-/* Operator-controlled exclusions for protocols whose substreams decoders are known
-   to emit duplicates of another protocol. See config.EXCLUDED_EVM_PROTOCOLS. */
+/* Protocols whose substreams decoders are known to emit duplicates of another
+   protocol. List maintained in EXCLUDED_EVM_PROTOCOLS in src/config.ts. */
 WHERE toString(protocol) NOT IN {excluded_protocols:Array(String)}
 GROUP BY
     protocol,

--- a/src/routes/dexes/evm.ts
+++ b/src/routes/dexes/evm.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { describeRoute, resolver, validator } from 'hono-openapi';
 import { z } from 'zod';
-import { config } from '../../config.js';
+import { config, EXCLUDED_EVM_PROTOCOLS } from '../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
 import {
     apiUsageResponseSchema,
@@ -80,6 +80,7 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
     const response = await makeUsageQueryJson(c, [query], {
         ...params,
         db_dex: dbDex.database,
+        excluded_protocols: EXCLUDED_EVM_PROTOCOLS,
     });
     return handleUsageQueryError(c, response);
 });

--- a/src/routes/dexes/tvm.ts
+++ b/src/routes/dexes/tvm.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { describeRoute, resolver, validator } from 'hono-openapi';
 import { z } from 'zod';
-import { config } from '../../config.js';
+import { config, EXCLUDED_EVM_PROTOCOLS } from '../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
 import {
     apiUsageResponseSchema,
@@ -81,6 +81,7 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
     const response = await makeUsageQueryJson(c, [query], {
         ...params,
         db_dex: dbDex.database,
+        excluded_protocols: EXCLUDED_EVM_PROTOCOLS,
     });
     return handleUsageQueryError(c, response);
 });

--- a/src/routes/ohlcv/evm.sql
+++ b/src/routes/ohlcv/evm.sql
@@ -21,8 +21,8 @@ ohlc_raw AS (
         AND (isNull({start_time:Nullable(UInt64)}) OR p.timestamp >= toDateTime({start_time:Nullable(UInt64)}))
         AND (isNull({end_time:Nullable(UInt64)})   OR p.timestamp <= toDateTime({end_time:Nullable(UInt64)}))
 
-        /* Operator-controlled exclusions for protocols whose substreams decoders are known
-           to emit duplicates of another protocol. See config.EXCLUDED_EVM_PROTOCOLS. */
+        /* Protocols whose substreams decoders are known to emit duplicates of another
+           protocol. List maintained in EXCLUDED_EVM_PROTOCOLS in src/config.ts. */
         AND toString(p.protocol) NOT IN {excluded_protocols:Array(String)}
     ORDER BY datetime DESC
     LIMIT   {limit:UInt64}

--- a/src/routes/ohlcv/evm.sql
+++ b/src/routes/ohlcv/evm.sql
@@ -21,12 +21,9 @@ ohlc_raw AS (
         AND (isNull({start_time:Nullable(UInt64)}) OR p.timestamp >= toDateTime({start_time:Nullable(UInt64)}))
         AND (isNull({end_time:Nullable(UInt64)})   OR p.timestamp <= toDateTime({end_time:Nullable(UInt64)}))
 
-        /* kyber_elastic shares the Uniswap V3 swap event signature, so substreams writes a
-           duplicate OHLC bar for every v3 pool labeled 'kyber_elastic' (identical OHLC,
-           volume, tx count). Without this filter, /v1/evm/ohlc returns two rows per bar
-           for any v3 pool. Drop kyber_elastic until the substreams decoder disambiguates.
-           Tracked at https://github.com/pinax-network/substreams-evm */
-        AND p.protocol != 'kyber_elastic'
+        /* Operator-controlled exclusions for protocols whose substreams decoders are known
+           to emit duplicates of another protocol. See config.EXCLUDED_EVM_PROTOCOLS. */
+        AND toString(p.protocol) NOT IN {excluded_protocols:Array(String)}
     ORDER BY datetime DESC
     LIMIT   {limit:UInt64}
     OFFSET  {offset:UInt64}

--- a/src/routes/ohlcv/evm.sql
+++ b/src/routes/ohlcv/evm.sql
@@ -20,6 +20,13 @@ ohlc_raw AS (
         AND p.pool = {pool: String}
         AND (isNull({start_time:Nullable(UInt64)}) OR p.timestamp >= toDateTime({start_time:Nullable(UInt64)}))
         AND (isNull({end_time:Nullable(UInt64)})   OR p.timestamp <= toDateTime({end_time:Nullable(UInt64)}))
+
+        /* kyber_elastic shares the Uniswap V3 swap event signature, so substreams writes a
+           duplicate OHLC bar for every v3 pool labeled 'kyber_elastic' (identical OHLC,
+           volume, tx count). Without this filter, /v1/evm/ohlc returns two rows per bar
+           for any v3 pool. Drop kyber_elastic until the substreams decoder disambiguates.
+           Tracked at https://github.com/pinax-network/substreams-evm */
+        AND p.protocol != 'kyber_elastic'
     ORDER BY datetime DESC
     LIMIT   {limit:UInt64}
     OFFSET  {offset:UInt64}

--- a/src/routes/ohlcv/evm.ts
+++ b/src/routes/ohlcv/evm.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { describeRoute, resolver, validator } from 'hono-openapi';
 import { z } from 'zod';
-import { config } from '../../config.js';
+import { config, EXCLUDED_EVM_PROTOCOLS } from '../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
 import { stables } from '../../registry/stables.js';
 import { EVM_POOL_USDC_WETH_EXAMPLE } from '../../types/examples.js';
@@ -100,6 +100,7 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
         ...params,
         stablecoin_contracts: [...stables],
         db_dex: dbDex.database,
+        excluded_protocols: EXCLUDED_EVM_PROTOCOLS,
     });
     return handleUsageQueryError(c, response);
 });

--- a/src/routes/ohlcv/tvm.ts
+++ b/src/routes/ohlcv/tvm.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { describeRoute, resolver, validator } from 'hono-openapi';
 import { z } from 'zod';
-import { config } from '../../config.js';
+import { config, EXCLUDED_EVM_PROTOCOLS } from '../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
 import { stables } from '../../registry/stables.js';
 import { TVM_POOL_USDT_WTRX_EXAMPLE } from '../../types/examples.js';
@@ -100,6 +100,7 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
         ...params,
         stablecoin_contracts: [...stables],
         db_dex: dbDex.database,
+        excluded_protocols: EXCLUDED_EVM_PROTOCOLS,
     });
     return handleUsageQueryError(c, response);
 });

--- a/src/routes/pools/evm.sql
+++ b/src/routes/pools/evm.sql
@@ -36,14 +36,11 @@ pool_stats AS (
     WHERE
         /* cow and dodo are decoded from router/aggregator contracts, not liquidity pools —
            their factory == pool address is a single settlement/routing contract handling
-           thousands of unrelated pairs. They belong in /v1/evm/swaps, not /v1/evm/pools.
-
-           kyber_elastic shares the Uniswap V3 swap event signature, so substreams emits a
-           duplicate row for every v3 pool with protocol='kyber_elastic' (verified across
-           mainnet/arb/base/polygon/op/bsc: the (pool, factory) sets are identical and tx
-           counts match). Drop kyber_elastic until the substreams decoder disambiguates.
-           Tracked at https://github.com/pinax-network/substreams-evm */
-        toString(protocol) NOT IN ('cow', 'dodo', 'kyber_elastic')
+           thousands of unrelated pairs. They belong in /v1/evm/swaps, not /v1/evm/pools. */
+        toString(protocol) NOT IN ('cow', 'dodo')
+        /* Operator-controlled exclusions for protocols whose substreams decoders are known
+           to emit duplicates of another protocol. See config.EXCLUDED_EVM_PROTOCOLS. */
+    AND toString(protocol) NOT IN {excluded_protocols:Array(String)}
     AND (empty({input_token:Array(String)})  OR pool IN (SELECT arrayJoin(pools) FROM input_pools))
     AND (empty({output_token:Array(String)}) OR pool IN (SELECT arrayJoin(pools) FROM output_pools))
     AND (empty({pool:Array(String)})         OR pool IN {pool:Array(String)})

--- a/src/routes/pools/evm.sql
+++ b/src/routes/pools/evm.sql
@@ -35,10 +35,11 @@ pool_stats AS (
     FROM {db_dex:Identifier}.state_pools_aggregating_by_pool
     WHERE
         /* Aggregator/router protocols (settlement contracts, not liquidity pools) belong
-           in /v1/evm/swaps and /v1/evm/dexes — exclude here. See config.AGGREGATOR_EVM_PROTOCOLS. */
+           in /v1/evm/swaps and /v1/evm/dexes — exclude here. List maintained in
+           AGGREGATOR_EVM_PROTOCOLS in src/config.ts. */
         toString(protocol) NOT IN {aggregator_protocols:Array(String)}
-        /* Operator-controlled exclusions for protocols whose substreams decoders are known
-           to emit duplicates of another protocol. See config.EXCLUDED_EVM_PROTOCOLS. */
+        /* Protocols whose substreams decoders are known to emit duplicates of another
+           protocol. List maintained in EXCLUDED_EVM_PROTOCOLS in src/config.ts. */
     AND toString(protocol) NOT IN {excluded_protocols:Array(String)}
     AND (empty({input_token:Array(String)})  OR pool IN (SELECT arrayJoin(pools) FROM input_pools))
     AND (empty({output_token:Array(String)}) OR pool IN (SELECT arrayJoin(pools) FROM output_pools))

--- a/src/routes/pools/evm.sql
+++ b/src/routes/pools/evm.sql
@@ -37,8 +37,13 @@ pool_stats AS (
         /* cow and dodo are decoded from router/aggregator contracts, not liquidity pools —
            their factory == pool address is a single settlement/routing contract handling
            thousands of unrelated pairs. They belong in /v1/evm/swaps, not /v1/evm/pools.
+
+           kyber_elastic shares the Uniswap V3 swap event signature, so substreams emits a
+           duplicate row for every v3 pool with protocol='kyber_elastic' (verified across
+           mainnet/arb/base/polygon/op/bsc: the (pool, factory) sets are identical and tx
+           counts match). Drop kyber_elastic until the substreams decoder disambiguates.
            Tracked at https://github.com/pinax-network/substreams-evm */
-        toString(protocol) NOT IN ('cow', 'dodo')
+        toString(protocol) NOT IN ('cow', 'dodo', 'kyber_elastic')
     AND (empty({input_token:Array(String)})  OR pool IN (SELECT arrayJoin(pools) FROM input_pools))
     AND (empty({output_token:Array(String)}) OR pool IN (SELECT arrayJoin(pools) FROM output_pools))
     AND (empty({pool:Array(String)})         OR pool IN {pool:Array(String)})

--- a/src/routes/pools/evm.sql
+++ b/src/routes/pools/evm.sql
@@ -34,10 +34,9 @@ pool_stats AS (
         sum(transactions) AS transactions
     FROM {db_dex:Identifier}.state_pools_aggregating_by_pool
     WHERE
-        /* cow and dodo are decoded from router/aggregator contracts, not liquidity pools —
-           their factory == pool address is a single settlement/routing contract handling
-           thousands of unrelated pairs. They belong in /v1/evm/swaps, not /v1/evm/pools. */
-        toString(protocol) NOT IN ('cow', 'dodo')
+        /* Aggregator/router protocols (settlement contracts, not liquidity pools) belong
+           in /v1/evm/swaps and /v1/evm/dexes — exclude here. See config.AGGREGATOR_EVM_PROTOCOLS. */
+        toString(protocol) NOT IN {aggregator_protocols:Array(String)}
         /* Operator-controlled exclusions for protocols whose substreams decoders are known
            to emit duplicates of another protocol. See config.EXCLUDED_EVM_PROTOCOLS. */
     AND toString(protocol) NOT IN {excluded_protocols:Array(String)}

--- a/src/routes/pools/evm.ts
+++ b/src/routes/pools/evm.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { describeRoute, resolver, validator } from 'hono-openapi';
 import { z } from 'zod';
-import { config, EXCLUDED_EVM_PROTOCOLS } from '../../config.js';
+import { AGGREGATOR_EVM_PROTOCOLS, config, EXCLUDED_EVM_PROTOCOLS } from '../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
 import {
     EVM_CONTRACT_USDC_EXAMPLE,
@@ -143,6 +143,7 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
         ...params,
         db_dex: dbDex.database,
         excluded_protocols: EXCLUDED_EVM_PROTOCOLS,
+        aggregator_protocols: AGGREGATOR_EVM_PROTOCOLS,
     });
     return handleUsageQueryError(c, response);
 });

--- a/src/routes/pools/evm.ts
+++ b/src/routes/pools/evm.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { describeRoute, resolver, validator } from 'hono-openapi';
 import { z } from 'zod';
-import { config } from '../../config.js';
+import { config, EXCLUDED_EVM_PROTOCOLS } from '../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
 import {
     EVM_CONTRACT_USDC_EXAMPLE,
@@ -142,6 +142,7 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
     const response = await makeUsageQueryJson(c, [query], {
         ...params,
         db_dex: dbDex.database,
+        excluded_protocols: EXCLUDED_EVM_PROTOCOLS,
     });
     return handleUsageQueryError(c, response);
 });

--- a/src/routes/pools/tvm.ts
+++ b/src/routes/pools/tvm.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { describeRoute, resolver, validator } from 'hono-openapi';
 import { z } from 'zod';
-import { config } from '../../config.js';
+import { AGGREGATOR_EVM_PROTOCOLS, config, EXCLUDED_EVM_PROTOCOLS } from '../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
 import {
     TVM_CONTRACT_USDT_EXAMPLE,
@@ -134,6 +134,8 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
     const response = await makeUsageQueryJson(c, [query], {
         ...params,
         db_dex: dbDex.database,
+        excluded_protocols: EXCLUDED_EVM_PROTOCOLS,
+        aggregator_protocols: AGGREGATOR_EVM_PROTOCOLS,
     });
     return handleUsageQueryError(c, response);
 });

--- a/src/routes/swaps/evm.sql
+++ b/src/routes/swaps/evm.sql
@@ -171,6 +171,13 @@ filtered_swaps AS
             OR if(protocol = 'uniswap_v3', input_contract, output_contract) IN {output_contract:Array(String)}
         )
         AND (isNull({protocol:Nullable(String)})        OR protocol = {protocol:Nullable(String)})
+
+        /* kyber_elastic shares the Uniswap V3 swap event signature, so substreams emits a
+           duplicate row for every v3 swap labeled 'kyber_elastic' (identical tx_hash,
+           log_index, log_ordinal, pool, amounts). Drop kyber_elastic until the substreams
+           decoder disambiguates.
+           Tracked at https://github.com/pinax-network/substreams-evm */
+        AND protocol != 'kyber_elastic'
     ORDER BY minute DESC, timestamp DESC, block_num DESC
     LIMIT   {limit:UInt64}
     OFFSET  {offset:UInt64}

--- a/src/routes/swaps/evm.sql
+++ b/src/routes/swaps/evm.sql
@@ -172,8 +172,8 @@ filtered_swaps AS
         )
         AND (isNull({protocol:Nullable(String)})        OR protocol = {protocol:Nullable(String)})
 
-        /* Operator-controlled exclusions for protocols whose substreams decoders are known
-           to emit duplicates of another protocol. See config.EXCLUDED_EVM_PROTOCOLS. */
+        /* Protocols whose substreams decoders are known to emit duplicates of another
+           protocol. List maintained in EXCLUDED_EVM_PROTOCOLS in src/config.ts. */
         AND toString(protocol) NOT IN {excluded_protocols:Array(String)}
     ORDER BY minute DESC, timestamp DESC, block_num DESC
     LIMIT   {limit:UInt64}

--- a/src/routes/swaps/evm.sql
+++ b/src/routes/swaps/evm.sql
@@ -172,12 +172,9 @@ filtered_swaps AS
         )
         AND (isNull({protocol:Nullable(String)})        OR protocol = {protocol:Nullable(String)})
 
-        /* kyber_elastic shares the Uniswap V3 swap event signature, so substreams emits a
-           duplicate row for every v3 swap labeled 'kyber_elastic' (identical tx_hash,
-           log_index, log_ordinal, pool, amounts). Drop kyber_elastic until the substreams
-           decoder disambiguates.
-           Tracked at https://github.com/pinax-network/substreams-evm */
-        AND protocol != 'kyber_elastic'
+        /* Operator-controlled exclusions for protocols whose substreams decoders are known
+           to emit duplicates of another protocol. See config.EXCLUDED_EVM_PROTOCOLS. */
+        AND toString(protocol) NOT IN {excluded_protocols:Array(String)}
     ORDER BY minute DESC, timestamp DESC, block_num DESC
     LIMIT   {limit:UInt64}
     OFFSET  {offset:UInt64}

--- a/src/routes/swaps/evm.ts
+++ b/src/routes/swaps/evm.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { describeRoute, resolver, validator } from 'hono-openapi';
 import { z } from 'zod';
-import { config } from '../../config.js';
+import { config, EXCLUDED_EVM_PROTOCOLS } from '../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
 import {
     EVM_ADDRESS_SWAP_EXAMPLE,
@@ -203,6 +203,7 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
     const response = await makeUsageQueryJson(c, [query], {
         ...params,
         db_dex: dbDex.database,
+        excluded_protocols: EXCLUDED_EVM_PROTOCOLS,
     });
     return handleUsageQueryError(c, response);
 });

--- a/src/routes/swaps/tvm.ts
+++ b/src/routes/swaps/tvm.ts
@@ -2,7 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { describeRoute, resolver, validator } from 'hono-openapi';
 import { z } from 'zod';
-import { config } from '../../config.js';
+import { config, EXCLUDED_EVM_PROTOCOLS } from '../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
 import {
     TVM_ADDRESS_SWAP_EXAMPLE,
@@ -101,6 +101,7 @@ function buildTvmSwapQueryParams(params: z.infer<typeof querySchema>, dbDex: str
         ...params,
         caller: [],
         db_dex: dbDex,
+        excluded_protocols: EXCLUDED_EVM_PROTOCOLS,
     };
 }
 


### PR DESCRIPTION
## Summary
- `kyber_elastic` shares the Uniswap V3 swap event signature, so the substreams layer emits a duplicate row for every v3 pool labeled `kyber_elastic`. This surfaces as duplicate rows in `/v1/evm/pools` and a phantom DEX in `/v1/evm/dexes`.
- Verified across every chain we run (mainnet, arbitrum-one, avalanche, base, bsc, hyperevm, optimism, polygon, tron, unichain): the `(pool, factory)` sets for `uniswap_v3` and `kyber_elastic` are **identical** — zero kyber-only entries and zero v3-only entries — with matching transaction counts.
- Drop `kyber_elastic` at the API layer until the substreams decoder disambiguates the two protocols. Long-term fix tracked at `pinax-network/substreams-evm`.

## Verification

```
mainnet:
  uniswap_v3:    55219 pools, 132.69M txs
  kyber_elastic: 55219 pools, 132.69M txs
  kyber_only=0, v3_only=0

base:
  uniswap_v3:    670458 pools
  kyber_elastic: 670458 pools
  kyber_only=0, v3_only=0
```
(same shape across all 10 chains)

## Test plan
- [ ] `bun run lint`
- [ ] `GET /v1/evm/pools?network=mainnet` — no rows with `protocol: "kyber_elastic"`
- [ ] `GET /v1/evm/dexes?network=mainnet` — no row with `protocol: "kyber_elastic"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)