### PR TITLE
feat(hyperliquid): outcomes endpoint follow-ups

### DIFF
--- a/src/routes/hyperliquid/outcomes.sql
+++ b/src/routes/hyperliquid/outcomes.sql
@@ -27,7 +27,7 @@ WITH
         FROM rollup
         GROUP BY outcome_id
     ),
-    price_yes AS (
+    price_yes_cur AS (
         SELECT
             intDiv(toUInt64(splitByChar('#', coin)[2]), 10) AS outcome_id,
             toNullable(argMaxMerge(close))                  AS price_yes
@@ -35,6 +35,38 @@ WITH
         WHERE interval_min = 60
           AND (toUInt64(splitByChar('#', coin)[2]) % 10) = 0
           AND timestamp >= now() - INTERVAL 24 HOUR
+        GROUP BY coin
+    ),
+    price_no_cur AS (
+        SELECT
+            intDiv(toUInt64(splitByChar('#', coin)[2]), 10) AS outcome_id,
+            toNullable(argMaxMerge(close))                  AS price_no
+        FROM {db_hypercore:Identifier}.state_ohlcv_outcomes
+        WHERE interval_min = 60
+          AND (toUInt64(splitByChar('#', coin)[2]) % 10) = 1
+          AND timestamp >= now() - INTERVAL 24 HOUR
+        GROUP BY coin
+    ),
+    price_yes_prev AS (
+        SELECT
+            intDiv(toUInt64(splitByChar('#', coin)[2]), 10) AS outcome_id,
+            toNullable(argMaxMerge(close))                  AS price_yes_24h
+        FROM {db_hypercore:Identifier}.state_ohlcv_outcomes
+        WHERE interval_min = 60
+          AND (toUInt64(splitByChar('#', coin)[2]) % 10) = 0
+          AND timestamp >= now() - INTERVAL 48 HOUR
+          AND timestamp <  now() - INTERVAL 24 HOUR
+        GROUP BY coin
+    ),
+    price_no_prev AS (
+        SELECT
+            intDiv(toUInt64(splitByChar('#', coin)[2]), 10) AS outcome_id,
+            toNullable(argMaxMerge(close))                  AS price_no_24h
+        FROM {db_hypercore:Identifier}.state_ohlcv_outcomes
+        WHERE interval_min = 60
+          AND (toUInt64(splitByChar('#', coin)[2]) % 10) = 1
+          AND timestamp >= now() - INTERVAL 48 HOUR
+          AND timestamp <  now() - INTERVAL 24 HOUR
         GROUP BY coin
     ),
     questions AS (
@@ -63,7 +95,16 @@ SELECT
         )
         AS Array(Tuple(label String, coin String, side_index UInt8))
     )                                                                     AS sides,
-    py.price_yes                                                          AS price_yes,
+    pyc.price_yes                                                         AS price_yes,
+    pnc.price_no                                                          AS price_no,
+    pyp.price_yes_24h                                                     AS price_yes_24h,
+    pnp.price_no_24h                                                      AS price_no_24h,
+    if(isNotNull(pyp.price_yes_24h) AND pyp.price_yes_24h > 0 AND isNotNull(pyc.price_yes),
+       (pyc.price_yes - pyp.price_yes_24h) / pyp.price_yes_24h,
+       NULL)                                                              AS price_yes_24h_change,
+    if(isNotNull(pnp.price_no_24h) AND pnp.price_no_24h > 0 AND isNotNull(pnc.price_no),
+       (pnc.price_no - pnp.price_no_24h) / pnp.price_no_24h,
+       NULL)                                                              AS price_no_24h_change,
     coalesce(r.volume_24h, 0)                                             AS volume_24h,
     coalesce(r.trades_24h, 0)                                             AS trades_24h,
     r.last_trade                                                          AS last_trade,
@@ -86,9 +127,12 @@ SELECT
         )
     )                                                                     AS question
 FROM meta AS m
