### PR TITLE
perf(evm): faster /holders/native (ERC-20 reverted — see proposal)

### DIFF
--- a/docs/proposals/evm-holders-erc20-balance-projection.md
+++ b/docs/proposals/evm-holders-erc20-balance-projection.md
@@ -1,0 +1,115 @@
+# Proposal: fast + correct ERC-20 `/holders` via a `(contract, balance)` projection
+
+**Status:** draft / for discussion
+**Author:** perf audit (June 2026), follow-up to PR #558
+**Scope:** DB-side schema change on `<network>:evm-balances@*.erc20_balances` + a query rewrite in `src/routes/holders/evm.sql`. No handler changes.
+
+---
+
+## 1. Problem
+
+`GET /v1/evm/holders` returns the top-N holders of an ERC-20 contract ranked by **current** balance. The query is:
+
+```sql
+SELECT … FROM erc20_balances FINAL
+WHERE contract = {contract} AND balance > 0
+ORDER BY balance DESC, address
+LIMIT {limit} OFFSET {offset}
+```
+
+`erc20_balances` is:
+
+```
+ENGINE = ReplicatedReplacingMergeTree(block_num)
+ORDER BY (contract, address)
+-- skip index: minmax idx_balance (GRANULARITY 1)
+-- projections: prj_address_contract (ORDER BY address, contract), prj_contract_count
+```
+
+Nothing is ordered by `balance`, so a top-N-by-balance read must scan **every holder of the contract** and sort. Measured on polygon:
+
+| Token | holder rows | time | rows read |
+| --- | --- | --- | --- |
+| USDT `0xc213…` | 60M | ~1.6s warm / 3.6s cold | 64M / 8.1GB |
+| Worst `0x2ab0…` | 225M | ~4.9s | ~225M |
+
+`idx_balance` (minmax) prunes nothing because `balance` is scattered across address-ordered granules. Only ~184 polygon contracts have >1M holder rows, but those are exactly the popular tokens (USDT, USDC, …) people query and paginate.
+
+This query is **correct** today — it's just slow.
+
+## 2. Why there is no query-only fix
+
+PR #558 attempted a two-pass rewrite (skip-index top-k candidates → `argMax` dedup) and **had to be reverted** because it returned wrong results. Summary of everything tried (all validated against a `FINAL`/`argMax` ground truth, which agree 100/100):
+
+| Approach | Fast? | Correct? | Note |
+| --- | --- | --- | --- |
+| `FINAL … ORDER BY balance DESC LIMIT N` (current) | ❌ ~1.6s/3.6s | ✅ exact | full-contract scan |
+| skip-index top-k on **raw rows** | ✅ ~0.6s | ❌ **wrong** | USDT page 2 = 65/100; limit=1000 = 334/1000 |
+| `LIMIT 1 BY address` (distinct candidates) | ❌ ~1.45s | ✅ exact | dedup defeats the skip-index prune |
+| distinct `GROUP BY address` | ❌ ~1.55s | ✅ exact | reads all contract rows |
+
+Root cause of the wrong-but-fast case: candidates were ranked by **raw rows** from a `ReplacingMergeTree`. The top holders are exchanges with many *unmerged* balance-change rows (~6 each, up to 14), so their duplicate rows consume the candidate window and crowd real holders out — only 185 of the true top 210 even reached the pool. Copilot's review on PR #558 independently flagged this.
+
+There is no way to be both fast and correct at the query layer, because the data is not ordered by the column we rank on. (The native `/holders/native` endpoint gets away with a distinct-candidate `GROUP BY` only because its per-network cutoff shrinks the set first via `idx_balance`; ERC-20 has no equivalent — its only filter is `contract=X`, which still spans every holder, and a per-*token* cutoff is infeasible.)
+
+## 3. Proposed fix: a `(contract, balance)` projection
+
+Add a balance-ordered projection so the candidate read becomes a range read instead of a full-contract scan:
+
+```sql
+ALTER TABLE `<network>:evm-balances@vX`.erc20_balances
+  ON CLUSTER `tokenapis-c`
+  ADD PROJECTION prj_contract_balance (SELECT * ORDER BY contract, balance);
+
+ALTER TABLE `<network>:evm-balances@vX`.erc20_balances
+  ON CLUSTER `tokenapis-c`
+  MATERIALIZE PROJECTION prj_contract_balance;   -- heavy background mutation
+```
+
+With `(contract, balance)` ordering, `WHERE contract=X ORDER BY balance DESC LIMIT K` is a primary-key range read on the projection (~ms). The table already sets `deduplicate_merge_projection_mode = 'rebuild'`, so the projection stays consistent with the `ReplacingMergeTree` dedup on merge — same mechanism as the existing `prj_address_contract`.
+
+### Query rewrite
+
+`FINAL` **bypasses projections** (verified via `EXPLAIN`), so keep a two-pass shape: pass-1 reads distinct candidates from the projection (no `FINAL`); pass-2 resolves exact current balances over the small candidate set with `argMax`.
+
+```sql
+WITH candidates AS (              -- served by prj_contract_balance: range read, no full scan
+    SELECT address
+    FROM {db_balances:Identifier}.erc20_balances
+    WHERE contract = {contract:String} AND balance > 0
+    ORDER BY balance DESC
+    LIMIT 1 BY address                          -- distinct per address (peak-balance row)
+    LIMIT {limit:UInt64} + {offset:UInt64} * 2 + 1000
+)
+SELECT
+    address,
+    argMax(balance, block_num)   AS amount,     -- exact current balance (== FINAL semantics)
+    argMax(timestamp, block_num) AS ts,
+    max(block_num)               AS bn
+FROM {db_balances:Identifier}.erc20_balances
+WHERE contract = {contract:String} AND address IN (SELECT address FROM candidates)
+GROUP BY address
+HAVING amount > 0
+ORDER BY amount DESC, address
+LIMIT {limit:UInt64} OFFSET {offset:UInt64}
+-- (downstream is_contract lookup + metadata join unchanged)
+```
+
+Notes:
+- `LIMIT 1 BY address` makes candidates **distinct** (addresses Copilot's point), so the candidate window holds K real addresses, not K raw rows.
+- The `offset*2 + 1000` buffer covers addresses whose *peak* balance outranks their *current* balance (faded whales); it scales headroom with depth so deep pages stay exact. This is the same buffer the shipped native endpoint uses (exact through offset 3000+ on the worst-dup chain tested).
+- Expected: correct at all depths **and** sub-second. The shipped native endpoint already proves the distinct-candidate + `argMax` shape is correct; the projection is what supplies the missing *fast* candidate read for ERC-20.
+
+## 4. Cost / tradeoffs
+
+- **Storage** (the main reason this wasn't done in PR #558): one extra full copy of `erc20_balances` per network. The table is large, and it already carries `prj_address_contract` + `prj_contract_count`.
+- **Rollout:** `ADD` + `MATERIALIZE PROJECTION` per network — a heavy background mutation (comparable to the recent `erc1155_balances` `idx_owner` materialization). Must also be added to the substreams sink schema so it survives re-syncs.
+- **Buffer assumption:** `offset*2 + 1000` distinct candidates must exceed the count of faded-whale addresses ranked above the page. Safe across all chains tested; revisit only if a chain shows a wrong rank at deep pagination.
+- **Access:** the `token_api` query user is read-only and cannot run the `ALTER` — needs a privileged user.
+
+## 5. Recommendation
+
+1. Land PR #558 (native only) now — it's correct and 1.3–1.9× faster.
+2. Treat ERC-20 as a separate change gated on the storage/rollout decision. Once `prj_contract_balance` exists on one network, the query above can be validated against the `FINAL` ground truth before rolling out further.
+
+Until the projection exists, **keep the original `FINAL` query** — it is correct, just slow.

--- a/docs/proposals/evm-holders-erc20-balance-projection.md
+++ b/docs/proposals/evm-holders-erc20-balance-projection.md
@@ -77,7 +77,7 @@ WITH candidates AS (              -- served by prj_contract_balance: range read,
     SELECT address
     FROM {db_balances:Identifier}.erc20_balances
     WHERE contract = {contract:String} AND balance > 0
-    ORDER BY balance DESC
+    ORDER BY balance DESC, address              -- address tie-breaker → deterministic paging
     LIMIT 1 BY address                          -- distinct per address (peak-balance row)
     LIMIT {limit:UInt64} + {offset:UInt64} * 2 + 1000
 )

--- a/src/routes/holders/evm.sql
+++ b/src/routes/holders/evm.sql
@@ -1,13 +1,38 @@
-/* Materialize top-N balances once into a row array, then expand via arrayJoin.
-   The address-array is reused to pre-filter the contracts lookup via primary key,
-   avoiding the full-table hash build a plain JOIN would trigger. */
-WITH rows_arr AS (
-    SELECT groupArray(tuple(address, balance, timestamp, block_num)) AS r
+/* Top holders ranked by balance. The table is ORDER BY (contract, address), so a direct
+   `FINAL ... ORDER BY balance DESC LIMIT N` must read every holder of the contract (tens to
+   hundreds of millions of rows for popular tokens) just to sort the top N. Instead use a
+   two-pass approach:
+
+   1) candidates: grab an over-inclusive set of candidate addresses via the balance
+      skip-index top-k (no FINAL, so it may surface superseded/stale balances — that's fine,
+      it only over-includes). The +1000 buffer covers stale rows ranked above the requested
+      page; deep pages scale it via limit+offset.
+   2) rows_arr: resolve each candidate's CURRENT balance with argMax(block_num) — equivalent
+      to FINAL but only over the candidate addresses — then rank and page. The result is
+      materialized once into a row array (reused below for the contracts lookup) and expanded
+      via arrayJoin. */
+WITH candidates AS (
+    SELECT address
+    FROM {db_balances:Identifier}.erc20_balances
+    WHERE contract = {contract:String} AND balance > 0
+    ORDER BY balance DESC
+    LIMIT {limit:UInt64} + {offset:UInt64} + 1000
+    SETTINGS use_skip_indexes_for_top_k = 1, use_top_k_dynamic_filtering = 1
+),
+rows_arr AS (
+    SELECT groupArray(tuple(address, amount, ts, bn)) AS r
     FROM (
-        SELECT address, balance, timestamp, block_num
-        FROM {db_balances:Identifier}.erc20_balances FINAL
-        WHERE contract = {contract:String} AND balance > 0
-        ORDER BY balance DESC, address
+        SELECT
+            address,
+            argMax(balance, block_num)   AS amount,
+            argMax(timestamp, block_num) AS ts,
+            max(block_num)               AS bn
+        FROM {db_balances:Identifier}.erc20_balances
+        WHERE contract = {contract:String}
+          AND address IN (SELECT address FROM candidates)
+        GROUP BY address
+        HAVING amount > 0
+        ORDER BY amount DESC, address
         LIMIT {limit:UInt64} OFFSET {offset:UInt64}
     )
 ),

--- a/src/routes/holders/evm.sql
+++ b/src/routes/holders/evm.sql
@@ -1,38 +1,13 @@
-/* Top holders ranked by balance. The table is ORDER BY (contract, address), so a direct
-   `FINAL ... ORDER BY balance DESC LIMIT N` must read every holder of the contract (tens to
-   hundreds of millions of rows for popular tokens) just to sort the top N. Instead use a
-   two-pass approach:
-
-   1) candidates: grab an over-inclusive set of candidate addresses via the balance
-      skip-index top-k (no FINAL, so it may surface superseded/stale balances — that's fine,
-      it only over-includes). The +1000 buffer covers stale rows ranked above the requested
-      page; deep pages scale it via limit+offset.
-   2) rows_arr: resolve each candidate's CURRENT balance with argMax(block_num) — equivalent
-      to FINAL but only over the candidate addresses — then rank and page. The result is
-      materialized once into a row array (reused below for the contracts lookup) and expanded
-      via arrayJoin. */
-WITH candidates AS (
-    SELECT address
-    FROM {db_balances:Identifier}.erc20_balances
-    WHERE contract = {contract:String} AND balance > 0
-    ORDER BY balance DESC
-    LIMIT {limit:UInt64} + {offset:UInt64} + 1000
-    SETTINGS use_skip_indexes_for_top_k = 1, use_top_k_dynamic_filtering = 1
-),
-rows_arr AS (
-    SELECT groupArray(tuple(address, amount, ts, bn)) AS r
+/* Materialize top-N balances once into a row array, then expand via arrayJoin.
+   The address-array is reused to pre-filter the contracts lookup via primary key,
+   avoiding the full-table hash build a plain JOIN would trigger. */
+WITH rows_arr AS (
+    SELECT groupArray(tuple(address, balance, timestamp, block_num)) AS r
     FROM (
-        SELECT
-            address,
-            argMax(balance, block_num)   AS amount,
-            argMax(timestamp, block_num) AS ts,
-            max(block_num)               AS bn
-        FROM {db_balances:Identifier}.erc20_balances
-        WHERE contract = {contract:String}
-          AND address IN (SELECT address FROM candidates)
-        GROUP BY address
-        HAVING amount > 0
-        ORDER BY amount DESC, address
+        SELECT address, balance, timestamp, block_num
+        FROM {db_balances:Identifier}.erc20_balances FINAL
+        WHERE contract = {contract:String} AND balance > 0
+        ORDER BY balance DESC, address
         LIMIT {limit:UInt64} OFFSET {offset:UInt64}
     )
 ),

--- a/src/routes/holders/evm_native.sql
+++ b/src/routes/holders/evm_native.sql
@@ -16,10 +16,18 @@ WITH cutoff AS (
             toUInt256(100 * pow(10, 18))
         )
 ),
-/* find addresses above cutoff (ex: >=5000 ETH) */
+/* Candidate holders: addresses that have ever been above the cutoff, capped to the slice
+   the requested page can possibly need. Rank DISTINCT addresses by their peak balance
+   (+1000 buffer for addresses whose peak outranks their current balance) — ranking raw
+   rows instead would be dominated by whale balance-change history on busy chains and
+   silently under-fill the candidate set. The cutoff keeps this read tiny via the balance
+   min-max skip index; capping the candidates is what makes the argMax dedup below cheap. */
 addresses AS (
     SELECT address FROM {db_balances:Identifier}.native_balances
     WHERE balance >= (SELECT * FROM cutoff)
+    GROUP BY address
+    ORDER BY max(balance) DESC
+    LIMIT {limit:UInt64} + {offset:UInt64} + 1000
 ),
 /* Materialize top-N balances once into a row array, then expand via arrayJoin.
    The address-array is reused to pre-filter the contracts lookup via primary key,

--- a/src/routes/holders/evm_native.sql
+++ b/src/routes/holders/evm_native.sql
@@ -17,17 +17,18 @@ WITH cutoff AS (
         )
 ),
 /* Candidate holders: addresses that have ever been above the cutoff, capped to the slice
-   the requested page can possibly need. Rank DISTINCT addresses by their peak balance
-   (+1000 buffer for addresses whose peak outranks their current balance) — ranking raw
-   rows instead would be dominated by whale balance-change history on busy chains and
-   silently under-fill the candidate set. The cutoff keeps this read tiny via the balance
-   min-max skip index; capping the candidates is what makes the argMax dedup below cheap. */
+   the requested page can possibly need. Rank DISTINCT addresses by their peak balance —
+   ranking raw rows instead would be dominated by whale balance-change history on busy chains
+   and silently under-fill the candidate set. The buffer (offset*2 + 1000) covers addresses
+   whose peak outranks their current balance; it scales with offset because that density grows
+   with depth, keeping deep pages correct while page 1 stays cheap. The cutoff keeps this read
+   tiny via the balance min-max skip index; capping the candidates makes the argMax dedup cheap. */
 addresses AS (
     SELECT address FROM {db_balances:Identifier}.native_balances
     WHERE balance >= (SELECT * FROM cutoff)
     GROUP BY address
     ORDER BY max(balance) DESC
-    LIMIT {limit:UInt64} + {offset:UInt64} + 1000
+    LIMIT {limit:UInt64} + {offset:UInt64} * 2 + 1000
 ),
 /* Materialize top-N balances once into a row array, then expand via arrayJoin.
    The address-array is reused to pre-filter the contracts lookup via primary key,

--- a/src/routes/holders/evm_native.sql
+++ b/src/routes/holders/evm_native.sql
@@ -27,7 +27,7 @@ addresses AS (
     SELECT address FROM {db_balances:Identifier}.native_balances
     WHERE balance >= (SELECT * FROM cutoff)
     GROUP BY address
-    ORDER BY max(balance) DESC
+    ORDER BY max(balance) DESC, address
     LIMIT {limit:UInt64} + {offset:UInt64} * 2 + 1000
 ),
 /* Materialize top-N balances once into a row array, then expand via arrayJoin.


### PR DESCRIPTION
Speeds up `/v1/evm/holders/native`.

> **Scope note:** this PR originally also rewrote `/v1/evm/holders` (ERC-20). That change was **reverted** — it introduced a correctness regression (see below). A correct *and* fast ERC-20 version needs a schema change; proposed as a follow-up in the comments.

## `/v1/evm/holders/native`

Already used a cutoff + `argMax` two-pass, but the `addresses` candidate CTE returned *every* address ever above the per-network cutoff (polygon ~9.4k, base ~4.6k distinct), so the `argMax` pass read the full balance history of all of them.

**Fix:** cap candidates to the page's needs — rank **distinct** addresses by peak balance, keep `limit + offset*2 + 1000`. Ranking *distinct* addresses (not raw rows) is essential on busy chains: base has a 2.46× balance-updates-per-holder ratio, so a raw-row `LIMIT` collapses to too few distinct addresses. The `offset*2` buffer scales headroom with depth so deep pages stay exact (flat `+1000` diverged at offset ~2000 on base); page-1 cost is unchanged. The cutoff still prunes the read via the min-max skip index.

**Results (best-of-3, limit 10):**

| Chain | dup ratio | Before | After | Speedup | exact @ offset 0/200/500/3000 |
|---|---|---|---|---|---|
| base | 2.46× | 1.48s | **0.83s** | 1.8× | ✓ |
| bsc | — | 1.81s | **0.94s** | 1.9× | ✓ |
| mainnet | — | 0.82s | **0.61s** | 1.3× | ✓ |
| polygon | — | 1.86s | **1.02s** | 1.8× | ✓ |

Validated against a `FINAL`/`argMax` ground truth: top-N **addresses identical**, including `limit=1000, offset=0` → **1000/1000**. `tsc` + `biome` + `bun test` (272 pass / 0 fail; DB-gated tests skipped).

## Why ERC-20 was reverted

The ERC-20 two-pass ranked **raw rows** from the `ReplacingMergeTree` for candidates. Top holders are exchanges with many unmerged balance rows (~6 each), which crowded real holders out of the candidate window. Verified vs ground truth, USDT returned **65/100 on page 2** (limit=100, offset=100) and **334/1000** at limit=1000 — the original `FINAL` query is exact at all depths. The only correct query-only alternatives (`LIMIT 1 BY address`, distinct `GROUP BY`) are no faster than `FINAL`, so there was no win to keep. Reverted to the original. The fast+correct path (a `(contract, balance)` projection) is written up in [`docs/proposals/evm-holders-erc20-balance-projection.md`](docs/proposals/evm-holders-erc20-balance-projection.md), added in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)