### PR TITLE
chore: revert version to v3.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "pinax-api",
     "description": "Pinax API",
-    "version": "3.21.1",
+    "version": "3.21.0",
     "homepage": "https://github.com/pinax-network/pinax-api",
     "license": "Apache-2.0",
     "type": "module",


### PR DESCRIPTION
The v3.21.1 release was the docs follow-up to v3.21.0 ([#563](https://github.com/pinax-network/pinax-api/pull/563)). At the user's request the docs are being folded into the v3.21.0 release entirely — v3.21.1 release + tag will be deleted and v3.21.0 git tag will be moved forward to include the docs commit.

Resets `package.json` so the rebuilt v3.21.0 image reports the correct version string. (Without this, the rebuilt image would still self-report `3.21.1` via `/v1/version` while the release tag is `v3.21.0`.)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)