### PR TITLE
fix(polymarket/markets): apply m.* filters before LEFT JOIN

### DIFF
--- a/src/routes/polymarket/markets.sql
+++ b/src/routes/polymarket/markets.sql
@@ -20,14 +20,21 @@ SELECT
     m.volume_num AS volume,
     m.start_date,
     m.end_date
-FROM {db_scraper:Identifier}.polymarket_markets m FINAL
+FROM (
+    SELECT
+        condition_id, market_slug, question, description,
+        outcomes, clob_token_ids,
+        closed, neg_risk, accepting_orders, fees_enabled,
+        volume_num, start_date, end_date
+    FROM {db_scraper:Identifier}.polymarket_markets FINAL
+    WHERE (empty({condition_id:Array(String)}) OR condition_id IN {condition_id:Array(String)})
+      AND (empty({market_slug:Array(String)})  OR market_slug  IN {market_slug:Array(String)})
+      AND (empty({token_id:Array(String)})     OR condition_id IN (SELECT condition_id FROM token_condition_ids))
+      AND (isNull({closed:Nullable(Bool)})     OR closed = {closed:Nullable(Bool)})
+) m
 LEFT JOIN {db_scraper:Identifier}.polymarket_events e FINAL
     ON e.condition_id = m.condition_id
-WHERE (empty({condition_id:Array(String)}) OR m.condition_id IN {condition_id:Array(String)})
-  AND (empty({market_slug:Array(String)})  OR m.market_slug  IN {market_slug:Array(String)})
-  AND (empty({token_id:Array(String)})     OR m.condition_id IN (SELECT condition_id FROM token_condition_ids))
-  AND (empty({event_slug:Array(String)})   OR e.slug         IN {event_slug:Array(String)})
-  AND (isNull({closed:Nullable(UInt8)})    OR m.closed = {closed:Nullable(UInt8)})
+WHERE (empty({event_slug:Array(String)}) OR e.slug IN {event_slug:Array(String)})
 ORDER BY m.volume_num DESC
 LIMIT {limit:UInt64}
 OFFSET {offset:UInt64}


### PR DESCRIPTION
## Summary

`/v1/polymarket/markets?closed=...` returns 500 `NOT_FOUND_COLUMN_IN_BLOCK` from ClickHouse 26.5.2.39. The new analyzer fails whenever a wide projection on a `LEFT JOIN FINAL` left side has any WHERE predicate that references a column of that table — bare literal comparisons (`m.closed = TRUE`) and the optional-param idiom (`isNull(p) OR m.closed = p`) both trigger it. Same family as ClickHouse#80443 / #79095 / #58998 (the latter two still open against master).

## Approach

Move every predicate that touches `polymarket_markets` into a subquery on the left side of the JOIN. The outer WHERE keeps only the `event_slug` predicate (which references the right side and can't be pushed down anyway).

```
FROM (
    SELECT ... FROM polymarket_markets FINAL
    WHERE <all m.* predicates>
) m
LEFT JOIN polymarket_events e FINAL ON ...
WHERE <only e.* predicates>
```

The analyzer no longer has to thread `m.*` expressions across the JOIN.

## What didn't work

- `SETTINGS enable_analyzer = 0` (and the legacy alias): works, but disables the new analyzer for the query — a long-term workaround, not a fix. The old analyzer is in maintenance mode and will eventually be removed.
- Type swap `Nullable(UInt8) → Nullable(Bool)`: no effect — the bug doesn't depend on the cast direction.
- Host-layer rewrite of the optional-param idiom: doesn't help — the trigger is just `Bool_col = literal` across a wide-projection LEFT JOIN.
- `LEFT ANY JOIN`, `PREWHERE`, simple subquery on `m` without moving the other `m.*` filters: all still trip the analyzer because outer predicates get re-pushed.

## Verification

- 8 ad-hoc scenarios pass: every combination of `closed=true/false` with `condition_id`, `market_slug`, `token_id`, `event_slug`, and `sort_by`.
- `.temp/polymarket/perf` harness: 85/86 pass (the one fail is the pre-existing `err:limit-too-big` assertion, unrelated).
- Latency improves vs. the pre-CH-26.5 baseline because filters now reduce the JOIN cardinality:
  - `markets:closed-true` 606ms → 315ms
  - `markets:by-slug` 623ms → 352ms
  - `markets:no-params` 394ms → 324ms
- Only regression: `markets:by-event` 376ms → 654ms — `e.slug` filter can't push past the JOIN anymore. Acceptable trade-off; still well under the 1s SLO.

`src/routes/polymarket/markets.sql:23-37`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)