-LEFT JOIN rollup_agg AS r USING (outcome_id)
-LEFT JOIN price_yes  AS py USING (outcome_id)
-LEFT JOIN questions  AS q ON q.question_id = m.question_id
+LEFT JOIN rollup_agg    AS r   USING (outcome_id)
+LEFT JOIN price_yes_cur AS pyc USING (outcome_id)
+LEFT JOIN price_no_cur  AS pnc USING (outcome_id)
+LEFT JOIN price_yes_prev AS pyp USING (outcome_id)
+LEFT JOIN price_no_prev  AS pnp USING (outcome_id)
+LEFT JOIN questions      AS q ON q.question_id = m.question_id
 ORDER BY
     if({sort_by:String} = 'volume_24h', coalesce(r.volume_24h, 0), 0)     DESC,
     if({sort_by:String} = 'outcome_id', -toInt64(m.outcome_id), 0)        DESC,

--- a/src/routes/hyperliquid/outcomes.sql
+++ b/src/routes/hyperliquid/outcomes.sql
@@ -1,4 +1,9 @@
 WITH
+    all_questions AS (
+        SELECT question_id, name, description, fallback_outcome_id,
+               named_outcome_ids, settled_outcome_ids
+        FROM {db_hypercore:Identifier}.state_question_meta FINAL
+    ),
     meta AS (
         SELECT outcome_id, question_id, name, description, side_specs, quote_token,
                status, settle_fraction, settle_details
@@ -8,9 +13,7 @@ WITH
           AND ({status:String} = 'all' OR status = {status:String})
           AND (isNull({quote_token:Nullable(String)}) OR quote_token = {quote_token:Nullable(String)})
           AND ({include_fallback:Bool} OR outcome_id NOT IN (
-              SELECT fallback_outcome_id
-              FROM {db_hypercore:Identifier}.state_question_meta FINAL
-              WHERE fallback_outcome_id IS NOT NULL
+              SELECT fallback_outcome_id FROM all_questions WHERE fallback_outcome_id IS NOT NULL
           ))
     ),
     rollup AS (
@@ -75,9 +78,7 @@ WITH
         GROUP BY coin
     ),
     questions AS (
-        SELECT question_id, name, description, fallback_outcome_id,
-               named_outcome_ids, settled_outcome_ids
-        FROM {db_hypercore:Identifier}.state_question_meta FINAL
+        SELECT * FROM all_questions
         WHERE question_id IN (SELECT question_id FROM meta WHERE question_id IS NOT NULL)
     )
 SELECT

--- a/src/routes/hyperliquid/outcomes.sql
+++ b/src/routes/hyperliquid/outcomes.sql
@@ -7,6 +7,11 @@ WITH
           AND (empty({question_id:Array(String)})  OR question_id IN (SELECT toUInt64(arrayJoin({question_id:Array(String)}))))
           AND ({status:String} = 'all' OR status = {status:String})
           AND (isNull({quote_token:Nullable(String)}) OR quote_token = {quote_token:Nullable(String)})
