### PR TITLE
feat(hyperliquid): /v1/hyperliquid/outcomes/* endpoints

### DIFF
--- a/src/routes/hyperliquid/outcomes.sql
+++ b/src/routes/hyperliquid/outcomes.sql
@@ -1,0 +1,97 @@
+WITH
+    meta AS (
+        SELECT outcome_id, question_id, name, description, side_specs, quote_token,
+               status, settle_fraction, settle_details
+        FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
+        WHERE (empty({outcome_id:Array(String)})   OR outcome_id  IN (SELECT toUInt64(arrayJoin({outcome_id:Array(String)}))))
+          AND (empty({question_id:Array(String)})  OR question_id IN (SELECT toUInt64(arrayJoin({question_id:Array(String)}))))
+          AND ({status:String} = 'all' OR status = {status:String})
+          AND (isNull({quote_token:Nullable(String)}) OR quote_token = {quote_token:Nullable(String)})
+    ),
+    rollup AS (
+        SELECT
+            intDiv(toUInt64(splitByChar('#', coin)[2]), 10) AS outcome_id,
+            sum(side_buy_volume + side_ask_volume)          AS volume_24h,
+            sum(transactions)                               AS trades_24h,
+            max(max_timestamp)                              AS last_trade
+        FROM {db_hypercore:Identifier}.state_ohlcv_outcomes
+        WHERE interval_min = 60
+          AND timestamp >= now() - INTERVAL 24 HOUR
+        GROUP BY coin
+    ),
+    rollup_agg AS (
+        SELECT outcome_id,
+               sum(volume_24h)               AS volume_24h,
+               sum(trades_24h)               AS trades_24h,
+               toNullable(max(last_trade))   AS last_trade
+        FROM rollup
+        GROUP BY outcome_id
+    ),
+    price_yes AS (
+        SELECT
+            intDiv(toUInt64(splitByChar('#', coin)[2]), 10) AS outcome_id,
+            toNullable(argMaxMerge(close))                  AS price_yes
+        FROM {db_hypercore:Identifier}.state_ohlcv_outcomes
+        WHERE interval_min = 60
+          AND (toUInt64(splitByChar('#', coin)[2]) % 10) = 0
+          AND timestamp >= now() - INTERVAL 24 HOUR
+        GROUP BY coin
+    ),
+    questions AS (
+        SELECT question_id, name, description, fallback_outcome_id,
+               named_outcome_ids, settled_outcome_ids
+        FROM {db_hypercore:Identifier}.state_question_meta FINAL
+    )
+SELECT
+    m.outcome_id                                                          AS outcome_id,
+    m.name                                                                AS name,
+    m.description                                                         AS description,
+    m.side_specs                                                          AS side_specs,
+    m.status                                                              AS status,
+    m.quote_token                                                         AS quote_token,
+    m.settle_fraction                                                     AS settle_fraction,
+    m.settle_details                                                      AS settle_details,
+    CAST(
+        arrayMap(
+            i -> (
+                CAST(m.side_specs[i + 1] AS String),
+                concat('#', toString(m.outcome_id * 10 + i)),
+                toUInt8(i)
+            ),
+            range(0, length(m.side_specs))
+        )
+        AS Array(Tuple(label String, coin String, side_index UInt8))
+    )                                                                     AS sides,
+    py.price_yes                                                          AS price_yes,
+    coalesce(r.volume_24h, 0)                                             AS volume_24h,
+    coalesce(r.trades_24h, 0)                                             AS trades_24h,
+    r.last_trade                                                          AS last_trade,
+    CAST(
+        (
+            m.question_id,
+            nullIf(q.name, ''),
+            nullIf(q.description, ''),
+            q.fallback_outcome_id,
+            q.named_outcome_ids,
+            q.settled_outcome_ids
+        )
+        AS Tuple(
+            question_id Nullable(UInt64),
+            name Nullable(String),
+            description Nullable(String),
+            fallback_outcome_id Nullable(UInt64),
+            named_outcome_ids Array(UInt64),
+            settled_outcome_ids Array(UInt64)
+        )
+    )                                                                     AS question
+FROM meta AS m
+LEFT JOIN rollup_agg AS r USING (outcome_id)
+LEFT JOIN price_yes  AS py USING (outcome_id)
+LEFT JOIN questions  AS q ON q.question_id = m.question_id
+ORDER BY
+    if({sort_by:String} = 'volume_24h', coalesce(r.volume_24h, 0), 0)     DESC,
+    if({sort_by:String} = 'outcome_id', -toInt64(m.outcome_id), 0)        DESC,
+    if({sort_by:String} = 'last_trade', toUnixTimestamp(r.last_trade), 0) DESC,
+    m.outcome_id ASC
+LIMIT {limit:UInt64}
+OFFSET {offset:UInt64}

--- a/src/routes/hyperliquid/outcomes.sql
+++ b/src/routes/hyperliquid/outcomes.sql
@@ -41,6 +41,7 @@ WITH
         SELECT question_id, name, description, fallback_outcome_id,
                named_outcome_ids, settled_outcome_ids
         FROM {db_hypercore:Identifier}.state_question_meta FINAL
+        WHERE question_id IN (SELECT question_id FROM meta WHERE question_id IS NOT NULL)
     )
 SELECT
     m.outcome_id                                                          AS outcome_id,

--- a/src/routes/hyperliquid/outcomes.sql
+++ b/src/routes/hyperliquid/outcomes.sql
@@ -11,7 +11,7 @@ WITH
     rollup AS (
         SELECT
             intDiv(toUInt64(splitByChar('#', coin)[2]), 10) AS outcome_id,
-            sum(side_buy_volume + side_ask_volume)          AS volume_24h,
+            sum(taker_buy_volume + taker_sell_volume)       AS volume_24h,
             sum(transactions)                               AS trades_24h,
             max(max_timestamp)                              AS last_trade
         FROM {db_hypercore:Identifier}.state_ohlcv_outcomes

--- a/src/routes/hyperliquid/outcomes.ts
+++ b/src/routes/hyperliquid/outcomes.ts
@@ -117,7 +117,8 @@ const openapi = describeRoute(
                                             question: {
                                                 question_id: 32,
                                                 name: '2026 World Cup Champion',
-                                                description: 'Each associated outcome corresponds to a team confirmed to be participating ...',
+                                                description:
+                                                    'Each associated outcome corresponds to a team confirmed to be participating ...',
                                                 fallback_outcome_id: 171,
                                                 named_outcome_ids: [172, 173, 174],
                                                 settled_outcome_ids: [],

--- a/src/routes/hyperliquid/outcomes.ts
+++ b/src/routes/hyperliquid/outcomes.ts
@@ -1,0 +1,155 @@
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { describeRoute, resolver, validator } from 'hono-openapi';
+import { z } from 'zod';
+import { config } from '../../config.js';
+import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
+import {
+    apiUsageResponseSchema,
+    createQuerySchema,
+    dateTimeSchema,
+    hyperliquidOutcomeIdSchema,
+    hyperliquidOutcomeStatusSchema,
+    hyperliquidQuestionIdSchema,
+} from '../../types/zod.js';
+import { validatorHook, withErrorResponses } from '../../utils.js';
+
+import baseQuery from './outcomes.sql' with { type: 'text' };
+
+const outcomesSortFields = ['volume_24h', 'last_trade', 'outcome_id'] as const;
+const outcomesSortBySchema = z.enum(outcomesSortFields).meta({
+    type: 'string',
+    enum: outcomesSortFields,
+    default: 'volume_24h',
+    description:
+        '`volume_24h` (default) sorts by combined Yes+No leg volume in last 24h, ties broken by `outcome_id`. `last_trade` sorts by recency. `outcome_id` sorts numerically ascending.',
+});
+
+const quoteTokenSchema = z
+    .string()
+    .min(1)
+    .refine((val) => !/[,\s]/.test(val), 'Invalid quote token (no commas or whitespace)')
+    .meta({
+        type: 'string',
+        description: 'Quote token for the outcome market (e.g. `USDC`, `USDH`).',
+        example: 'USDC',
+    });
+
+const querySchema = createQuerySchema({
+    outcome_id: { schema: hyperliquidOutcomeIdSchema, batched: true, optional: true },
+    question_id: { schema: hyperliquidQuestionIdSchema, batched: true, optional: true },
+    status: { schema: hyperliquidOutcomeStatusSchema, prefault: 'live' },
+    quote_token: { schema: quoteTokenSchema, optional: true },
+    sort_by: { schema: outcomesSortBySchema, prefault: 'volume_24h' },
+});
+
+const sideSchema = z.object({
+    label: z.string(),
+    coin: z.string(),
+    side_index: z.number().int(),
+});
+
+const questionSchema = z.object({
+    question_id: z.number().int().nullable(),
+    name: z.string().nullable(),
+    description: z.string().nullable(),
+    fallback_outcome_id: z.number().int().nullable(),
+    named_outcome_ids: z.array(z.number().int()),
+    settled_outcome_ids: z.array(z.number().int()),
+});
+
+const responseSchema = apiUsageResponseSchema.extend({
+    data: z.array(
+        z.object({
+            outcome_id: z.number().int(),
+            name: z.string(),
+            description: z.string(),
+            side_specs: z.array(z.string()),
+            status: z.string(),
+            quote_token: z.string(),
+            settle_fraction: z.number().nullable(),
+            settle_details: z.string().nullable(),
+            sides: z.array(sideSchema),
+            price_yes: z.number().nullable(),
+            volume_24h: z.number(),
+            trades_24h: z.number().int(),
+            last_trade: dateTimeSchema.nullable(),
+            question: questionSchema,
+        })
+    ),
+});
+
+const openapi = describeRoute(
+    withErrorResponses({
+        summary: 'Outcomes Lookup',
+        description:
+            'Returns HIP-4 outcome markets with metadata and 24h trading rollup. Each outcome trades as two side coins (Yes/No or custom labels) under one collateralized market.\n\nFilter with `outcome_id` for direct lookup, `question_id` to walk a multi-outcome question, or `status` to scope to live or settled outcomes. `question.question_id IS NULL` indicates a binary single-outcome market (no parent question grouping in HL `outcomeMeta`).\n\nThe two side coins are exposed in `sides[]`; use them with `/v1/hyperliquid/outcomes/ohlc` (per-leg) and `/v1/hyperliquid/outcomes/trades` (per-leg fills). Trade-shaped endpoints like `/v1/hyperliquid/markets/*` reject outcome coins.',
+        tags: ['Hyperliquid Outcomes'],
+        security: [{ bearerAuth: [] }],
+        responses: {
+            200: {
+                description: 'Successful Response',
+                content: {
+                    'application/json': {
+                        schema: resolver(responseSchema),
+                        examples: {
+                            multi_outcome: {
+                                value: {
+                                    data: [
+                                        {
+                                            outcome_id: 172,
+                                            name: 'Argentina',
+                                            description:
+                                                'This outcome resolves to Yes if Argentina is officially declared the 2026 FIFA World Cup champion.',
+                                            side_specs: ['Yes', 'No'],
+                                            status: 'live',
+                                            quote_token: 'USDC',
+                                            settle_fraction: null,
+                                            settle_details: null,
+                                            sides: [
+                                                { label: 'Yes', coin: '#1720', side_index: 0 },
+                                                { label: 'No', coin: '#1721', side_index: 1 },
+                                            ],
+                                            price_yes: 0.012,
+                                            volume_24h: 4521.32,
+                                            trades_24h: 18,
+                                            last_trade: '2026-06-12 13:38:55',
+                                            question: {
+                                                question_id: 32,
+                                                name: '2026 World Cup Champion',
+                                                description: 'Each associated outcome corresponds to a team confirmed to be participating ...',
+                                                fallback_outcome_id: 171,
+                                                named_outcome_ids: [172, 173, 174],
+                                                settled_outcome_ids: [],
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
+);
+
+const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema> } }>();
+
+route.get('/', openapi, zValidator('query', querySchema, validatorHook), validator('query', querySchema), async (c) => {
+    const params = c.req.valid('query');
+
+    const hypercore = config.hypercoreDatabases.hyperliquid;
+    if (!hypercore) {
+        return c.json({ error: 'Hyperliquid not configured' }, 500);
+    }
+
+    const response = await makeUsageQueryJson(c, [baseQuery], {
+        ...params,
+        network: 'hyperliquid',
+        db_hypercore: hypercore.database,
+    });
+    return handleUsageQueryError(c, response);
+});
+
+export default route;

--- a/src/routes/hyperliquid/outcomes_ohlc.sql
+++ b/src/routes/hyperliquid/outcomes_ohlc.sql
@@ -1,0 +1,79 @@
+WITH
+    coin_parts AS (
+        SELECT
+            {coin:String}                                              AS coin,
+            toUInt64(splitByChar('#', {coin:String})[2])               AS coin_id,
+            intDiv(toUInt64(splitByChar('#', {coin:String})[2]), 10)   AS outcome_id,
+            toUInt8(toUInt64(splitByChar('#', {coin:String})[2]) % 10) AS side_index
+    ),
+    bounds AS (
+        SELECT
+            min(timestamp) AS start_ts,
+            max(timestamp) AS end_ts
+        FROM (
+            SELECT timestamp
+            FROM {db_hypercore:Identifier}.state_ohlcv_outcomes
+            WHERE coin = {coin:String}
+              AND interval_min = {interval:UInt32}
+              AND (isNull({start_time:Nullable(UInt64)}) OR timestamp >= toDateTime({start_time:Nullable(UInt64)}))
+              AND (isNull({end_time:Nullable(UInt64)})   OR timestamp <  toDateTime({end_time:Nullable(UInt64)}))
+            GROUP BY timestamp
+            ORDER BY timestamp DESC
+            LIMIT {limit:UInt64} OFFSET {offset:UInt64}
+        )
+    ),
+    meta AS (
+        SELECT
+            outcome_id,
+            name                                                       AS outcome_name,
+            side_specs
+        FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
+        WHERE outcome_id = (SELECT outcome_id FROM coin_parts)
+    )
+SELECT
+    candles.timestamp                                              AS timestamp,
+    candles.coin                                                   AS coin,
+    (SELECT outcome_id FROM coin_parts)                            AS outcome_id,
+    (SELECT side_index FROM coin_parts)                            AS side_index,
+    coalesce(m.side_specs[(SELECT side_index FROM coin_parts) + 1], '') AS side_label,
+    coalesce(m.outcome_name, '')                                   AS outcome_name,
+    candles.interval_min                                           AS interval_min,
+    candles.open                                                   AS open,
+    greatest(candles.high_quantile, candles.open, candles.close)   AS high,
+    least(candles.low_quantile, candles.open, candles.close)       AS low,
+    candles.close                                                  AS close,
+    candles.buy_volume                                             AS buy_volume,
+    candles.sell_volume                                            AS sell_volume,
+    candles.gross_volume                                           AS gross_volume,
+    candles.net_volume                                             AS net_volume,
+    candles.transactions                                           AS transactions,
+    candles.buys                                                   AS buys,
+    candles.sells                                                  AS sells,
+    candles.total_fees                                             AS total_fees
+FROM (
+    SELECT
+        t.timestamp                                                AS timestamp,
+        t.coin                                                     AS coin,
+        t.interval_min                                             AS interval_min,
+        argMinMerge(t.open)                                        AS open,
+        quantilesDeterministicMerge(0.05, 0.95)(t.quantile)[2]     AS high_quantile,
+        quantilesDeterministicMerge(0.05, 0.95)(t.quantile)[1]     AS low_quantile,
+        argMaxMerge(t.close)                                       AS close,
+        sum(t.side_buy_volume)                                     AS buy_volume,
+        sum(t.side_ask_volume)                                     AS sell_volume,
+        sum(t.side_buy_volume) + sum(t.side_ask_volume)            AS gross_volume,
+        sum(t.side_buy_volume) - sum(t.side_ask_volume)            AS net_volume,
+        sum(t.transactions)                                        AS transactions,
+        sum(t.buy_count)                                           AS buys,
+        sum(t.sell_count)                                          AS sells,
+        sum(t.total_fees)                                          AS total_fees
+    FROM {db_hypercore:Identifier}.state_ohlcv_outcomes AS t
+    WHERE t.coin = {coin:String}
+      AND t.interval_min = {interval:UInt32}
+      AND t.timestamp >= (SELECT start_ts FROM bounds)
+      AND t.timestamp <= (SELECT end_ts FROM bounds)
+    GROUP BY t.interval_min, t.coin, t.timestamp
+    SETTINGS optimize_aggregation_in_order = 1
+) AS candles
+LEFT JOIN meta AS m ON 1 = 1
+ORDER BY candles.timestamp DESC

--- a/src/routes/hyperliquid/outcomes_ohlc.sql
+++ b/src/routes/hyperliquid/outcomes_ohlc.sql
@@ -47,8 +47,6 @@ SELECT
     candles.gross_volume                                           AS gross_volume,
     candles.net_volume                                             AS net_volume,
     candles.transactions                                           AS transactions,
-    candles.buys                                                   AS buys,
-    candles.sells                                                  AS sells,
     candles.total_fees                                             AS total_fees
 FROM (
     SELECT
@@ -59,13 +57,11 @@ FROM (
         quantilesDeterministicMerge(0.05, 0.95)(t.quantile)[2]     AS high_quantile,
         quantilesDeterministicMerge(0.05, 0.95)(t.quantile)[1]     AS low_quantile,
         argMaxMerge(t.close)                                       AS close,
-        sum(t.side_buy_volume)                                     AS buy_volume,
-        sum(t.side_ask_volume)                                     AS sell_volume,
-        sum(t.side_buy_volume) + sum(t.side_ask_volume)            AS gross_volume,
-        sum(t.side_buy_volume) - sum(t.side_ask_volume)            AS net_volume,
+        sum(t.taker_buy_volume)                                    AS buy_volume,
+        sum(t.taker_sell_volume)                                   AS sell_volume,
+        sum(t.taker_buy_volume) + sum(t.taker_sell_volume)         AS gross_volume,
+        sum(t.taker_buy_volume) - sum(t.taker_sell_volume)         AS net_volume,
         sum(t.transactions)                                        AS transactions,
-        sum(t.buy_count)                                           AS buys,
-        sum(t.sell_count)                                          AS sells,
         sum(t.total_fees)                                          AS total_fees
     FROM {db_hypercore:Identifier}.state_ohlcv_outcomes AS t
     WHERE t.coin = {coin:String}

--- a/src/routes/hyperliquid/outcomes_ohlc.ts
+++ b/src/routes/hyperliquid/outcomes_ohlc.ts
@@ -42,8 +42,6 @@ const responseSchema = apiUsageResponseSchema.extend({
             gross_volume: z.number(),
             net_volume: z.number(),
             transactions: z.number().int(),
-            buys: z.number().int(),
-            sells: z.number().int(),
             total_fees: z.number(),
         })
     ),
@@ -83,8 +81,6 @@ const openapi = describeRoute(
                                             gross_volume: 48008.52,
                                             net_volume: 48008.52,
                                             transactions: 60,
-                                            buys: 60,
-                                            sells: 0,
                                             total_fees: 0,
                                         },
                                     ],

--- a/src/routes/hyperliquid/outcomes_ohlc.ts
+++ b/src/routes/hyperliquid/outcomes_ohlc.ts
@@ -1,0 +1,119 @@
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { describeRoute, resolver, validator } from 'hono-openapi';
+import { z } from 'zod';
+import { config } from '../../config.js';
+import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
+import {
+    apiUsageResponseSchema,
+    createQuerySchema,
+    dateTimeSchema,
+    evmIntervalSchema,
+    hyperliquidOutcomeCoinSchema,
+    timestampSchema,
+} from '../../types/zod.js';
+import { validatorHook, withErrorResponses } from '../../utils.js';
+
+import query from './outcomes_ohlc.sql' with { type: 'text' };
+
+const querySchema = createQuerySchema({
+    coin: { schema: hyperliquidOutcomeCoinSchema },
+    interval: { schema: evmIntervalSchema, prefault: '1h' },
+    start_time: { schema: timestampSchema, optional: true },
+    end_time: { schema: timestampSchema, optional: true },
+});
+
+const responseSchema = apiUsageResponseSchema.extend({
+    data: z.array(
+        z.object({
+            timestamp: dateTimeSchema,
+            coin: z.string(),
+            outcome_id: z.number().int(),
+            side_index: z.number().int(),
+            side_label: z.string(),
+            outcome_name: z.string(),
+            interval_min: z.number().int(),
+            open: z.number(),
+            high: z.number(),
+            low: z.number(),
+            close: z.number(),
+            buy_volume: z.number(),
+            sell_volume: z.number(),
+            gross_volume: z.number(),
+            net_volume: z.number(),
+            transactions: z.number().int(),
+            buys: z.number().int(),
+            sells: z.number().int(),
+            total_fees: z.number(),
+        })
+    ),
+});
+
+const openapi = describeRoute(
+    withErrorResponses({
+        summary: 'Outcome OHLCV',
+        description:
+            'Returns OHLCV candles for a single outcome leg (one Yes/No side) over the requested interval. Trade-side (`buy_volume`/`sell_volume`) carries the directional split — `buy_volume` counts taker buys of this leg, `sell_volume` counts taker sells. Composition events (SPLIT_OUTCOME, MERGE_OUTCOME, MERGE_QUESTION, NEGATE_OUTCOME) and SETTLEMENT payouts are excluded from candles by design — query them via `/v1/hyperliquid/outcomes/trades` for the raw stream.\n\n`total_fees` is currently always zero on outcomes — HL does not charge per-trade fees on HIP-4 markets. Field retained for forward-compat.',
+        tags: ['Hyperliquid Outcomes'],
+        security: [{ bearerAuth: [] }],
+        responses: {
+            200: {
+                description: 'Successful Response',
+                content: {
+                    'application/json': {
+                        schema: resolver(responseSchema),
+                        examples: {
+                            default: {
+                                value: {
+                                    data: [
+                                        {
+                                            timestamp: '2026-06-15 05:00:00',
+                                            coin: '#3290',
+                                            outcome_id: 329,
+                                            side_index: 0,
+                                            side_label: 'Yes',
+                                            outcome_name: 'Recurring',
+                                            interval_min: 60,
+                                            open: 0.99999,
+                                            high: 0.99999,
+                                            low: 0.99999,
+                                            close: 0.99999,
+                                            buy_volume: 48008.52,
+                                            sell_volume: 0,
+                                            gross_volume: 48008.52,
+                                            net_volume: 48008.52,
+                                            transactions: 60,
+                                            buys: 60,
+                                            sells: 0,
+                                            total_fees: 0,
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
+);
+
+const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema> } }>();
+
+route.get('/', openapi, zValidator('query', querySchema, validatorHook), validator('query', querySchema), async (c) => {
+    const params = c.req.valid('query');
+
+    const hypercore = config.hypercoreDatabases.hyperliquid;
+    if (!hypercore) {
+        return c.json({ error: 'Hyperliquid not configured' }, 500);
+    }
+
+    const response = await makeUsageQueryJson(c, [query], {
+        ...params,
+        network: 'hyperliquid',
+        db_hypercore: hypercore.database,
+    });
+    return handleUsageQueryError(c, response);
+});
+
+export default route;

--- a/src/routes/hyperliquid/outcomes_trades.sql
+++ b/src/routes/hyperliquid/outcomes_trades.sql
@@ -1,0 +1,85 @@
+WITH
+    start_ts AS (
+        SELECT if(
+            isNotNull({start_time:Nullable(UInt64)}),
+            toDateTime({start_time:Nullable(UInt64)}),
+            now() - INTERVAL 24 HOUR
+        ) AS t
+    ),
+    end_ts AS (
+        SELECT if(
+            isNotNull({end_time:Nullable(UInt64)}),
+            toDateTime({end_time:Nullable(UInt64)}),
+            now()
+        ) AS t
+    ),
+    question_outcome_ids AS (
+        SELECT arrayJoin(arrayConcat(named_outcome_ids, settled_outcome_ids, [fallback_outcome_id])) AS outcome_id
+        FROM {db_hypercore:Identifier}.state_question_meta FINAL
+        WHERE question_id IN (SELECT toUInt64(arrayJoin({question_id:Array(String)})))
+    )
+SELECT
+    page.block_num                                          AS block_num,
+    page.timestamp                                          AS timestamp,
+    page.transaction_hash                                   AS transaction_hash,
+    page.transaction_id                                     AS transaction_id,
+    page.event_index                                        AS event_index,
+    page.coin                                               AS coin,
+    page.outcome_id                                         AS outcome_id,
+    page.side_index                                         AS side_index,
+    coalesce(m.side_specs[page.side_index + 1], '')         AS side_label,
+    coalesce(m.outcome_name, '')                            AS outcome_name,
+    page.user                                               AS user,
+    page.side                                               AS side,
+    page.direction                                          AS direction,
+    page.price                                              AS price,
+    page.size                                               AS size,
+    page.notional                                           AS notional,
+    page.start_position                                     AS start_position,
+    page.closed_pnl                                         AS closed_pnl,
+    page.fee                                                AS fee,
+    page.fee_token                                          AS fee_token,
+    page.order_id                                           AS order_id,
+    page.client_order_id                                    AS client_order_id,
+    page.twap_id                                            AS twap_id,
+    page.crossed                                            AS crossed
+FROM (
+    SELECT
+        timestamp,
+        coin,
+        outcome_id,
+        side_index,
+        user,
+        side,
+        direction,
+        price,
+        size,
+        size * price          AS notional,
+        start_position,
+        closed_pnl_num        AS closed_pnl,
+        fee,
+        fee_token,
+        order_id,
+        client_order_id,
+        twap_id,
+        crossed,
+        event_hash            AS transaction_hash,
+        transaction_id,
+        block_num,
+        event_index
+    FROM {db_hypercore:Identifier}.outcome_fills
+    WHERE timestamp >= (SELECT t FROM start_ts)
+      AND timestamp <  (SELECT t FROM end_ts)
+      AND (empty({user:Array(String)})        OR user       IN {user:Array(String)})
+      AND (empty({coin:Array(String)})        OR coin       IN {coin:Array(String)})
+      AND (empty({outcome_id:Array(String)})  OR outcome_id IN (SELECT toUInt64(arrayJoin({outcome_id:Array(String)}))))
+      AND (empty({question_id:Array(String)}) OR outcome_id IN (SELECT outcome_id FROM question_outcome_ids))
+    ORDER BY timestamp DESC, block_num DESC, event_index DESC
+    LIMIT {limit:UInt64}
+    OFFSET {offset:UInt64}
+) AS page
+LEFT JOIN (
+    SELECT outcome_id, name AS outcome_name, side_specs
+    FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
+) AS m ON m.outcome_id = page.outcome_id
+ORDER BY page.timestamp DESC, page.block_num DESC, page.event_index DESC

--- a/src/routes/hyperliquid/outcomes_trades.ts
+++ b/src/routes/hyperliquid/outcomes_trades.ts
@@ -1,0 +1,145 @@
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { describeRoute, resolver, validator } from 'hono-openapi';
+import { z } from 'zod';
+import { config } from '../../config.js';
+import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
+import {
+    apiUsageResponseSchema,
+    createQuerySchema,
+    dateTimeSchema,
+    evmAddressSchema,
+    hyperliquidOutcomeCoinSchema,
+    hyperliquidOutcomeIdSchema,
+    hyperliquidQuestionIdSchema,
+    timestampSchema,
+} from '../../types/zod.js';
+import { validatorHook, withErrorResponses } from '../../utils.js';
+
+import query from './outcomes_trades.sql' with { type: 'text' };
+
+const querySchema = createQuerySchema({
+    coin: { schema: hyperliquidOutcomeCoinSchema, batched: true, optional: true },
+    outcome_id: { schema: hyperliquidOutcomeIdSchema, batched: true, optional: true },
+    question_id: { schema: hyperliquidQuestionIdSchema, batched: true, optional: true },
+    user: { schema: evmAddressSchema, batched: true, optional: true },
+    start_time: { schema: timestampSchema, optional: true },
+    end_time: { schema: timestampSchema, optional: true },
+});
+
+const responseSchema = apiUsageResponseSchema.extend({
+    data: z.array(
+        z.object({
+            block_num: z.number().int(),
+            timestamp: dateTimeSchema,
+            transaction_hash: z.string(),
+            transaction_id: z.number().int(),
+            event_index: z.number().int(),
+            coin: z.string(),
+            outcome_id: z.number().int(),
+            side_index: z.number().int(),
+            side_label: z.string(),
+            outcome_name: z.string(),
+            user: z.string(),
+            side: z.string(),
+            direction: z.string(),
+            price: z.number(),
+            size: z.number(),
+            notional: z.number(),
+            start_position: z.string(),
+            closed_pnl: z.number(),
+            fee: z.number(),
+            fee_token: z.string(),
+            order_id: z.number().int(),
+            client_order_id: z.string(),
+            twap_id: z.number().int(),
+            crossed: z.boolean(),
+        })
+    ),
+});
+
+const openapi = describeRoute(
+    withErrorResponses({
+        summary: 'Outcome Trades',
+        description:
+            'Returns a chronological fill feed for HIP-4 outcome markets. Each row is a single fill carrying price, size, side (`BID` = user bought / `ASK` = user sold), and one of seven directions:\n\n- `BUY`, `SELL` — regular taker matches; these are the only directions that flow into OHLCV candles\n- `SETTLEMENT` — payout when the outcome resolved; size = position cleared, price = 1 on the winning leg / 0 on the losing leg\n- `SPLIT_OUTCOME` — user minted both Yes+No legs by depositing $1 of the quote token\n- `MERGE_OUTCOME` — user redeemed Yes+No legs back to $1 of the quote token\n- `MERGE_QUESTION` — user redeemed a full set of question outcomes back to $1 (multi-outcome only)\n- `NEGATE_OUTCOME` — converted a Yes-leg holding into a No-leg holding for the *other* outcomes under the same question (multi-outcome only)\n\nFilters compose additively. At least one of `coin`, `outcome_id`, `question_id`, or `user` is required. Defaults to the last 24 hours when no time range is specified.\n\nFor candle aggregates of the BUY/SELL subset, see `/v1/hyperliquid/outcomes/ohlc`. `fee_token` shows `+<coin_number>` on zero-fee fills (HL wire-format quirk).',
+        tags: ['Hyperliquid Outcomes'],
+        security: [{ bearerAuth: [] }],
+        responses: {
+            200: {
+                description: 'Successful Response',
+                content: {
+                    'application/json': {
+                        schema: resolver(responseSchema),
+                        examples: {
+                            settlement: {
+                                value: {
+                                    data: [
+                                        {
+                                            block_num: 1036093214,
+                                            timestamp: '2026-06-15 06:00:23',
+                                            transaction_hash:
+                                                '0x40163a5290e2756e418f043dc1871e00005152382be59440e3dee5a54fe64f58',
+                                            transaction_id: 218233422822675,
+                                            event_index: 347,
+                                            coin: '#3290',
+                                            outcome_id: 329,
+                                            side_index: 0,
+                                            side_label: 'Yes',
+                                            outcome_name: 'Recurring',
+                                            user: '0xfc0a9d73b4382348bac7f4f600439bc61bb00271',
+                                            side: 'ASK',
+                                            direction: 'SETTLEMENT',
+                                            price: 1,
+                                            size: 428,
+                                            notional: 428,
+                                            start_position: '428.0',
+                                            closed_pnl: 75.00065,
+                                            fee: 0,
+                                            fee_token: 'USDC',
+                                            order_id: 469409912004,
+                                            client_order_id: '',
+                                            twap_id: 0,
+                                            crossed: true,
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
+);
+
+const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema> } }>();
+
+route.get('/', openapi, zValidator('query', querySchema, validatorHook), validator('query', querySchema), async (c) => {
+    const params = c.req.valid('query');
+
+    if (!params.coin.length && !params.outcome_id.length && !params.question_id.length && !params.user.length) {
+        return c.json(
+            {
+                status: 400,
+                code: 'bad_query_input',
+                message: 'Provide at least one of coin, outcome_id, question_id, or user',
+            },
+            400
+        );
+    }
+
+    const hypercore = config.hypercoreDatabases.hyperliquid;
+    if (!hypercore) {
+        return c.json({ error: 'Hyperliquid not configured' }, 500);
+    }
+
+    const response = await makeUsageQueryJson(c, [query], {
+        ...params,
+        network: 'hyperliquid',
+        db_hypercore: hypercore.database,
+    });
+    return handleUsageQueryError(c, response);
+});
+
+export default route;

--- a/src/routes/hyperliquid/outcomes_users.sql
+++ b/src/routes/hyperliquid/outcomes_users.sql
@@ -1,0 +1,68 @@
+WITH
+    question_outcome_ids AS (
+        SELECT arrayJoin(arrayConcat(named_outcome_ids, settled_outcome_ids, [fallback_outcome_id])) AS outcome_id
+        FROM {db_hypercore:Identifier}.state_question_meta FINAL
+        WHERE question_id IN (SELECT toUInt64(arrayJoin({question_id:Array(String)})))
+    ),
+    rows AS (
+        SELECT
+            user,
+            intDiv(toUInt64(splitByChar('#', coin)[2]), 10) AS outcome_id,
+            transactions,
+            buys,
+            sells,
+            volume_bought,
+            volume_sold,
+            total_volume,
+            total_fees,
+            realized_pnl,
+            first_trade,
+            last_trade
+        FROM {db_hypercore:Identifier}.state_user_by_coin FINAL
+        WHERE dex = 'outcome'
+          AND interval_min = {interval_min:UInt32}
+          AND user IN {user:Array(String)}
+    )
+SELECT
+    r.user                                                   AS user,
+    r.outcome_id                                             AS outcome_id,
+    coalesce(m.name, '')                                     AS outcome_name,
+    coalesce(m.status, '')                                   AS status,
+    coalesce(m.side_specs, [])                               AS side_specs,
+    sum(r.transactions)                                      AS transactions,
+    sum(r.buys)                                              AS buys,
+    sum(r.sells)                                             AS sells,
+    sum(r.volume_bought)                                     AS volume_bought,
+    sum(r.volume_sold)                                       AS volume_sold,
+    sum(r.total_volume)                                      AS total_volume,
+    sum(r.total_fees)                                        AS total_fees,
+    sum(r.realized_pnl)                                      AS realized_pnl,
+    min(r.first_trade)                                       AS first_trade,
+    max(r.last_trade)                                        AS last_trade,
+    CAST(
+        (
+            m.question_id,
+            nullIf(coalesce(q.name, ''), ''),
+            q.fallback_outcome_id
+        )
+        AS Tuple(
+            question_id Nullable(UInt64),
+            name Nullable(String),
+            fallback_outcome_id Nullable(UInt64)
+        )
+    )                                                        AS question
+FROM rows AS r
+LEFT JOIN (
+    SELECT outcome_id, name, status, side_specs, question_id
+    FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
+) AS m ON m.outcome_id = r.outcome_id
+LEFT JOIN (
+    SELECT question_id, name, fallback_outcome_id
+    FROM {db_hypercore:Identifier}.state_question_meta FINAL
+) AS q ON q.question_id = m.question_id
+WHERE (empty({outcome_id:Array(String)})  OR r.outcome_id IN (SELECT toUInt64(arrayJoin({outcome_id:Array(String)}))))
+  AND (empty({question_id:Array(String)}) OR r.outcome_id IN (SELECT outcome_id FROM question_outcome_ids))
+GROUP BY r.user, r.outcome_id, m.name, m.status, m.side_specs, m.question_id, q.name, q.fallback_outcome_id
+ORDER BY total_volume DESC
+LIMIT {limit:UInt64}
+OFFSET {offset:UInt64}

--- a/src/routes/hyperliquid/outcomes_users.ts
+++ b/src/routes/hyperliquid/outcomes_users.ts
@@ -1,0 +1,129 @@
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { describeRoute, resolver, validator } from 'hono-openapi';
+import { z } from 'zod';
+import { config } from '../../config.js';
+import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
+import {
+    apiUsageResponseSchema,
+    createQuerySchema,
+    dateTimeSchema,
+    evmAddressSchema,
+    hyperliquidOutcomeIdSchema,
+    hyperliquidQuestionIdSchema,
+    userLookbackIntervalSchema,
+} from '../../types/zod.js';
+import { validatorHook, withErrorResponses } from '../../utils.js';
+
+import query from './outcomes_users.sql' with { type: 'text' };
+
+const querySchema = createQuerySchema({
+    user: { schema: evmAddressSchema, batched: true },
+    outcome_id: { schema: hyperliquidOutcomeIdSchema, batched: true, optional: true },
+    question_id: { schema: hyperliquidQuestionIdSchema, batched: true, optional: true },
+    interval: { schema: userLookbackIntervalSchema, optional: true },
+});
+
+const questionSchema = z.object({
+    question_id: z.number().int().nullable(),
+    name: z.string().nullable(),
+    fallback_outcome_id: z.number().int().nullable(),
+});
+
+const responseSchema = apiUsageResponseSchema.extend({
+    data: z.array(
+        z.object({
+            user: z.string(),
+            outcome_id: z.number().int(),
+            outcome_name: z.string(),
+            status: z.string(),
+            side_specs: z.array(z.string()),
+            transactions: z.number().int(),
+            buys: z.number().int(),
+            sells: z.number().int(),
+            volume_bought: z.number(),
+            volume_sold: z.number(),
+            total_volume: z.number(),
+            total_fees: z.number(),
+            realized_pnl: z.number(),
+            first_trade: dateTimeSchema,
+            last_trade: dateTimeSchema,
+            question: questionSchema,
+        })
+    ),
+});
+
+const openapi = describeRoute(
+    withErrorResponses({
+        summary: 'Outcome User Activity',
+        description:
+            'Returns trading aggregates per outcome for a given user, with both side legs (Yes/No or custom labels) collapsed into one row per outcome. Includes fill count, buys/sells split, volume bought/sold, realized PnL, and first/last trade times across all seven outcome directions (BUY/SELL/SETTLEMENT/SPLIT_OUTCOME/MERGE_OUTCOME/MERGE_QUESTION/NEGATE_OUTCOME).\n\n`user` is required; `outcome_id` and `question_id` narrow further. Sorted by `total_volume` descending. Backed by `state_user_by_coin` (hourly refresh — `interval=1h` lags up to 1h).\n\n`total_fees` is currently always zero on outcomes — HL does not charge per-trade fees on HIP-4 markets.\n\n`question.question_id IS NULL` indicates a binary single-outcome market (no parent question grouping in HL `outcomeMeta`).',
+        tags: ['Hyperliquid Outcomes'],
+        security: [{ bearerAuth: [] }],
+        responses: {
+            200: {
+                description: 'Successful Response',
+                content: {
+                    'application/json': {
+                        schema: resolver(responseSchema),
+                        examples: {
+                            default: {
+                                value: {
+                                    data: [
+                                        {
+                                            user: '0xfcecc2a54724cf0502eb7c916e2717ef76a510ed',
+                                            outcome_id: 318,
+                                            outcome_name: 'Germany',
+                                            status: 'settled',
+                                            side_specs: ['Yes', 'No'],
+                                            transactions: 276,
+                                            buys: 30,
+                                            sells: 246,
+                                            volume_bought: 62980.97,
+                                            volume_sold: 194043.55,
+                                            total_volume: 257024.52,
+                                            total_fees: 0,
+                                            realized_pnl: 61796.11,
+                                            first_trade: '2026-06-12 09:36:14',
+                                            last_trade: '2026-06-14 18:15:01',
+                                            question: {
+                                                question_id: null,
+                                                name: null,
+                                                fallback_outcome_id: null,
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    })
+);
+
+const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema> } }>();
+
+route.get('/', openapi, zValidator('query', querySchema, validatorHook), validator('query', querySchema), async (c) => {
+    const params = c.req.valid('query');
+
+    if (!params.user.length) {
+        return c.json({ status: 400, code: 'bad_query_input', message: 'user is required' }, 400);
+    }
+
+    const hypercore = config.hypercoreDatabases.hyperliquid;
+    if (!hypercore) {
+        return c.json({ error: 'Hyperliquid not configured' }, 500);
+    }
+
+    const response = await makeUsageQueryJson(c, [query], {
+        ...params,
+        interval_min: params.interval ?? 0,
+        network: 'hyperliquid',
+        db_hypercore: hypercore.database,
+    });
+    return handleUsageQueryError(c, response);
+});
+
+export default route;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -45,6 +45,7 @@ import hyperliquidMarketsOhlc from './hyperliquid/markets_ohlc.js';
 import hyperliquidMarketsOi from './hyperliquid/markets_oi.js';
 import hyperliquidOutcomes from './hyperliquid/outcomes.js';
 import hyperliquidOutcomesOhlc from './hyperliquid/outcomes_ohlc.js';
+import hyperliquidOutcomesTrades from './hyperliquid/outcomes_trades.js';
 import hyperliquidPlatform from './hyperliquid/platform.js';
 import hyperliquidUsers from './hyperliquid/users.js';
 import hyperliquidUsersActivity from './hyperliquid/users_activity.js';
@@ -191,6 +192,7 @@ router.route('/v1/hyperliquid/markets/liquidations', hyperliquidMarketsLiquidati
 router.route('/v1/hyperliquid/markets/liquidations/ohlc', hyperliquidMarketsLiquidationsOhlc);
 router.route('/v1/hyperliquid/outcomes', hyperliquidOutcomes);
 router.route('/v1/hyperliquid/outcomes/ohlc', hyperliquidOutcomesOhlc);
+router.route('/v1/hyperliquid/outcomes/trades', hyperliquidOutcomesTrades);
 router.route('/v1/hyperliquid/users', hyperliquidUsers);
 router.route('/v1/hyperliquid/users/positions', hyperliquidUsersPositions);
 router.route('/v1/hyperliquid/users/activity', hyperliquidUsersActivity);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -46,6 +46,7 @@ import hyperliquidMarketsOi from './hyperliquid/markets_oi.js';
 import hyperliquidOutcomes from './hyperliquid/outcomes.js';
 import hyperliquidOutcomesOhlc from './hyperliquid/outcomes_ohlc.js';
 import hyperliquidOutcomesTrades from './hyperliquid/outcomes_trades.js';
+import hyperliquidOutcomesUsers from './hyperliquid/outcomes_users.js';
 import hyperliquidPlatform from './hyperliquid/platform.js';
 import hyperliquidUsers from './hyperliquid/users.js';
 import hyperliquidUsersActivity from './hyperliquid/users_activity.js';
@@ -193,6 +194,7 @@ router.route('/v1/hyperliquid/markets/liquidations/ohlc', hyperliquidMarketsLiqu
 router.route('/v1/hyperliquid/outcomes', hyperliquidOutcomes);
 router.route('/v1/hyperliquid/outcomes/ohlc', hyperliquidOutcomesOhlc);
 router.route('/v1/hyperliquid/outcomes/trades', hyperliquidOutcomesTrades);
+router.route('/v1/hyperliquid/outcomes/users', hyperliquidOutcomesUsers);
 router.route('/v1/hyperliquid/users', hyperliquidUsers);
 router.route('/v1/hyperliquid/users/positions', hyperliquidUsersPositions);
 router.route('/v1/hyperliquid/users/activity', hyperliquidUsersActivity);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -44,6 +44,7 @@ import hyperliquidMarketsLiquidationsOhlc from './hyperliquid/markets_liquidatio
 import hyperliquidMarketsOhlc from './hyperliquid/markets_ohlc.js';
 import hyperliquidMarketsOi from './hyperliquid/markets_oi.js';
 import hyperliquidOutcomes from './hyperliquid/outcomes.js';
+import hyperliquidOutcomesOhlc from './hyperliquid/outcomes_ohlc.js';
 import hyperliquidPlatform from './hyperliquid/platform.js';
 import hyperliquidUsers from './hyperliquid/users.js';
 import hyperliquidUsersActivity from './hyperliquid/users_activity.js';
@@ -189,6 +190,7 @@ router.route('/v1/hyperliquid/markets/activity', hyperliquidMarketsActivity);
 router.route('/v1/hyperliquid/markets/liquidations', hyperliquidMarketsLiquidations);
 router.route('/v1/hyperliquid/markets/liquidations/ohlc', hyperliquidMarketsLiquidationsOhlc);
 router.route('/v1/hyperliquid/outcomes', hyperliquidOutcomes);
+router.route('/v1/hyperliquid/outcomes/ohlc', hyperliquidOutcomesOhlc);
 router.route('/v1/hyperliquid/users', hyperliquidUsers);
 router.route('/v1/hyperliquid/users/positions', hyperliquidUsersPositions);
 router.route('/v1/hyperliquid/users/activity', hyperliquidUsersActivity);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -43,6 +43,7 @@ import hyperliquidMarketsLiquidations from './hyperliquid/markets_liquidations.j
 import hyperliquidMarketsLiquidationsOhlc from './hyperliquid/markets_liquidations_ohlc.js';
 import hyperliquidMarketsOhlc from './hyperliquid/markets_ohlc.js';
 import hyperliquidMarketsOi from './hyperliquid/markets_oi.js';
+import hyperliquidOutcomes from './hyperliquid/outcomes.js';
 import hyperliquidPlatform from './hyperliquid/platform.js';
 import hyperliquidUsers from './hyperliquid/users.js';
 import hyperliquidUsersActivity from './hyperliquid/users_activity.js';
@@ -176,6 +177,7 @@ router.route('/v1/tvm/dexes', tvmDexes);
 // and real-time data. See project_hyperliquid_scoping.md for the full list.
 router.use('/v1/hyperliquid/dexes', cacheControl());
 router.use('/v1/hyperliquid/markets', cacheControl());
+router.use('/v1/hyperliquid/outcomes', cacheControl());
 router.use('/v1/hyperliquid/users', cacheControl());
 router.use('/v1/hyperliquid/vaults', cacheControl());
 router.use('/v1/hyperliquid/vaults/depositors', cacheControl());
@@ -186,6 +188,7 @@ router.route('/v1/hyperliquid/markets/oi', hyperliquidMarketsOi);
 router.route('/v1/hyperliquid/markets/activity', hyperliquidMarketsActivity);
 router.route('/v1/hyperliquid/markets/liquidations', hyperliquidMarketsLiquidations);
 router.route('/v1/hyperliquid/markets/liquidations/ohlc', hyperliquidMarketsLiquidationsOhlc);
+router.route('/v1/hyperliquid/outcomes', hyperliquidOutcomes);
 router.route('/v1/hyperliquid/users', hyperliquidUsers);
 router.route('/v1/hyperliquid/users/positions', hyperliquidUsersPositions);
 router.route('/v1/hyperliquid/users/activity', hyperliquidUsersActivity);

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -935,22 +935,22 @@ export const userLookbackIntervalSchema = z
 
 // ── Hyperliquid Schemas ──
 
-// `dex` values returned by the substreams `dex_from_coin(coin)` UDF.
-// `perps` = unprefixed core perps (BTC, ETH, HYPE, ...). `spot` = `@N`-indexed
-// spot pairs. Named DEXs are builder-deployed perp venues with permissionless
-// onboarding — represented as an open lowercase-alphanumeric string so new
-// builder DEXs work without a release. Discovery is via `/v1/hyperliquid/dexes`.
-const knownHyperliquidDexes = ['perps', 'spot', 'xyz', 'cash', 'km', 'hyna', 'flx', 'vntl', 'para'] as const;
-export const hyperliquidDexIdSchema = z.coerce
-    .string()
-    .min(1)
-    .refine((val) => /^[a-z0-9]+$/.test(val), 'Invalid DEX id (lowercase alphanumeric only)')
-    .meta({
-        type: 'string',
-        description:
-            'DEX identifier. `perps` for core perps, `spot` for `@N` spot pairs, or a builder DEX name (`xyz`, `cash`, …). Call `/v1/hyperliquid/dexes` for the live set.',
-        examples: knownHyperliquidDexes,
-    });
+// `dex` values exposed on the perps/spot/builder endpoints. `perps` =
+// unprefixed core perps (BTC, ETH, HYPE, …). `spot` = `@N`-indexed spot pairs.
+// Named DEXs are builder-deployed perp venues; the live set is rarely changing
+// (~9 since launch) so a strict enum drives OpenAPI + SDK autocomplete and
+// catches typos. Outcome markets (`#N` coins) are deliberately NOT a valid
+// `dex` value here — they go through the dedicated `/v1/hyperliquid/outcomes/*`
+// family. Call `/v1/hyperliquid/dexes` for the live set; bump this enum when
+// a new builder DEX lands.
+const hyperliquidDexValues = ['perps', 'spot', 'xyz', 'cash', 'km', 'hyna', 'flx', 'vntl', 'para'] as const;
+export const hyperliquidDexIdSchema = z.enum(hyperliquidDexValues).meta({
+    type: 'string',
+    enum: hyperliquidDexValues,
+    description:
+        'DEX identifier. `perps` for core perps, `spot` for `@N` spot pairs, or a builder DEX name (`xyz`, `cash`, …). Outcome markets are served separately under `/v1/hyperliquid/outcomes/*`.',
+    examples: hyperliquidDexValues,
+});
 
 const hyperliquidLiquidationSortFields = ['notional', 'time'] as const;
 export const hyperliquidLiquidationSortBySchema = z.enum(hyperliquidLiquidationSortFields).meta({
@@ -1026,13 +1026,55 @@ export const hyperliquidTokenSchema = z.coerce
         examples: ['HYPE', 'USDC', 'BTC'],
     });
 
+// Coin identifier for the perps/spot/builder endpoint family. Outcome coins
+// (`#N`) are rejected — they go through `/v1/hyperliquid/outcomes/*` instead.
 export const hyperliquidCoinSchema = z.coerce
     .string()
     .min(1)
     .refine((val) => !/[,\s]/.test(val), 'Invalid coin identifier (no commas or whitespace)')
+    .refine((val) => !val.startsWith('#'), 'Outcome coins (`#N`) are served by `/v1/hyperliquid/outcomes/*`')
     .meta({
         type: 'string',
         description:
-            'Hyperliquid coin identifier. Core perps have no prefix (`BTC`, `HYPE`); spot pairs use `@N` (`@107`); builder DEXs prefix the symbol with the DEX name (`xyz:SILVER`).',
+            'Hyperliquid coin identifier. Core perps have no prefix (`BTC`, `HYPE`); spot pairs use `@N` (`@107`); builder DEXs prefix the symbol with the DEX name (`xyz:SILVER`). Outcome coins (`#N`) are not accepted here — use `/v1/hyperliquid/outcomes/*`.',
         example: 'BTC',
     });
+
+// Outcome coin identifier (`#<outcome_id*10 + side_index>`) for the
+// `/v1/hyperliquid/outcomes/*` family. Two coins per outcome — one per side
+// (Yes/No or custom labels per `state_outcome_meta.side_specs`).
+export const hyperliquidOutcomeCoinSchema = z.coerce
+    .string()
+    .min(2)
+    .refine((val) => /^#\d+$/.test(val), 'Invalid outcome coin (must match `#<integer>`)')
+    .meta({
+        type: 'string',
+        description:
+            'Outcome coin identifier in HIP-4 encoding: `#<outcome_id*10 + side_index>`. Side index is 0 or 1 indexing into `state_outcome_meta.side_specs`. Use `/v1/hyperliquid/outcomes` to discover outcomes and their side coins.',
+        example: '#1720',
+    });
+
+// Outcome id (UInt64) for filtering across outcomes' two side coins.
+export const hyperliquidOutcomeIdSchema = z.coerce.number().int().nonnegative().meta({
+    type: 'integer',
+    description: 'HIP-4 outcome id (UInt64). One outcome has two side coins, `#<id*10>` and `#<id*10+1>`.',
+    example: 172,
+});
+
+// Question id (UInt64) for filtering to a multi-outcome question's siblings.
+export const hyperliquidQuestionIdSchema = z.coerce.number().int().nonnegative().meta({
+    type: 'integer',
+    description:
+        'HIP-4 question id (UInt64). Groups multi-outcome questions (e.g. World Cup). Binary single-outcome markets have no question id.',
+    example: 32,
+});
+
+// Outcome status filter for `/v1/hyperliquid/outcomes`.
+const hyperliquidOutcomeStatusValues = ['live', 'settled', 'all'] as const;
+export const hyperliquidOutcomeStatusSchema = z.enum(hyperliquidOutcomeStatusValues).meta({
+    type: 'string',
+    enum: hyperliquidOutcomeStatusValues,
+    default: 'live',
+    description:
+        '`live` (still trading) or `settled` (resolution captured via `settledOutcome` probe). `all` returns both.',
+});

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -1046,7 +1046,10 @@ export const hyperliquidCoinSchema = z.coerce
 export const hyperliquidOutcomeCoinSchema = z.coerce
     .string()
     .min(2)
-    .refine((val) => /^#\d+$/.test(val), 'Invalid outcome coin (must match `#<integer>`)')
+    .refine(
+        (val) => /^#\d+[01]$/.test(val),
+        'Invalid outcome coin (must match `#<outcome_id*10 + side_index>` with side_index in {0,1})'
+    )
     .meta({
         type: 'string',
         description:
@@ -1061,7 +1064,8 @@ export const hyperliquidOutcomeIdSchema = z.coerce
     .string()
     .regex(/^\d+$/, 'Outcome id must be a non-negative integer')
     .meta({
-        type: 'integer',
+        type: 'string',
+        format: 'uint64',
         description: 'HIP-4 outcome id (UInt64). One outcome has two side coins, `#<id*10>` and `#<id*10+1>`.',
         example: '172',
     });
@@ -1071,7 +1075,8 @@ export const hyperliquidQuestionIdSchema = z.coerce
     .string()
     .regex(/^\d+$/, 'Question id must be a non-negative integer')
     .meta({
-        type: 'integer',
+        type: 'string',
+        format: 'uint64',
         description:
             'HIP-4 question id (UInt64). Groups multi-outcome questions (e.g. World Cup). Binary single-outcome markets have no question id.',
         example: '32',

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -1036,7 +1036,7 @@ export const hyperliquidCoinSchema = z.coerce
     .meta({
         type: 'string',
         description:
-            'Hyperliquid coin identifier. Core perps have no prefix (`BTC`, `HYPE`); spot pairs use `@N` (`@107`); builder DEXs prefix the symbol with the DEX name (`xyz:SILVER`). Outcome coins (`#N`) are not accepted here — use `/v1/hyperliquid/outcomes/*`.',
+            'Hyperliquid coin id. Perps: `BTC`. Spot: `@N` (`@107`). Builder DEXs: `xyz:SILVER`. Outcome coins (`#N`) are rejected — use `/v1/hyperliquid/outcomes/*`.',
         example: 'BTC',
     });
 
@@ -1054,20 +1054,28 @@ export const hyperliquidOutcomeCoinSchema = z.coerce
         example: '#1720',
     });
 
-// Outcome id (UInt64) for filtering across outcomes' two side coins.
-export const hyperliquidOutcomeIdSchema = z.coerce.number().int().nonnegative().meta({
-    type: 'integer',
-    description: 'HIP-4 outcome id (UInt64). One outcome has two side coins, `#<id*10>` and `#<id*10+1>`.',
-    example: 172,
-});
+// Outcome id (UInt64) for filtering across outcomes' two side coins. Accepted
+// as a numeric string so it round-trips through the ClickHouse `Array(UInt64)`
+// parameter type without losing precision on large values.
+export const hyperliquidOutcomeIdSchema = z.coerce
+    .string()
+    .regex(/^\d+$/, 'Outcome id must be a non-negative integer')
+    .meta({
+        type: 'integer',
+        description: 'HIP-4 outcome id (UInt64). One outcome has two side coins, `#<id*10>` and `#<id*10+1>`.',
+        example: '172',
+    });
 
 // Question id (UInt64) for filtering to a multi-outcome question's siblings.
-export const hyperliquidQuestionIdSchema = z.coerce.number().int().nonnegative().meta({
-    type: 'integer',
-    description:
-        'HIP-4 question id (UInt64). Groups multi-outcome questions (e.g. World Cup). Binary single-outcome markets have no question id.',
-    example: 32,
-});
+export const hyperliquidQuestionIdSchema = z.coerce
+    .string()
+    .regex(/^\d+$/, 'Question id must be a non-negative integer')
+    .meta({
+        type: 'integer',
+        description:
+            'HIP-4 question id (UInt64). Groups multi-outcome questions (e.g. World Cup). Binary single-outcome markets have no question id.',
+        example: '32',
+    });
 
 // Outcome status filter for `/v1/hyperliquid/outcomes`.
 const hyperliquidOutcomeStatusValues = ['live', 'settled', 'all'] as const;

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -1050,7 +1050,7 @@ export const hyperliquidOutcomeCoinSchema = z.coerce
     .meta({
         type: 'string',
         description:
-            'Outcome coin identifier in HIP-4 encoding: `#<outcome_id*10 + side_index>`. Side index is 0 or 1 indexing into `state_outcome_meta.side_specs`. Use `/v1/hyperliquid/outcomes` to discover outcomes and their side coins.',
+            'Outcome coin (`#<outcome_id*10 + side_index>`). Side index = 0 or 1. Discover via `/v1/hyperliquid/outcomes`.',
         example: '#1720',
     });
 


### PR DESCRIPTION
## Summary

- Adds four `/v1/hyperliquid/outcomes/*` endpoints serving HIP-4 outcome markets from the new `outcome_fills` table and `state_outcome_meta` / `state_question_meta` tables shipped in `substreams-hypercore` v0.4.0 / v0.4.1.
- Tightens `hyperliquidDexIdSchema` and `hyperliquidCoinSchema` so the existing `/v1/hyperliquid/*` family no longer serves outcome data — outcomes are now exclusively under `/outcomes/*`.

## Why

HIP-4 outcome markets have a different shape than perps/spot: settlement/composition events (`SPLIT_OUTCOME`, `MERGE_OUTCOME`, `MERGE_QUESTION`, `NEGATE_OUTCOME`, `SETTLEMENT`) don't fit the markets fill stream, and the two-coin Yes/No structure needs its own metadata join. Carving them out lets the markets endpoints stay simple and the outcomes endpoints expose the right primitives.

## Endpoints

- **`GET /v1/hyperliquid/outcomes`** ([src/routes/hyperliquid/outcomes.ts](src/routes/hyperliquid/outcomes.ts)) — Outcome listing with 24h trading rollup. Filters: `outcome_id`, `question_id`, `status` (live|settled|all), `quote_token`. Returns `sides[]` (two side coins per outcome) and `question{}` block inline; `question.question_id IS NULL` for binary single-outcome markets.
- **`GET /v1/hyperliquid/outcomes/ohlc`** ([src/routes/hyperliquid/outcomes_ohlc.ts](src/routes/hyperliquid/outcomes_ohlc.ts)) — Per-leg OHLCV candles from `state_ohlcv_outcomes`. Coin filter accepts `#N`. Drops the perp-only directional-volume fields (`open_long_volume`/etc.) and the `unique_users` join (no MV today).
- **`GET /v1/hyperliquid/outcomes/trades`** ([src/routes/hyperliquid/outcomes_trades.ts](src/routes/hyperliquid/outcomes_trades.ts)) — Raw fill stream over `outcome_fills`, joined to outcome metadata. Filters: `coin`, `outcome_id`, `question_id`, `user` (≥1 required). Surfaces all seven outcome directions.
- **`GET /v1/hyperliquid/outcomes/users`** ([src/routes/hyperliquid/outcomes_users.ts](src/routes/hyperliquid/outcomes_users.ts)) — Trading aggregates per outcome for a single user, with Yes+No legs collapsed per outcome. Backed by `state_user_by_coin` filtered to `dex='outcome'` (v0.4.1 UNION refresh).

## Behavior change vs prod (v0.2.2)

| Existing endpoint | Before | After |
|---|---|---|
| `/dexes` | included `outcome` row | dropped — outcomes have own family |
| `/markets*`, `/users` per-coin / per-dex | accepted `#N` coin / `dex=outcome` | rejects them at validation (400) |
| `/users` leaderboard, `/platform` | included outcome volumes | continues to include (v0.4.1 source MVs merge outcomes) |

Schema tightening in [src/types/zod.ts](src/types/zod.ts): `hyperliquidDexIdSchema` is now a strict enum of the 9 known builder DEXes; `hyperliquidCoinSchema` refuses `#N`-prefixed values with a pointer to the outcomes family.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)