### PR TITLE
fix(polymarket/ohlc): dedup market metadata join

### DIFF
--- a/src/routes/polymarket/ohlcv.sql
+++ b/src/routes/polymarket/ohlcv.sql
@@ -21,7 +21,7 @@ SELECT
 FROM {db_polymarket:Identifier}.orderbook o
 LEFT JOIN {db_polymarket:Identifier}.fee f
     ON f.asset_id = o.asset_id AND f.timestamp = o.timestamp AND f.interval_min = o.interval_min
-LEFT JOIN {db_scraper:Identifier}.polymarket_markets_by_asset_id a
+LEFT JOIN {db_scraper:Identifier}.polymarket_markets_by_asset_id a FINAL
     ON a.asset_id = o.asset_id
 WHERE o.interval_min = {interval:UInt32}
   AND o.asset_id = toUInt256({token_id:String})


### PR DESCRIPTION
## Summary

- `/v1/polymarket/markets/ohlc` returned each candle twice for any token whose `polymarket_markets_by_asset_id` row hadn't merged yet (ReplacingMergeTree).
- The LEFT JOIN ran without `FINAL`, so any unmerged duplicate in the scraper table multiplied the OHLC rows.
- Adding `FINAL` collapses the join to one metadata row per `asset_id`, matching the pattern already used in [`markets.sql`](src/routes/polymarket/markets.sql), [`oi.sql`](src/routes/polymarket/oi.sql), and [`activity.sql`](src/routes/polymarket/activity.sql).

🤖 Generated with [Claude Code](https://claude.com/claude-code)