+          AND ({include_fallback:Bool} OR outcome_id NOT IN (
+              SELECT fallback_outcome_id
+              FROM {db_hypercore:Identifier}.state_question_meta FINAL
+              WHERE fallback_outcome_id IS NOT NULL
+          ))
     ),
     rollup AS (
         SELECT

--- a/src/routes/hyperliquid/outcomes.sql
+++ b/src/routes/hyperliquid/outcomes.sql
@@ -12,9 +12,11 @@ WITH
           AND (empty({question_id:Array(String)})  OR question_id IN (SELECT toUInt64(arrayJoin({question_id:Array(String)}))))
           AND ({status:String} = 'all' OR status = {status:String})
           AND (isNull({quote_token:Nullable(String)}) OR quote_token = {quote_token:Nullable(String)})
-          AND ({include_fallback:Bool} OR outcome_id NOT IN (
-              SELECT fallback_outcome_id FROM all_questions WHERE fallback_outcome_id IS NOT NULL
-          ))
+          AND ({include_fallback:Bool}
+               OR notEmpty({outcome_id:Array(String)})
+               OR outcome_id NOT IN (
+                   SELECT fallback_outcome_id FROM all_questions WHERE fallback_outcome_id IS NOT NULL
+               ))
     ),
     rollup AS (
         SELECT

--- a/src/routes/hyperliquid/outcomes.ts
+++ b/src/routes/hyperliquid/outcomes.ts
@@ -38,7 +38,7 @@ const quoteTokenSchema = z
 
 const includeFallbackSchema = booleanFromString.meta({
     description:
-        'When `true`, include each multi-outcome question\'s fallback row (the catch-all "none of the above" leg). Defaults to `false` so list responses match the named outcomes a UI would render.',
+        'When `true`, include each multi-outcome question\'s fallback row (the catch-all "none of the above" leg). Defaults to `false` so list responses match the named outcomes a UI would render. Explicit `outcome_id` lookups always return the requested rows regardless of this flag.',
 });
 
 const querySchema = createQuerySchema({

--- a/src/routes/hyperliquid/outcomes.ts
+++ b/src/routes/hyperliquid/outcomes.ts
@@ -78,12 +78,39 @@ const responseSchema = apiUsageResponseSchema.extend({
                 .number()
                 .nullable()
                 .describe(
-                    'Last traded price on the Yes leg (side_index=0) over the last 24h. Independent of other legs in the same question; sum across legs reflects market overround, not a normalized probability. Null when the Yes leg has no recent activity even if the No leg traded — query `/v1/hyperliquid/outcomes/ohlc` on `sides[1].coin` for the No-leg close.'
+                    'Last traded price on the Yes leg (side_index=0) within the last 24h. Independent of `price_no`; sum across legs reflects market overround, not a normalized probability. Null when the Yes leg has no activity in the window even if the No leg traded — read `price_no` for the No-leg quote.'
                 ),
+            price_no: z
+                .number()
+                .nullable()
+                .describe(
+                    'Last traded price on the No leg (side_index=1) within the last 24h. Independent of `price_yes`. Null when the No leg has no activity in the window.'
+                ),
+            price_yes_24h: z
+                .number()
+                .nullable()
+                .describe(
+                    'Close on the Yes leg from 24–48h ago (matches `/v1/hyperliquid/markets`' +
+                        ' `price_24h` convention). Null when no trades occurred in that window.'
+                ),
+            price_no_24h: z
+                .number()
+                .nullable()
+                .describe('Close on the No leg from 24–48h ago. Null when no trades occurred in that window.'),
+            price_yes_24h_change: z
+                .number()
+                .nullable()
+                .describe(
+                    'Decimal price change on the Yes leg over the last 24h, computed as `(price_yes - price_yes_24h) / price_yes_24h`. Null when either anchor is missing.'
+                ),
+            price_no_24h_change: z
+                .number()
+                .nullable()
+                .describe('Decimal price change on the No leg over the last 24h. Null when either anchor is missing.'),
             volume_24h: z
                 .number()
                 .describe(
-                    'Combined Yes+No leg taker notional over the last 24h, denominated in the outcome `quote_token`.'
+                    'Combined Yes+No leg taker notional over the last 24h, denominated in the outcome `quote_token`. Direction is signalled via `price_yes_24h_change` / `price_no_24h_change`, mirroring the convention used by Polymarket and Kalshi.'
                 ),
             trades_24h: z.number().int().describe('Number of BUY/SELL taker fills across both legs in the last 24h.'),
             last_trade: dateTimeSchema.nullable(),
@@ -110,7 +137,7 @@ const openapi = describeRoute(
                                 value: {
                                     data: [
                                         {
-                                            outcome_id: 172,
+                                            outcome_id: 173,
                                             name: 'Argentina',
                                             description:
                                                 'This outcome resolves to Yes if Argentina is officially declared the 2026 FIFA World Cup champion.',
@@ -120,13 +147,18 @@ const openapi = describeRoute(
                                             settle_fraction: null,
                                             settle_details: null,
                                             sides: [
-                                                { label: 'Yes', coin: '#1720', side_index: 0 },
-                                                { label: 'No', coin: '#1721', side_index: 1 },
+                                                { label: 'Yes', coin: '#1730', side_index: 0 },
+                                                { label: 'No', coin: '#1731', side_index: 1 },
                                             ],
-                                            price_yes: 0.012,
-                                            volume_24h: 4521.32,
-                                            trades_24h: 18,
-                                            last_trade: '2026-06-12 13:38:55',
+                                            price_yes: 0.09604,
+                                            price_no: 0.90313,
+                                            price_yes_24h: 0.09425,
+                                            price_no_24h: 0.90575,
+                                            price_yes_24h_change: 0.018992,
+                                            price_no_24h_change: -0.002893,
+                                            volume_24h: 82430.17,
+                                            trades_24h: 93,
+                                            last_trade: '2026-06-16 15:50:51',
                                             question: {
                                                 question_id: 32,
                                                 name: '2026 World Cup Champion',

--- a/src/routes/hyperliquid/outcomes.ts
+++ b/src/routes/hyperliquid/outcomes.ts
@@ -6,6 +6,7 @@ import { config } from '../../config.js';
 import { handleUsageQueryError, makeUsageQueryJson } from '../../handleQuery.js';
 import {
     apiUsageResponseSchema,
+    booleanFromString,
     createQuerySchema,
     dateTimeSchema,
     hyperliquidOutcomeIdSchema,
@@ -35,11 +36,17 @@ const quoteTokenSchema = z
         example: 'USDC',
     });
 
+const includeFallbackSchema = booleanFromString.meta({
+    description:
+        'When `true`, include each multi-outcome question\'s fallback row (the catch-all "none of the above" leg). Defaults to `false` so list responses match the named outcomes a UI would render.',
+});
+
 const querySchema = createQuerySchema({
     outcome_id: { schema: hyperliquidOutcomeIdSchema, batched: true, optional: true },
     question_id: { schema: hyperliquidQuestionIdSchema, batched: true, optional: true },
     status: { schema: hyperliquidOutcomeStatusSchema, prefault: 'live' },
     quote_token: { schema: quoteTokenSchema, optional: true },
+    include_fallback: { schema: includeFallbackSchema, default: false },
     sort_by: { schema: outcomesSortBySchema, prefault: 'volume_24h' },
 });
 

--- a/src/routes/hyperliquid/outcomes_ohlc.sql
+++ b/src/routes/hyperliquid/outcomes_ohlc.sql
@@ -1,11 +1,4 @@
 WITH
-    coin_parts AS (
-        SELECT
-            {coin:String}                                              AS coin,
-            toUInt64(splitByChar('#', {coin:String})[2])               AS coin_id,
-            intDiv(toUInt64(splitByChar('#', {coin:String})[2]), 10)   AS outcome_id,
-            toUInt8(toUInt64(splitByChar('#', {coin:String})[2]) % 10) AS side_index
-    ),
     bounds AS (
         SELECT
             min(timestamp) AS start_ts,
@@ -13,7 +6,7 @@ WITH
         FROM (
             SELECT timestamp
             FROM {db_hypercore:Identifier}.state_ohlcv_outcomes
-            WHERE coin = {coin:String}
+            WHERE coin IN {coin:Array(String)}
               AND interval_min = {interval:UInt32}
               AND (isNull({start_time:Nullable(UInt64)}) OR timestamp >= toDateTime({start_time:Nullable(UInt64)}))
               AND (isNull({end_time:Nullable(UInt64)})   OR timestamp <  toDateTime({end_time:Nullable(UInt64)}))
@@ -25,17 +18,20 @@ WITH
     meta AS (
         SELECT
             outcome_id,
-            name                                                       AS outcome_name,
+            name AS outcome_name,
             side_specs
         FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
-        WHERE outcome_id = (SELECT outcome_id FROM coin_parts)
+        WHERE outcome_id IN (
+            SELECT intDiv(toUInt64(splitByChar('#', c)[2]), 10)
+            FROM (SELECT arrayJoin({coin:Array(String)}) AS c)
+        )
     )
 SELECT
     candles.timestamp                                              AS timestamp,
     candles.coin                                                   AS coin,
-    (SELECT outcome_id FROM coin_parts)                            AS outcome_id,
-    (SELECT side_index FROM coin_parts)                            AS side_index,
-    coalesce(m.side_specs[(SELECT side_index FROM coin_parts) + 1], '') AS side_label,
+    intDiv(toUInt64(splitByChar('#', candles.coin)[2]), 10)        AS outcome_id,
+    toUInt8(toUInt64(splitByChar('#', candles.coin)[2]) % 10)      AS side_index,
+    coalesce(m.side_specs[toUInt8(toUInt64(splitByChar('#', candles.coin)[2]) % 10) + 1], '') AS side_label,
     coalesce(m.outcome_name, '')                                   AS outcome_name,
     candles.interval_min                                           AS interval_min,
     candles.open                                                   AS open,
@@ -64,12 +60,12 @@ FROM (
         sum(t.transactions)                                        AS transactions,
         sum(t.total_fees)                                          AS total_fees
     FROM {db_hypercore:Identifier}.state_ohlcv_outcomes AS t
-    WHERE t.coin = {coin:String}
+    WHERE t.coin IN {coin:Array(String)}
       AND t.interval_min = {interval:UInt32}
       AND t.timestamp >= (SELECT start_ts FROM bounds)
       AND t.timestamp <= (SELECT end_ts FROM bounds)
     GROUP BY t.interval_min, t.coin, t.timestamp
     SETTINGS optimize_aggregation_in_order = 1
 ) AS candles
-LEFT JOIN meta AS m ON 1 = 1
-ORDER BY candles.timestamp DESC
+LEFT JOIN meta AS m ON m.outcome_id = intDiv(toUInt64(splitByChar('#', candles.coin)[2]), 10)
+ORDER BY candles.timestamp DESC, candles.coin

--- a/src/routes/hyperliquid/outcomes_ohlc.sql
+++ b/src/routes/hyperliquid/outcomes_ohlc.sql
@@ -29,9 +29,9 @@ WITH
 SELECT
     candles.timestamp                                              AS timestamp,
     candles.coin                                                   AS coin,
-    intDiv(toUInt64(splitByChar('#', candles.coin)[2]), 10)        AS outcome_id,
-    toUInt8(toUInt64(splitByChar('#', candles.coin)[2]) % 10)      AS side_index,
-    coalesce(m.side_specs[toUInt8(toUInt64(splitByChar('#', candles.coin)[2]) % 10) + 1], '') AS side_label,
+    candles.outcome_id                                             AS outcome_id,
+    candles.side_index                                             AS side_index,
+    coalesce(m.side_specs[candles.side_index + 1], '')             AS side_label,
     coalesce(m.outcome_name, '')                                   AS outcome_name,
     candles.interval_min                                           AS interval_min,
     candles.open                                                   AS open,
@@ -48,6 +48,8 @@ FROM (
     SELECT
         t.timestamp                                                AS timestamp,
         t.coin                                                     AS coin,
+        intDiv(toUInt64(splitByChar('#', t.coin)[2]), 10)          AS outcome_id,
+        toUInt8(toUInt64(splitByChar('#', t.coin)[2]) % 10)        AS side_index,
         t.interval_min                                             AS interval_min,
         argMinMerge(t.open)                                        AS open,
         quantilesDeterministicMerge(0.05, 0.95)(t.quantile)[2]     AS high_quantile,
@@ -67,5 +69,5 @@ FROM (
     GROUP BY t.interval_min, t.coin, t.timestamp
     SETTINGS optimize_aggregation_in_order = 1
 ) AS candles
-LEFT JOIN meta AS m ON m.outcome_id = intDiv(toUInt64(splitByChar('#', candles.coin)[2]), 10)
+LEFT JOIN meta AS m ON m.outcome_id = candles.outcome_id
 ORDER BY candles.timestamp DESC, candles.coin

--- a/src/routes/hyperliquid/outcomes_ohlc.ts
+++ b/src/routes/hyperliquid/outcomes_ohlc.ts
@@ -10,14 +10,26 @@ import {
     dateTimeSchema,
     evmIntervalSchema,
     hyperliquidOutcomeCoinSchema,
+    hyperliquidOutcomeIdSchema,
     timestampSchema,
 } from '../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../utils.js';
 
 import query from './outcomes_ohlc.sql' with { type: 'text' };
 
+const sideValues = ['yes', 'no', 'both'] as const;
+const sideSchema = z.enum(sideValues).meta({
+    type: 'string',
+    enum: sideValues,
+    default: 'yes',
+    description:
+        '`yes` (default) returns candles for the side at `side_index=0`, `no` for `side_index=1`, `both` returns both legs interleaved. Only used in combination with `outcome_id`; ignored when `coin` is provided explicitly.',
+});
+
 const querySchema = createQuerySchema({
-    coin: { schema: hyperliquidOutcomeCoinSchema },
+    coin: { schema: hyperliquidOutcomeCoinSchema, batched: true, optional: true },
+    outcome_id: { schema: hyperliquidOutcomeIdSchema, batched: true, optional: true },
+    side: { schema: sideSchema, prefault: 'yes' },
     interval: { schema: evmIntervalSchema, prefault: '1h' },
     start_time: { schema: timestampSchema, optional: true },
     end_time: { schema: timestampSchema, optional: true },
@@ -51,7 +63,7 @@ const openapi = describeRoute(
     withErrorResponses({
         summary: 'Outcome OHLCV',
         description:
-            'Returns OHLCV candles for a single outcome leg (one Yes/No side) over the requested interval. Trade-side fields (`buy_volume`, `sell_volume`) carry the directional split: `buy_volume` counts taker buys of this leg, `sell_volume` counts taker sells. Composition events (SPLIT_OUTCOME, MERGE_OUTCOME, MERGE_QUESTION, NEGATE_OUTCOME) and SETTLEMENT payouts are excluded from candles by design; query them via `/v1/hyperliquid/outcomes/trades` for the raw stream.\n\n`total_fees` is currently always zero on outcomes since Hyperliquid does not charge per-trade fees on HIP-4 markets. Field retained for forward compatibility.',
+            "Returns OHLCV candles for one or more outcome legs over the requested interval. Provide either `coin` (full Hyperliquid coin identifier, e.g. `#1730`) or `outcome_id` (UInt64); both accept CSV for batched grid views. With `outcome_id`, the `side` selector resolves to side_index 0 (`yes`, default), 1 (`no`), or returns both (`both`).\n\nTrade-side fields (`buy_volume`, `sell_volume`) carry the directional split: `buy_volume` counts taker buys of this leg, `sell_volume` counts taker sells. Composition events (SPLIT_OUTCOME, MERGE_OUTCOME, MERGE_QUESTION, NEGATE_OUTCOME) and SETTLEMENT payouts are excluded from candles by design; query them via `/v1/hyperliquid/outcomes/trades` for the raw stream.\n\nWhen multiple legs are requested, each timestamp bucket is paginated as a unit — the response contains every requested leg's candle for the most recent `limit` distinct timestamps. `total_fees` is currently always zero on outcomes since Hyperliquid does not charge per-trade fees on HIP-4 markets. Field retained for forward compatibility.",
         tags: ['Hyperliquid Outcomes'],
         security: [{ bearerAuth: [] }],
         responses: {
@@ -61,26 +73,71 @@ const openapi = describeRoute(
                     'application/json': {
                         schema: resolver(responseSchema),
                         examples: {
-                            default: {
+                            single_leg: {
                                 value: {
                                     data: [
                                         {
-                                            timestamp: '2026-06-15 05:00:00',
-                                            coin: '#3290',
-                                            outcome_id: 329,
+                                            timestamp: '2026-06-16 15:00:00',
+                                            coin: '#1730',
+                                            outcome_id: 173,
                                             side_index: 0,
                                             side_label: 'Yes',
-                                            outcome_name: 'Recurring',
+                                            outcome_name: 'Argentina',
                                             interval_min: 60,
-                                            open: 0.99999,
-                                            high: 0.99999,
-                                            low: 0.99999,
-                                            close: 0.99999,
-                                            buy_volume: 48008.52,
-                                            sell_volume: 0,
-                                            gross_volume: 48008.52,
-                                            net_volume: 48008.52,
-                                            transactions: 60,
+                                            open: 0.09562,
+                                            high: 0.09732,
+                                            low: 0.09525,
+                                            close: 0.09688,
+                                            buy_volume: 4521.32,
+                                            sell_volume: 2814.71,
+                                            gross_volume: 7336.03,
+                                            net_volume: 1706.61,
+                                            transactions: 18,
+                                            total_fees: 0,
+                                        },
+                                    ],
+                                },
+                            },
+                            both_legs: {
+                                summary: 'outcome_id=173&side=both — Yes and No interleaved per timestamp',
+                                value: {
+                                    data: [
+                                        {
+                                            timestamp: '2026-06-16 15:00:00',
+                                            coin: '#1730',
+                                            outcome_id: 173,
+                                            side_index: 0,
+                                            side_label: 'Yes',
+                                            outcome_name: 'Argentina',
+                                            interval_min: 60,
+                                            open: 0.09562,
+                                            high: 0.09732,
+                                            low: 0.09525,
+                                            close: 0.09688,
+                                            buy_volume: 4521.32,
+                                            sell_volume: 2814.71,
+                                            gross_volume: 7336.03,
+                                            net_volume: 1706.61,
+                                            transactions: 18,
+                                            total_fees: 0,
+                                        },
+                                        {
+                                            timestamp: '2026-06-16 15:00:00',
+                                            coin: '#1731',
+                                            outcome_id: 173,
+                                            side_index: 1,
+                                            side_label: 'No',
+                                            outcome_name: 'Argentina',
+                                            interval_min: 60,
+                                            open: 0.90438,
+                                            high: 0.90475,
+                                            low: 0.90268,
+                                            close: 0.90305,
+                                            buy_volume: 1820.55,
+                                            sell_volume: 3104.88,
+                                            gross_volume: 4925.43,
+                                            net_volume: -1284.33,
+                                            transactions: 12,
                                             total_fees: 0,
                                         },
                                     ],
@@ -99,6 +156,20 @@ const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>
 route.get('/', openapi, zValidator('query', querySchema, validatorHook), validator('query', querySchema), async (c) => {
     const params = c.req.valid('query');
 
+    if (!params.coin.length && !params.outcome_id.length) {
+        return c.json(
+            { status: 400, code: 'bad_query_input', message: 'Provide at least one of coin or outcome_id' },
+            400
+        );
+    }
+
+    const resolvedCoins = new Set<string>(params.coin);
+    for (const oid of params.outcome_id) {
+        const base = BigInt(oid) * 10n;
+        if (params.side === 'yes' || params.side === 'both') resolvedCoins.add(`#${base}`);
+        if (params.side === 'no' || params.side === 'both') resolvedCoins.add(`#${base + 1n}`);
+    }
+
     const hypercore = config.hypercoreDatabases.hyperliquid;
     if (!hypercore) {
         return c.json({ error: 'Hyperliquid not configured' }, 500);
@@ -106,6 +177,7 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
 
     const response = await makeUsageQueryJson(c, [query], {
         ...params,
+        coin: [...resolvedCoins],
         network: 'hyperliquid',
         db_hypercore: hypercore.database,
     });


### PR DESCRIPTION
## Summary

Three independent field/parameter additions on the `/v1/hyperliquid/outcomes/*` endpoints, bundled into one PR after the field-level documentation pass in #566.

- **`/outcomes/ohlc`** — accept `outcome_id` (single or CSV) with `side=yes|no|both`; resolver maps to the right `#<id*10+i>` coin server-side. `coin` keeps working and also accepts CSV. Multi-leg pagination keeps each timestamp bucket as a unit (`limit` distinct timestamps, all requested legs).
- **`/outcomes`** — add `price_no`, `price_yes_24h`, `price_no_24h`, `price_yes_24h_change`, `price_no_24h_change`. Mirrors the `/v1/hyperliquid/markets` `price_24h` / `price_24h_change` convention and aligns with the prediction-market peer convention (gross volume + price-change indicator). `price_yes` and `volume_24h` keep their existing semantics. All new fields are nullable.
- **`/outcomes`** — `include_fallback` (default `false`). Hides each multi-outcome question's fallback leg by default. Set to `true` for completeness / audit views; identify a fallback row via `outcome_id === question.fallback_outcome_id` or `name === "Fallback"`.

Base set to `docs/outcomes-field-clarifications` (#566); merge that PR first so this rebases cleanly onto main with 3 commits.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)