### PR TITLE
perf+fix(svm): faster pools/holders/balances + pagination & determinism correctness fixes

### DIFF
--- a/docs/proposals/svm-finer-grained-indexing.md
+++ b/docs/proposals/svm-finer-grained-indexing.md
@@ -1,0 +1,205 @@
+# Proposal: finer-grained indexing for SVM `swaps` / `transfers` (and large-owner `balances`)
+
+**Status:** draft / for discussion
+**Author:** perf audit (May 2026), follow-up to PR #556
+**Scope:** DB-side schema changes on `solana:svm-dex@*.swaps`, `solana:svm-transfers@*.transfers`, and (secondary) `solana:svm-balances@*.balances_by_account`. No application changes are required for the index option; the projection/MV options pair with small query rewrites.
+
+---
+
+## 1. Problem
+
+`/v1/svm/swaps` and `/v1/svm/transfers` filter on high-cardinality non-key columns
+(`input_mint`, `output_mint`, `user`, `amm_pool`, `fee_payer`, `signer`, … / for transfers
+`source`, `destination`, `mint`, `authority`, …) and return the most recent N rows.
+
+Both tables are:
+
+```
+ORDER BY (timestamp, block_num, transaction_index, instruction_index)
+-- skip indexes: minmax on timestamp/block_num/amount only
+-- one PROJECTION prj_<col>_by_minute per filter column: SELECT <col>, minute GROUP BY <col>, minute
+```
+
+Because no filter column is in the sort key and none has a granule-level skip index, the
+queries can't jump to matching rows. The current workaround (`swaps/svm.sql`,
+`transfers/svm.sql`) uses the `prj_<col>_by_minute` projections to find the **minutes** each
+filter appears in, intersects them, and restricts the main timestamp scan to those minutes.
+
+This has two problems (see PR #556 discussion):
+
+1. **Correctness — under-return.** Multi-filter queries cap the candidate set at
+   `(limit+offset)*10` minutes (the `*10` heuristic). Minute-level presence ≠ row-level
+   co-match, so when filters co-occur sparsely the capped window can hold fewer than `limit`
+   actual matches and older matches are silently dropped.
+2. **Performance — minute coarseness.** A minute holds ~12,675 swaps (~1.5 granules). A
+   temporally-sparse token (e.g. `Fe5c…` ≈ 1 swap/min) has ~1 matching row per granule, but the
+   scan reads the **whole** candidate minutes — ~10–100M rows to surface 10 results (2–10 s).
+
+A query-only fix was prototyped and rejected: removing/raising the cap makes the
+selective-multi-filter case (e.g. `input_mint=Fe5c + output_mint=wSOL`) read the driver
+filter's full minute footprint and **time out** (9 s → >120 s). Correct-and-fast is not
+achievable while "minute" is the finest pruning unit. This needs a schema change.
+
+---
+
+## 2. Recommended fix — `bloom_filter` data-skipping indexes (primary)
+
+Add per-granule `bloom_filter` skip indexes on the high-cardinality filter columns, then
+**delete the entire minute machinery** and let the queries be a plain ordered scan.
+
+### DDL (swaps; mirror for transfers)
+
+```sql
+ALTER TABLE `solana:svm-dex@v0.5.2`.swaps
+  ADD INDEX idx_bf_input_mint  input_mint  TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX idx_bf_output_mint output_mint TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX idx_bf_user        user        TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX idx_bf_amm_pool    amm_pool    TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX idx_bf_fee_payer   fee_payer   TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX idx_bf_signer      signer      TYPE bloom_filter(0.01) GRANULARITY 1;
+-- signature: already covered by prj_signature_by_timestamp (and is unique) — optional bloom.
+-- program_id / protocol: low-cardinality; a bloom is wasteful. Use TYPE set(0) or leave to scan.
+
+-- Backfill existing parts (one MATERIALIZE per index; runs as a mutation):
+ALTER TABLE … MATERIALIZE INDEX idx_bf_input_mint;
+-- …repeat per index…
+
+-- transfers analog: source, destination, mint, authority, fee_payer, signer
+```
+
+### Resulting query shape (replaces ~130 lines of minute logic)
+
+```sql
+SELECT … FROM swaps
+WHERE (isNull({start_time}) OR timestamp >= …)         -- unchanged time bounds
+  AND (isNull({end_time})   OR timestamp <= …)
+  AND (empty({input_mint:Array(String)})  OR input_mint  IN {input_mint:Array(String)})
+  AND (empty({output_mint:Array(String)}) OR output_mint IN {output_mint:Array(String)})
+  AND …all other filters…
+ORDER BY timestamp DESC, block_num DESC, transaction_index DESC, instruction_index DESC
+LIMIT {limit} OFFSET {offset}
+```
+
+The `active_filters`, `minutes_union`, `filtered_minutes`/`candidate_minutes`, and the `*10`
+cap all go away.
+
+### Why it works
+
+- Base table is sorted by `timestamp`; ClickHouse reads granules newest→oldest
+  (`optimize_read_in_order`) and **early-terminates** at `offset+limit` matches.
+- The bloom indexes let it **skip granules** that can't contain the requested filter value(s).
+  A granule is read only if it might contain *all* active filter values → tight for
+  multi-filter.
+- Per-granule (8192 rows) is strictly finer than per-minute (~1.5 granules) and, crucially,
+  there is **no cap** → no under-return. For a sparse token it reads ~1 granule per candidate
+  row and stops once `limit` co-matches are found.
+
+### Cost
+
+- **Storage:** `bloom_filter(0.01)` ≈ low single-digit % of a column's compressed size; six
+  indexes total a small fraction of the table — far cheaper than any projection option below.
+- **Write:** each index is updated on insert/merge; modest, proportional to index size.
+- **App:** the query simplification removes complexity and the `*10` correctness caveat.
+
+### ⚠️ Must validate before adopting
+
+The one assumption to confirm on a scratch copy: that ClickHouse 26.x combines
+`bloom_filter` skip + `optimize_read_in_order` (timestamp DESC) + `LIMIT` early-termination
+for this table. Validation plan in §5. If early-termination does **not** kick in (scan walks
+all granules despite the index), fall back to §3.
+
+---
+
+## 3. Alternative — per-driver-column projection ordered by `(col, timestamp)` (fallback)
+
+If bloom + read-in-order does not early-terminate well, add projections that physically
+re-sort the data by each high-value driver column, carrying the **filter columns + PK** (not
+the heavy payload columns), so a filtered top-N resolves inside the projection and only the
+surviving ≤`limit` rows are fetched from the base table.
+
+```sql
+ALTER TABLE swaps ADD PROJECTION prj_input_mint
+(
+  SELECT input_mint, output_mint, user, amm, amm_pool, program_id, protocol,
+         fee_payer, signer, timestamp, block_num, transaction_index, instruction_index
+  ORDER BY input_mint, timestamp
+);
+-- repeat for output_mint, user, amm_pool (the common drivers)
+```
+
+Query (2-step): read PKs of matching rows from the driver projection (tight `(col, timestamp)`
+range, all filters applied, `ORDER BY timestamp DESC LIMIT offset+limit`), then fetch full
+rows from the base table by those PKs.
+
+- **Pro:** guaranteed tight (doesn't rely on skip-index early-termination); exact, no
+  under-return.
+- **Con:** each projection ≈ 40–70% of base size (filter columns are most of the row by
+  count); 4 drivers ≈ 2–3× base storage; higher write amplification; needs the query rewrite.
+
+Prefer §2 unless validation forces this.
+
+---
+
+## 4. Secondary — large-owner `balances` (`balances_by_account`)
+
+Separate but related hot spot (PR #556 flagged it): `/v1/svm/balances` resolves an owner's
+accounts then point-looks-up `balances_by_account` (keyed by `account`). An owner's accounts
+are scattered across the 2.8B-row table, so each costs ~10 granules; large/whale owners
+(10k–2.5M accounts) read 100M+ rows and time out. `balances_by_account` has **no `owner`
+column**, so a projection on it can't co-locate by owner.
+
+Fix is a denormalized, owner-keyed materialized view:
+
+```sql
+CREATE MATERIALIZED VIEW balances_by_owner
+ENGINE = ReplacingMergeTree(block_num)
+ORDER BY (owner, mint, account)
+AS SELECT o.owner AS owner, b.account, b.program_id, b.mint, b.amount, b.decimals,
+          b.block_num, b.timestamp
+   FROM balances_by_account AS b
+   INNER JOIN owner_view AS o USING (account);   -- shape TBD; needs the current-owner join
+```
+
+Then `/v1/svm/balances` reads `WHERE owner IN (…)` as a contiguous PK range (~1 granule per
+owner instead of ~10 per account). Caveats: keeping it consistent with owner reassignment /
+account close (the dedup logic added in PR #556 must be reflected), and the MV's own
+maintenance cost. This is a larger data-modeling change than §2/§3 and warrants its own
+design pass — listed here for completeness, not bundled.
+
+---
+
+## 5. Validation plan (do this before any prod ALTER)
+
+On a scratch table (copy a recent slice, e.g. last 30 days of `swaps`):
+
+1. `CREATE TABLE swaps_test AS swaps`; add the §2 bloom indexes; `INSERT` the slice (or
+   `MATERIALIZE INDEX`).
+2. Run the simplified §2 query for representative cases and check `EXPLAIN indexes=1` +
+   `rows_read`/elapsed:
+   - selective single: `input_mint=<rare token>`
+   - **selective multi (the regressor): `input_mint=Fe5c… + output_mint=wSOL`** — must be
+     correct (full result) and fast (target: << current 9 s, ideally <1 s, reading ~the
+     driver's matching granules not whole minutes).
+   - non-selective multi: `input_mint=wSOL + protocol=raydium_amm_v4` — must stay fast (dense).
+   - deep `offset` and an old-data filter (value that stopped trading) — confirm
+     early-termination still jumps to the old granules.
+3. Confirm result sets match the current endpoint for cases where the current path is correct,
+   and **return more** for a constructed under-return case.
+4. Measure index storage and merge-time delta.
+
+Only promote to prod (`ALTER TABLE … ADD INDEX` + `MATERIALIZE INDEX`, online mutation) if (2)
+shows early-termination working.
+
+---
+
+## 6. Recommendation
+
+1. Validate §2 (bloom skip indexes) on a scratch table — cheapest, simplest, removes the
+   `*10` correctness caveat and the minute machinery entirely.
+2. If early-termination doesn't engage, adopt §3 (driver projections) for `input_mint`,
+   `output_mint`, `user`, `amm_pool`.
+3. Track §4 (`balances_by_owner` MV) separately.
+
+Until one of these lands, keep `swaps/svm.sql` / `transfers/svm.sql` as-is — the `*10`
+heuristic is a reasonable speed/correctness compromise and the prototyped query-only rewrite
+regressed the common selective-multi-filter case.

--- a/src/routes/balances/svm.sql
+++ b/src/routes/balances/svm.sql
@@ -1,28 +1,67 @@
-WITH owners AS (
-    SELECT owner, account
-    FROM {db_accounts:Identifier}.owner_state AS o
-    WHERE owner IN {owner:Array(String)}
-),
-balances AS
+WITH
+/* Accounts CURRENTLY owned by the requested owner(s), deduped to one row each.
+   The inner subquery finds every account ever associated with the owner (tight
+   lookup via the prj_owner projection, ORDER BY owner), then argMax(owner, version)
+   resolves each account's current owner (matching owner_view) and HAVING keeps only
+   those still owned by the requested owner(s). The previous version read owner_state
+   raw, returning every historical (owner, account) version — so a closed account
+   (latest owner '') or one reassigned to another owner would still be attributed to
+   the requested owner, and unmerged duplicate versions would duplicate in the join.
+   Bound as a cached scalar so the owner_state reads happen once. */
 (
+    SELECT groupArray((account, owner)) FROM (
+        SELECT account, argMax(owner, version) AS owner
+        FROM {db_accounts:Identifier}.owner_state
+        WHERE account IN (
+            SELECT account
+            FROM {db_accounts:Identifier}.owner_state
+            WHERE owner IN {owner:Array(String)}
+        )
+        GROUP BY account
+        HAVING owner IN {owner:Array(String)}
+    )
+) AS owners_arr,
+owners AS (
+    SELECT t.1 AS account, t.2 AS owner
+    FROM (SELECT arrayJoin(owners_arr) AS t)
+),
+/* Resolve the balance page (filters + ORDER/LIMIT) and bind it as a cached scalar so
+   balances_by_account is read exactly once. Previously the `balances` CTE was inlined
+   at each reference — the final SELECT plus `mints` (which feeds both `decimals` and
+   `metadata`) — so balances_by_account (and the owner lookups it depends on) were
+   re-scanned ~3x. Now only the ~{limit} paged rows flow downstream. */
+(
+    SELECT groupArray((block_num, timestamp, program_id, account, amount, mint, decimals)) FROM (
+        SELECT
+            max(b.block_num) AS block_num,
+            max(b.timestamp) AS timestamp,
+            program_id,
+            account,
+            argMax(b.amount, b.block_num) AS amount,
+            mint,
+            decimals
+        FROM {db_balances:Identifier}.balances_by_account AS b
+        WHERE b.account IN (SELECT account FROM owners)
+            AND (empty({token_account:Array(String)}) OR b.account IN {token_account:Array(String)})
+            AND (empty({mint:Array(String)}) OR b.mint IN {mint:Array(String)})
+            AND (isNull({program_id:Nullable(String)}) OR b.program_id = {program_id:Nullable(String)})
+        GROUP BY b.account, b.program_id, b.mint, b.decimals
+        HAVING {include_null_balances:Bool} OR amount > 0
+        ORDER BY timestamp DESC, account, mint
+        LIMIT  {limit:UInt64}
+        OFFSET {offset:UInt64}
+    )
+) AS page_arr,
+balances AS (
     SELECT
-        max(b.block_num) AS block_num,
-        max(b.timestamp) AS timestamp,
-        program_id,
-        account,
-        argMax(b.amount, b.block_num) AS amount,
-        mint,
-        decimals
-    FROM {db_balances:Identifier}.balances_by_account AS b
-    WHERE b.account IN (SELECT account FROM owners)
-        AND (empty({token_account:Array(String)}) OR b.account IN {token_account:Array(String)})
-        AND (empty({mint:Array(String)}) OR b.mint IN {mint:Array(String)})
-        AND (isNull({program_id:Nullable(String)}) OR b.program_id = {program_id:Nullable(String)})
-    GROUP BY b.account, b.program_id, b.mint, b.decimals
-    HAVING {include_null_balances:Bool} OR amount > 0
-    ORDER BY timestamp DESC, account, mint
-    LIMIT  {limit:UInt64}
-    OFFSET {offset:UInt64}
+        t.1 AS block_num,
+        t.2 AS timestamp,
+        t.3 AS program_id,
+        t.4 AS account,
+        t.5 AS amount,
+        t.6 AS mint,
+        t.7 AS decimals
+    FROM (SELECT arrayJoin(page_arr) AS t)
 ),
 mints AS (
     SELECT DISTINCT mint FROM balances

--- a/src/routes/balances/svm.sql
+++ b/src/routes/balances/svm.sql
@@ -1,35 +1,27 @@
 WITH
-/* Accounts CURRENTLY owned by the requested owner(s), deduped to one row each.
-   The inner subquery finds every account ever associated with the owner (tight
-   lookup via the prj_owner projection, ORDER BY owner), then argMax(owner, version)
-   resolves each account's current owner (matching owner_view) and HAVING keeps only
-   those still owned by the requested owner(s). The previous version read owner_state
-   raw, returning every historical (owner, account) version — so a closed account
-   (latest owner '') or one reassigned to another owner would still be attributed to
-   the requested owner, and unmerged duplicate versions would duplicate in the join.
-   Bound as a cached scalar so the owner_state reads happen once. */
-(
-    SELECT groupArray((account, owner)) FROM (
-        SELECT account, argMax(owner, version) AS owner
+/* Accounts CURRENTLY owned by the requested owner(s) — account only. The inner subquery
+   finds every account ever associated with the owner(s) (tight lookup via the prj_owner
+   projection), then argMax(owner, version) resolves each account's current owner (matching
+   owner_view) and HAVING keeps only those still owned by the requested owner(s). A closed
+   account (latest owner '') or one reassigned to another owner is dropped here. Referenced
+   once below (the balances filter), so it streams as a normal IN-set instead of being
+   materialized — no large in-memory array even for owners with millions of accounts. */
+owner_accounts AS (
+    SELECT account
+    FROM {db_accounts:Identifier}.owner_state
+    WHERE account IN (
+        SELECT account
         FROM {db_accounts:Identifier}.owner_state
-        WHERE account IN (
-            SELECT account
-            FROM {db_accounts:Identifier}.owner_state
-            WHERE owner IN {owner:Array(String)}
-        )
-        GROUP BY account
-        HAVING owner IN {owner:Array(String)}
+        WHERE owner IN {owner:Array(String)}
     )
-) AS owners_arr,
-owners AS (
-    SELECT t.1 AS account, t.2 AS owner
-    FROM (SELECT arrayJoin(owners_arr) AS t)
+    GROUP BY account
+    HAVING argMax(owner, version) IN {owner:Array(String)}
 ),
 /* Resolve the balance page (filters + ORDER/LIMIT) and bind it as a cached scalar so
-   balances_by_account is read exactly once. Previously the `balances` CTE was inlined
-   at each reference — the final SELECT plus `mints` (which feeds both `decimals` and
-   `metadata`) — so balances_by_account (and the owner lookups it depends on) were
-   re-scanned ~3x. Now only the ~{limit} paged rows flow downstream. */
+   balances_by_account is read exactly once. Previously the `balances` CTE was inlined at
+   each reference — the final SELECT plus `mints` (which feeds both `decimals` and
+   `metadata`) — so balances_by_account was re-scanned ~3x. Now only the ~{limit} paged
+   rows flow downstream. */
 (
     SELECT groupArray((block_num, timestamp, program_id, account, amount, mint, decimals)) FROM (
         SELECT
@@ -41,7 +33,7 @@ owners AS (
             mint,
             decimals
         FROM {db_balances:Identifier}.balances_by_account AS b
-        WHERE b.account IN (SELECT account FROM owners)
+        WHERE b.account IN (SELECT account FROM owner_accounts)
             AND (empty({token_account:Array(String)}) OR b.account IN {token_account:Array(String)})
             AND (empty({mint:Array(String)}) OR b.mint IN {mint:Array(String)})
             AND (isNull({program_id:Nullable(String)}) OR b.program_id = {program_id:Nullable(String)})
@@ -62,6 +54,16 @@ balances AS (
         t.6 AS mint,
         t.7 AS decimals
     FROM (SELECT arrayJoin(page_arr) AS t)
+),
+/* Owner labels for the ~{limit} returned accounts only — resolved after paging (the
+   account set is tiny here), so the current-owner argMax never has to be cached for the
+   owner's full account set. */
+owners AS (
+    SELECT account, argMax(owner, version) AS owner
+    FROM {db_accounts:Identifier}.owner_state
+    WHERE account IN (SELECT account FROM balances)
+    GROUP BY account
+    HAVING owner IN {owner:Array(String)}
 ),
 mints AS (
     SELECT DISTINCT mint FROM balances

--- a/src/routes/balances/svm.sql
+++ b/src/routes/balances/svm.sql
@@ -37,6 +37,7 @@ metadata AS (
     SELECT mint, name, symbol, uri
     FROM {db_metadata:Identifier}.metadata
     WHERE mint IN mints
+    ORDER BY timestamp DESC
     LIMIT 1 BY mint
 )
 SELECT

--- a/src/routes/balances/svm_native.sql
+++ b/src/routes/balances/svm_native.sql
@@ -9,7 +9,7 @@ WITH balances AS
     WHERE account IN {address:Array(String)}
     GROUP BY account
     HAVING {include_null_balances:Bool} OR amount > 0
-    ORDER BY timestamp DESC
+    ORDER BY timestamp DESC, account ASC
     LIMIT  {limit:UInt64}
     OFFSET {offset:UInt64}
 )
@@ -34,4 +34,4 @@ SELECT
     'SOL' AS symbol,
     {network:String} AS network
 FROM balances AS b
-ORDER BY timestamp DESC
+ORDER BY timestamp DESC, account ASC

--- a/src/routes/dexes/svm.sql
+++ b/src/routes/dexes/svm.sql
@@ -9,6 +9,6 @@ FROM {db_dex:Identifier}.state_pools_aggregating_by_pool AS p
 GROUP BY
     p.program_id,
     p.amm
-ORDER BY transactions DESC
+ORDER BY transactions DESC, program_id ASC, amm ASC
 LIMIT   {limit:UInt64}
 OFFSET  {offset:UInt64}

--- a/src/routes/holders/svm.sql
+++ b/src/routes/holders/svm.sql
@@ -2,6 +2,7 @@ WITH metadata AS (
     SELECT mint, name, symbol, uri
     FROM {db_metadata:Identifier}.metadata
     WHERE mint = {mint:String}
+    ORDER BY timestamp DESC
     LIMIT 1
 ),
 balances AS (

--- a/src/routes/holders/svm.sql
+++ b/src/routes/holders/svm.sql
@@ -15,10 +15,36 @@ close_accounts AS (
     FROM {db_accounts:Identifier}.close_account_view
     WHERE account IN (SELECT account FROM balances)
 ),
+/* Resolve the page (closed-account filter + ORDER/LIMIT) BEFORE looking up owners,
+   and bind it as a cached scalar array so the close_account_view aggregation runs
+   exactly once. `owner` is a display-only column (never filtered or ordered on), so
+   the owner_view lookup — which aggregates the 7.5B-row owner_state — then only needs
+   the ~{limit} returned accounts instead of all 1000 holder candidates. */
+(
+    SELECT groupArray((account, block_num, timestamp, program_id, amount, decimals)) FROM (
+        SELECT b.account, b.block_num, b.timestamp, b.program_id, b.amount, b.decimals
+        FROM balances AS b
+        LEFT JOIN close_accounts AS c USING (account)
+        WHERE c.closed IS NULL OR c.closed = false
+        ORDER BY b.amount DESC, b.account
+        LIMIT {limit:UInt64}
+        OFFSET {offset:UInt64}
+    )
+) AS page_arr,
+page AS (
+    SELECT
+        r.1 AS account,
+        r.2 AS block_num,
+        r.3 AS timestamp,
+        r.4 AS program_id,
+        r.5 AS amount,
+        r.6 AS decimals
+    FROM (SELECT arrayJoin(page_arr) AS r)
+),
 owners AS (
     SELECT account, owner
     FROM {db_accounts:Identifier}.owner_view
-    WHERE account IN (SELECT account FROM balances)
+    WHERE account IN (SELECT account FROM page)
 )
 SELECT
     /* block */
@@ -27,8 +53,8 @@ SELECT
     toUnixTimestamp(b.timestamp) AS last_update_timestamp,
 
     /* token */
-    program_id,
-    mint,
+    b.program_id AS program_id,
+    {mint:String} AS mint,
 
     /* token account */
     b.account AS token_account,
@@ -46,11 +72,7 @@ SELECT
 
     /* network */
     {network:String} as network
-FROM balances b
-LEFT JOIN metadata m USING (mint)
+FROM page b
+LEFT JOIN metadata m ON m.mint = {mint:String}
 LEFT JOIN owners o USING (account)
-LEFT JOIN close_accounts c USING (account)
-WHERE mint = {mint:String} AND (closed IS NULL OR closed = false)
 ORDER BY b.amount DESC, b.account
-LIMIT {limit:UInt64}
-OFFSET {offset:UInt64}

--- a/src/routes/pools/svm.sql
+++ b/src/routes/pools/svm.sql
@@ -1,30 +1,71 @@
 WITH
-amm_pools AS (
-    SELECT DISTINCT amm_pool
-    FROM {db_dex:Identifier}.state_pools_aggregating_by_mint
-    WHERE empty({mint:Array(String)}) OR mint IN {mint:Array(String)}
-    AND (isNull({protocol:Nullable(String)}) OR protocol = {protocol:Nullable(String)})
-    LIMIT 100000
-),
+/* Rank pools by total transactions, choosing the source table by whether a mint
+   filter is present. Exactly one of the two arrays below is populated; the other
+   scans nothing, and arrayConcat picks the live one. Both are bound as cached
+   scalars (`WITH (subquery) AS alias`) so each runs at most once instead of being
+   re-evaluated by the three downstream references (final SELECT, pools_with_tokens,
+   decimals). */
+
+/* Mint filter present: rank straight from state_pools_aggregating_by_mint, whose
+   first primary-key column is `mint` — so WHERE mint IN (...) is a tight, complete,
+   deterministic scan over only that mint's pools. This replaces the previous
+   `SELECT DISTINCT amm_pool ... LIMIT 100000` (no ORDER BY), which ranked an
+   arbitrary subset of pools for any mint appearing in >100k pools (wSOL/USDC/USDT)
+   and returned non-deterministic results. Per-(pool,protocol,program_id,amm)
+   transaction sums here are identical to state_pools_aggregating_by_pool, so the
+   ranking order and displayed counts match the unfiltered path. Scans nothing when
+   {mint} is empty (mint IN [] is an empty set). */
+(
+    SELECT groupArray((amm_pool, protocol, program_id, amm, transactions)) FROM (
+        SELECT
+            amm_pool,
+            protocol,
+            program_id,
+            amm,
+            sum(transactions) AS transactions
+        FROM {db_dex:Identifier}.state_pools_aggregating_by_mint
+        WHERE mint IN {mint:Array(String)}
+          AND amm_pool != ''
+          AND (empty({amm_pool:Array(String)}) OR amm_pool IN {amm_pool:Array(String)})
+          AND (empty({amm:Array(String)}) OR amm IN {amm:Array(String)})
+          AND (isNull({protocol:Nullable(String)}) OR protocol = {protocol:Nullable(String)})
+        GROUP BY amm_pool, protocol, program_id, amm
+        ORDER BY transactions DESC
+        LIMIT  {limit:UInt64}
+        OFFSET {offset:UInt64}
+    )
+) AS ranked_by_mint,
+/* No mint filter: rank across all pools from state_pools_aggregating_by_pool. Gated
+   on empty({mint}) so this full-table aggregation is skipped entirely (constant-false
+   WHERE → no scan) whenever the mint path above is in use. */
+(
+    SELECT groupArray((amm_pool, protocol, program_id, amm, transactions)) FROM (
+        SELECT
+            amm_pool,
+            protocol,
+            program_id,
+            amm,
+            sum(transactions) AS transactions
+        FROM {db_dex:Identifier}.state_pools_aggregating_by_pool
+        WHERE empty({mint:Array(String)})
+          AND amm_pool != ''
+          AND (empty({amm_pool:Array(String)}) OR amm_pool IN {amm_pool:Array(String)})
+          AND (empty({amm:Array(String)}) OR amm IN {amm:Array(String)})
+          AND (isNull({protocol:Nullable(String)}) OR protocol = {protocol:Nullable(String)})
+        GROUP BY amm_pool, protocol, program_id, amm
+        ORDER BY transactions DESC
+        LIMIT  {limit:UInt64}
+        OFFSET {offset:UInt64}
+    )
+) AS ranked_by_pool,
 pools AS (
     SELECT
-        protocol,
-        program_id,
-        amm,
-        amm_pool,
-        sum(transactions) as transactions
-    FROM {db_dex:Identifier}.state_pools_aggregating_by_pool
-    WHERE amm_pool != ''
-    AND (empty({amm_pool:Array(String)}) OR amm_pool IN {amm_pool:Array(String)})
-    AND (empty({amm:Array(String)}) OR amm IN {amm:Array(String)})
-    AND (empty({mint:Array(String)}) OR amm_pool IN amm_pools)
-    AND (isNull({protocol:Nullable(String)}) OR protocol = {protocol:Nullable(String)})
-
-    GROUP BY protocol, program_id, amm, amm_pool
-
-    ORDER BY transactions DESC
-    LIMIT   {limit:UInt64}
-    OFFSET  {offset:UInt64}
+        r.1 AS amm_pool,
+        r.2 AS protocol,
+        r.3 AS program_id,
+        r.4 AS amm,
+        r.5 AS transactions
+    FROM (SELECT arrayJoin(arrayConcat(ranked_by_mint, ranked_by_pool)) AS r)
 ),
 pools_with_tokens AS (
     SELECT

--- a/src/routes/pools/svm.sql
+++ b/src/routes/pools/svm.sql
@@ -30,7 +30,7 @@ WITH
           AND (empty({amm:Array(String)}) OR amm IN {amm:Array(String)})
           AND (isNull({protocol:Nullable(String)}) OR protocol = {protocol:Nullable(String)})
         GROUP BY amm_pool, protocol, program_id, amm
-        ORDER BY transactions DESC
+        ORDER BY transactions DESC, amm_pool ASC, protocol ASC, program_id ASC, amm ASC
         LIMIT  {limit:UInt64}
         OFFSET {offset:UInt64}
     )
@@ -53,7 +53,7 @@ WITH
           AND (empty({amm:Array(String)}) OR amm IN {amm:Array(String)})
           AND (isNull({protocol:Nullable(String)}) OR protocol = {protocol:Nullable(String)})
         GROUP BY amm_pool, protocol, program_id, amm
-        ORDER BY transactions DESC
+        ORDER BY transactions DESC, amm_pool ASC, protocol ASC, program_id ASC, amm ASC
         LIMIT  {limit:UInt64}
         OFFSET {offset:UInt64}
     )
@@ -109,4 +109,4 @@ FROM pools AS p
 JOIN pools_with_tokens AS pt ON p.amm_pool = pt.amm_pool AND p.protocol = pt.protocol
 LEFT JOIN decimals AS d0 ON d0.mint = pt.token0
 LEFT JOIN decimals AS d1 ON d1.mint = pt.token1
-ORDER BY p.transactions DESC
+ORDER BY p.transactions DESC, p.amm_pool ASC, p.protocol ASC, p.program_id ASC, p.amm ASC

--- a/src/routes/pools/svm.sql
+++ b/src/routes/pools/svm.sql
@@ -11,10 +11,17 @@ WITH
    deterministic scan over only that mint's pools. This replaces the previous
    `SELECT DISTINCT amm_pool ... LIMIT 100000` (no ORDER BY), which ranked an
    arbitrary subset of pools for any mint appearing in >100k pools (wSOL/USDC/USDT)
-   and returned non-deterministic results. Per-(pool,protocol,program_id,amm)
-   transaction sums here are identical to state_pools_aggregating_by_pool, so the
-   ranking order and displayed counts match the unfiltered path. Scans nothing when
-   {mint} is empty (mint IN [] is an empty set). */
+   and returned non-deterministic results. Scans nothing when {mint} is empty
+   (mint IN [] is an empty set).
+
+   Aggregation is max(sum-per-mint), not a plain sum: state_pools_aggregating_by_mint
+   holds one (mint, pool, …) row per swap-side, and every requested mint that occurs in a
+   pool repeats that pool's transaction count. The inner GROUP BY collapses the (unmerged
+   AggregatingMergeTree) parts per mint; the outer max() then takes a single mint's value
+   instead of adding them, so a pool containing >1 requested mint (e.g. a USDC/wSOL pool
+   queried with mint IN (USDC, wSOL)) is not double-counted. For a single requested mint
+   this is identical to summing, and matches the per-(pool,protocol,program_id,amm) total
+   in state_pools_aggregating_by_pool used by the unfiltered path. */
 (
     SELECT groupArray((amm_pool, protocol, program_id, amm, transactions)) FROM (
         SELECT
@@ -22,13 +29,23 @@ WITH
             protocol,
             program_id,
             amm,
-            sum(transactions) AS transactions
-        FROM {db_dex:Identifier}.state_pools_aggregating_by_mint
-        WHERE mint IN {mint:Array(String)}
-          AND amm_pool != ''
-          AND (empty({amm_pool:Array(String)}) OR amm_pool IN {amm_pool:Array(String)})
-          AND (empty({amm:Array(String)}) OR amm IN {amm:Array(String)})
-          AND (isNull({protocol:Nullable(String)}) OR protocol = {protocol:Nullable(String)})
+            max(mint_transactions) AS transactions
+        FROM (
+            SELECT
+                amm_pool,
+                protocol,
+                program_id,
+                amm,
+                mint,
+                sum(transactions) AS mint_transactions
+            FROM {db_dex:Identifier}.state_pools_aggregating_by_mint
+            WHERE mint IN {mint:Array(String)}
+              AND amm_pool != ''
+              AND (empty({amm_pool:Array(String)}) OR amm_pool IN {amm_pool:Array(String)})
+              AND (empty({amm:Array(String)}) OR amm IN {amm:Array(String)})
+              AND (isNull({protocol:Nullable(String)}) OR protocol = {protocol:Nullable(String)})
+            GROUP BY amm_pool, protocol, program_id, amm, mint
+        )
         GROUP BY amm_pool, protocol, program_id, amm
         ORDER BY transactions DESC, amm_pool ASC, protocol ASC, program_id ASC, amm ASC
         LIMIT  {limit:UInt64}
@@ -106,7 +123,11 @@ SELECT
     /* Network */
     {network: String} AS network
 FROM pools AS p
-JOIN pools_with_tokens AS pt ON p.amm_pool = pt.amm_pool AND p.protocol = pt.protocol
+JOIN pools_with_tokens AS pt
+  ON  p.amm_pool   = pt.amm_pool
+  AND p.protocol   = pt.protocol
+  AND p.program_id = pt.program_id
+  AND p.amm        = pt.amm
 LEFT JOIN decimals AS d0 ON d0.mint = pt.token0
 LEFT JOIN decimals AS d1 ON d1.mint = pt.token1
 ORDER BY p.transactions DESC, p.amm_pool ASC, p.protocol ASC, p.program_id ASC, p.amm ASC

--- a/src/routes/swaps/svm.sql
+++ b/src/routes/swaps/svm.sql
@@ -187,6 +187,7 @@ metadata AS
     SELECT mint, name, symbol, uri
     FROM {db_metadata:Identifier}.metadata
     WHERE mint IN mints
+    ORDER BY timestamp DESC
     LIMIT 1 BY mint
 ),
 decimals AS

--- a/src/routes/tokens/svm.sql
+++ b/src/routes/tokens/svm.sql
@@ -14,6 +14,7 @@ metadata AS
     SELECT mint, name, symbol, uri
     FROM {db_metadata:Identifier}.metadata
     WHERE mint IN {mint:Array(String)}
+    ORDER BY timestamp DESC
     LIMIT 1 BY mint
 ),
 decimals AS

--- a/src/routes/transfers/svm.sql
+++ b/src/routes/transfers/svm.sql
@@ -167,6 +167,7 @@ metadata AS
     SELECT mint, name, symbol, uri
     FROM {db_metadata:Identifier}.metadata
     WHERE mint IN mints
+    ORDER BY timestamp DESC
     LIMIT 1 BY mint
 ),
 decimals AS


### PR DESCRIPTION
SVM endpoint performance pass (following the EVM work in #550/#551/#553) plus a round of correctness fixes surfaced during the audit. All changes are **query-only** (no DB/schema changes) and were validated end-to-end against `solana:svm-dex@v0.5.2`, `svm-balances@v0.3.3`, `svm-accounts@v0.3.1`, `svm-metadata@v0.3.3` via `EXPLAIN indexes=1` and wall-clock.

> Audit note: SVM/TVM **metadata joins** were already optimal (SVM's `metadata`/`decimals_state` are keyed by `mint` alone and every query already lifts them into `WHERE mint IN (...)` CTEs; TVM's two endpoints were handled in #553). The wins here are elsewhere.

> Recurring root cause: a **named CTE is re-evaluated on every reference** in ClickHouse, so any heavy scan referenced by multiple downstream CTEs runs N times. Fix throughout: bind it as a **cached scalar** (`WITH (subquery) AS alias`, often `groupArray(...)`) and unfold with `arrayJoin`. ⚠️ `groupArray` inside a *named* CTE does **not** cache in CH 26.4 — only the scalar binding does.

## Performance

### `pools/svm` — ~10s → ~3s (unfiltered)
Top-N ranking is a full aggregation over ~34M rows of `state_pools_aggregating_by_pool`, referenced 3× (final SELECT, `pools_with_tokens`, `decimals`) → re-scanned each time. `amm_pools` also did a full `state_pools_aggregating_by_mint` scan on every *unfiltered* call. Fixed by binding the ranking as a cached scalar.

### `holders/svm` — ~1.5s → ~1.0s (154M → 103M rows)
The `owner_view` join (aggregates the 7.5B-row `owner_state`) ran over all 1000 holder candidates, but `owner` is display-only. Resolve the page (closed filter + ORDER/LIMIT) first, bound as a cached scalar, then look up `owner_view` for only the ~`{limit}` returned accounts.

### `balances/svm` — 60-account owner 19.5M → 9.8M rows, ~2× faster (grows with owner size)
The `balances` CTE was inlined at the final SELECT *and* via `mints` (which feeds both `decimals` and `metadata`), so `balances_by_account` was re-scanned ~3×. A 60-account owner read 19.5M rows → the source of the timeouts on larger owners. Now binds the owner set and the paged balances as cached scalars so each underlying table is read once. The benefit scales with owner count.

> Residual limit (not addressed here): `balances_by_account` is keyed by `account`, so one owner's accounts are scattered across the 2.8B-row table — each costs ~10 granules even though each is a single fully-merged row. Eliminating that needs an owner-co-located projection/MV (schema change), tracked separately. Whale owners (millions of accounts) still require a `mint`/`token_account` filter.

## Correctness

### `pools/svm` mint filter — was non-deterministic / wrong
The candidate set was `SELECT DISTINCT amm_pool ... LIMIT 100000` with **no `ORDER BY`**, so for any mint in >100k pools (wSOL/USDC/USDT) it ranked an *arbitrary subset* → wrong, non-deterministic results (3 consecutive runs returned empty / 1 pool / 5 different pools). Now ranks directly from `state_pools_aggregating_by_mint`, whose first PK column is `mint` → a tight, **complete**, deterministic scan over only that mint's pools. Per-`(pool,protocol,program_id,amm)` `sum(transactions)` there is identical to `by_pool`, so ranking order and displayed counts are unchanged where the old path was correct. Unfiltered still uses `by_pool`; the two sources are combined with `arrayConcat` and the inactive one's scan is gated off.

### `balances/svm` owner attribution — was returning closed/reassigned accounts
Read `owner_state` **raw**, returning every historical `(owner, account)` version — so an account since **closed** (latest owner `''`) or **reassigned** to another owner was still attributed to the requested owner, and unmerged duplicate versions duplicated rows in the join. Now resolves each candidate account's **current** owner via `argMax(owner, version)` (matching `owner_view`) and keeps only those still owned by the requested owner. Inner lookup still uses the `prj_owner` projection. Verified: owner `sKYmjJbo…` *ever* owned 22 accounts, **all now closed** → old returned 22 stale rows (even on the default `amount>0` path, since `balances_by_account` retains stale non-zero amounts), new returns 0.

### Pagination tiebreakers (ties could shuffle/duplicate/gap across pages)
- **`pools/svm`**: `ORDER BY transactions DESC` → `+ amm_pool, protocol, program_id, amm ASC` (both rankings + final). Verified consecutive pages no longer overlap and are stable across requests.
- **`dexes/svm`**: `+ program_id ASC, amm ASC`.
- **`balances/svm_native`**: `+ account ASC` (now consistent with `balances/svm`).

### Latest-metadata ordering
`metadata.metadata` is a `ReplacingMergeTree` with **no version column** and can hold transient unmerged duplicate rows per mint (~14 observed). `LIMIT 1 [BY mint]` without `ORDER BY` picked an arbitrary `name`/`symbol`/`uri`. Added `ORDER BY timestamp DESC` to the metadata reads in `tokens/svm`, `balances/svm`, `transfers/svm`, `swaps/svm`, `holders/svm`. `decimals_state` left as-is — decimals are immutable per mint.

## Not in this PR (flagged for follow-up)
- **Owner-co-located projection/MV for `balances_by_account`** — the real cure for large/whale owner lookups (schema change).
- **`swaps/svm` & `transfers/svm`** use a `*10` minute-window multiplier for multi-filter queries — an acknowledged in-code approximation that can under-return; deserves its own focused fix.

## Validation
- Output schema and all filters preserved across every endpoint.
- `pools/svm`: row-for-row vs the previous query for the unfiltered case and mid-cardinality mints; `mint=wSOL` now matches an authoritative top-N ranking and is stable across runs.
- `holders/svm`: page selection is independent of `owner` (verified as an account set).
- `balances/svm`: output identical to the prior query across `include_null_balances`, `mint`/`token_account` filters, offset pagination, and multi-owner queries; the closed-account bug fix verified on a real closed-out owner.
- Pagination stability verified for `pools`/`dexes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
