### PR TITLE
docs(hyperliquid): clarify outcome field semantics

### DIFF
--- a/src/routes/hyperliquid/outcomes.ts
+++ b/src/routes/hyperliquid/outcomes.ts
@@ -78,7 +78,7 @@ const responseSchema = apiUsageResponseSchema.extend({
                 .number()
                 .nullable()
                 .describe(
-                    'Last traded price on the Yes leg (side_index=0) over the last 24h. Independent of other legs in the same question. Null when the Yes leg has no recent activity even if the No leg traded — read `1 - price_no` via `/v1/hyperliquid/outcomes/ohlc` on `sides[1].coin` as a workaround. Sum across legs reflects market overround, not a normalized probability.'
+                    'Last traded price on the Yes leg (side_index=0) over the last 24h. Independent of other legs in the same question; sum across legs reflects market overround, not a normalized probability. Null when the Yes leg has no recent activity even if the No leg traded — query `/v1/hyperliquid/outcomes/ohlc` on `sides[1].coin` for the No-leg close.'
                 ),
             volume_24h: z
                 .number()

--- a/src/routes/hyperliquid/outcomes.ts
+++ b/src/routes/hyperliquid/outcomes.ts
@@ -62,7 +62,11 @@ const responseSchema = apiUsageResponseSchema.extend({
     data: z.array(
         z.object({
             outcome_id: z.number().int(),
-            name: z.string(),
+            name: z
+                .string()
+                .describe(
+                    'Outcome leaf name. For multi-outcome questions this is the per-leg label (team, candidate, bucket). For binary single-outcome markets (`question.question_id IS NULL`) this is the full market title.'
+                ),
             description: z.string(),
             side_specs: z.array(z.string()),
             status: z.string(),
@@ -70,9 +74,18 @@ const responseSchema = apiUsageResponseSchema.extend({
             settle_fraction: z.number().nullable(),
             settle_details: z.string().nullable(),
             sides: z.array(sideSchema),
-            price_yes: z.number().nullable(),
-            volume_24h: z.number(),
-            trades_24h: z.number().int(),
+            price_yes: z
+                .number()
+                .nullable()
+                .describe(
+                    'Last traded price on the Yes leg (side_index=0) over the last 24h. Independent of other legs in the same question. Null when the Yes leg has no recent activity even if the No leg traded — read `1 - price_no` via `/v1/hyperliquid/outcomes/ohlc` on `sides[1].coin` as a workaround. Sum across legs reflects market overround, not a normalized probability.'
+                ),
+            volume_24h: z
+                .number()
+                .describe(
+                    'Combined Yes+No leg taker notional over the last 24h, denominated in the outcome `quote_token`.'
+                ),
+            trades_24h: z.number().int().describe('Number of BUY/SELL taker fills across both legs in the last 24h.'),
             last_trade: dateTimeSchema.nullable(),
             question: questionSchema,
         })

--- a/src/routes/hyperliquid/outcomes_trades.ts
+++ b/src/routes/hyperliquid/outcomes_trades.ts
@@ -41,7 +41,11 @@ const responseSchema = apiUsageResponseSchema.extend({
             side_label: z.string(),
             outcome_name: z.string(),
             user: z.string(),
-            side: z.string(),
+            side: z
+                .string()
+                .describe(
+                    '`BID` = user bought this leg, `ASK` = user sold this leg. Composition events (`SPLIT_OUTCOME`/`MERGE_OUTCOME`/`MERGE_QUESTION`/`NEGATE_OUTCOME`) emit one row per leg involved; both legs of a SPLIT mint show as `BID`, both legs of a MERGE redeem show as `ASK`.'
+                ),
             direction: z.string(),
             price: z.number(),
             size: z.number(),

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -93,7 +93,14 @@ export const commit = z.coerce.string().regex(/^[0-9a-f]{7}$/);
 // e.g. 2025-01-01T12:00:00.000Z / 2025-01-01 12:00:00
 export const dateTimeSchema = z
     .string()
-    .regex(/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/, 'Invalid datetime format');
+    .regex(/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/, 'Invalid datetime format')
+    .meta({
+        type: 'string',
+        format: 'date-time',
+        description:
+            'UTC datetime. Returned in SQL form (`YYYY-MM-DD HH:MM:SS`) for ClickHouse-backed responses; ISO-8601 form (`YYYY-MM-DDTHH:MM:SS.sssZ`) is also accepted on parse.',
+        example: '2026-06-16 03:40:59',
+    });
 
 // Type exports
 export type EvmAddress = z.infer<typeof evmAddress>;

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -96,7 +96,6 @@ export const dateTimeSchema = z
     .regex(/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/, 'Invalid datetime format')
     .meta({
         type: 'string',
-        format: 'date-time',
         description:
             'UTC datetime. Returned in SQL form (`YYYY-MM-DD HH:MM:SS`) for ClickHouse-backed responses; ISO-8601 form (`YYYY-MM-DDTHH:MM:SS.sssZ`) is also accepted on parse.',
         example: '2026-06-16 03:40:59',

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -97,7 +97,7 @@ export const dateTimeSchema = z
     .meta({
         type: 'string',
         description:
-            'UTC datetime. Returned in SQL form (`YYYY-MM-DD HH:MM:SS`) for ClickHouse-backed responses; ISO-8601 form (`YYYY-MM-DDTHH:MM:SS.sssZ`) is also accepted on parse.',
+            'Datetime. Returned in SQL form (`YYYY-MM-DD HH:MM:SS`) on ClickHouse-backed responses, in the server timezone (UTC). See `pattern` for accepted input formats.',
         example: '2026-06-16 03:40:59',
     });
 


### PR DESCRIPTION
## Summary

Adds field-level descriptions on the `/v1/hyperliquid/outcomes/*` endpoints to remove ambiguities first-time integrators hit. Documentation-only — no response shape changes.

- `dateTimeSchema`: documents UTC + the two accepted shapes (SQL `YYYY-MM-DD HH:MM:SS` and ISO-8601 `T...Z`)
- `/outcomes` `name`: explains the leaf-vs-market-title dual semantics
- `/outcomes` `price_yes`: clarifies that null does not imply outcome inactivity (the No leg may carry the activity); cross-leg sum reflects market overround, not a normalized probability
- `/outcomes` `volume_24h` + `trades_24h`: spell out the combined-leg aggregation
- `/outcomes/trades` `side`: documents BID/ASK semantics including the cross-leg composition cases (SPLIT / MERGE / NEGATE)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)