### PR TITLE
feat(hyperliquid): coin auto-prefix + drop always-zero total_fees

### DIFF
--- a/src/routes/hyperliquid/outcomes_ohlc.sql
+++ b/src/routes/hyperliquid/outcomes_ohlc.sql
@@ -42,8 +42,7 @@ SELECT
     candles.sell_volume                                            AS sell_volume,
     candles.gross_volume                                           AS gross_volume,
     candles.net_volume                                             AS net_volume,
-    candles.transactions                                           AS transactions,
-    candles.total_fees                                             AS total_fees
+    candles.transactions                                           AS transactions
 FROM (
     SELECT
         t.timestamp                                                AS timestamp,
@@ -59,8 +58,7 @@ FROM (
         sum(t.taker_sell_volume)                                   AS sell_volume,
         sum(t.taker_buy_volume) + sum(t.taker_sell_volume)         AS gross_volume,
         sum(t.taker_buy_volume) - sum(t.taker_sell_volume)         AS net_volume,
-        sum(t.transactions)                                        AS transactions,
-        sum(t.total_fees)                                          AS total_fees
+        sum(t.transactions)                                        AS transactions
     FROM {db_hypercore:Identifier}.state_ohlcv_outcomes AS t
     WHERE t.coin IN {coin:Array(String)}
       AND t.interval_min = {interval:UInt32}

--- a/src/routes/hyperliquid/outcomes_ohlc.ts
+++ b/src/routes/hyperliquid/outcomes_ohlc.ts
@@ -54,7 +54,6 @@ const responseSchema = apiUsageResponseSchema.extend({
             gross_volume: z.number(),
             net_volume: z.number(),
             transactions: z.number().int(),
-            total_fees: z.number(),
         })
     ),
 });
@@ -63,7 +62,7 @@ const openapi = describeRoute(
     withErrorResponses({
         summary: 'Outcome OHLCV',
         description:
-            "Returns OHLCV candles for one or more outcome legs over the requested interval. Provide either `coin` (full Hyperliquid coin identifier, e.g. `#1730`) or `outcome_id` (UInt64); both accept CSV for batched grid views. With `outcome_id`, the `side` selector resolves to side_index 0 (`yes`, default), 1 (`no`), or returns both (`both`).\n\nTrade-side fields (`buy_volume`, `sell_volume`) carry the directional split: `buy_volume` counts taker buys of this leg, `sell_volume` counts taker sells. Composition events (SPLIT_OUTCOME, MERGE_OUTCOME, MERGE_QUESTION, NEGATE_OUTCOME) and SETTLEMENT payouts are excluded from candles by design; query them via `/v1/hyperliquid/outcomes/trades` for the raw stream.\n\nWhen multiple legs are requested, each timestamp bucket is paginated as a unit — the response contains every requested leg's candle for the most recent `limit` distinct timestamps. `total_fees` is currently always zero on outcomes since Hyperliquid does not charge per-trade fees on HIP-4 markets. Field retained for forward compatibility.",
+            "Returns OHLCV candles for one or more outcome legs over the requested interval. Provide either `coin` (full Hyperliquid coin identifier, e.g. `#1730`) or `outcome_id` (UInt64); both accept CSV for batched grid views. With `outcome_id`, the `side` selector resolves to side_index 0 (`yes`, default), 1 (`no`), or returns both (`both`).\n\nTrade-side fields (`buy_volume`, `sell_volume`) carry the directional split: `buy_volume` counts taker buys of this leg, `sell_volume` counts taker sells. Composition events (SPLIT_OUTCOME, MERGE_OUTCOME, MERGE_QUESTION, NEGATE_OUTCOME) and SETTLEMENT payouts are excluded from candles by design; query them via `/v1/hyperliquid/outcomes/trades` for the raw stream.\n\nWhen multiple legs are requested, each timestamp bucket is paginated as a unit — the response contains every requested leg's candle for the most recent `limit` distinct timestamps.",
         tags: ['Hyperliquid Outcomes'],
         security: [{ bearerAuth: [] }],
         responses: {
@@ -93,7 +92,6 @@ const openapi = describeRoute(
                                             gross_volume: 7336.03,
                                             net_volume: 1706.61,
                                             transactions: 18,
-                                            total_fees: 0,
                                         },
                                     ],
                                 },
@@ -119,7 +117,6 @@ const openapi = describeRoute(
                                             gross_volume: 7336.03,
                                             net_volume: 1706.61,
                                             transactions: 18,
-                                            total_fees: 0,
                                         },
                                         {
                                             timestamp: '2026-06-16 15:00:00',
@@ -138,7 +135,6 @@ const openapi = describeRoute(
                                             gross_volume: 4925.43,
                                             net_volume: -1284.33,
                                             transactions: 12,
-                                            total_fees: 0,
                                         },
                                     ],
                                 },

--- a/src/routes/hyperliquid/outcomes_users.sql
+++ b/src/routes/hyperliquid/outcomes_users.sql
@@ -14,7 +14,6 @@ WITH
             volume_bought,
             volume_sold,
             total_volume,
-            total_fees,
             realized_pnl,
             first_trade,
             last_trade
@@ -35,7 +34,6 @@ SELECT
     sum(r.volume_bought)                                     AS volume_bought,
     sum(r.volume_sold)                                       AS volume_sold,
     sum(r.total_volume)                                      AS total_volume,
-    sum(r.total_fees)                                        AS total_fees,
     sum(r.realized_pnl)                                      AS realized_pnl,
     min(r.first_trade)                                       AS first_trade,
     max(r.last_trade)                                        AS last_trade,

--- a/src/routes/hyperliquid/outcomes_users.ts
+++ b/src/routes/hyperliquid/outcomes_users.ts
@@ -44,7 +44,6 @@ const responseSchema = apiUsageResponseSchema.extend({
             volume_bought: z.number(),
             volume_sold: z.number(),
             total_volume: z.number(),
-            total_fees: z.number(),
             realized_pnl: z.number(),
             first_trade: dateTimeSchema,
             last_trade: dateTimeSchema,
@@ -57,7 +56,7 @@ const openapi = describeRoute(
     withErrorResponses({
         summary: 'Outcome User Activity',
         description:
-            'Returns trading aggregates per outcome for a given user, with both side legs (Yes/No or custom labels) collapsed into one row per outcome. Includes fill count, buys/sells split, volume bought/sold, realized PnL, and first/last trade times across all seven outcome directions (BUY/SELL/SETTLEMENT/SPLIT_OUTCOME/MERGE_OUTCOME/MERGE_QUESTION/NEGATE_OUTCOME).\n\n`user` is required; `outcome_id` and `question_id` narrow further. Sorted by `total_volume` descending. Backed by `state_user_by_coin` (hourly refresh; `interval=1h` lags up to 1h).\n\n`total_fees` is currently always zero on outcomes since Hyperliquid does not charge per-trade fees on HIP-4 markets.\n\n`question.question_id IS NULL` indicates a binary single-outcome market (no parent question grouping in HL `outcomeMeta`).',
+            'Returns trading aggregates per outcome for a given user, with both side legs (Yes/No or custom labels) collapsed into one row per outcome. Includes fill count, buys/sells split, volume bought/sold, realized PnL, and first/last trade times across all seven outcome directions (BUY/SELL/SETTLEMENT/SPLIT_OUTCOME/MERGE_OUTCOME/MERGE_QUESTION/NEGATE_OUTCOME).\n\n`user` is required; `outcome_id` and `question_id` narrow further. Sorted by `total_volume` descending. Backed by `state_user_by_coin` (hourly refresh; `interval=1h` lags up to 1h).\n\n`question.question_id IS NULL` indicates a binary single-outcome market (no parent question grouping in HL `outcomeMeta`).',
         tags: ['Hyperliquid Outcomes'],
         security: [{ bearerAuth: [] }],
         responses: {
@@ -82,7 +81,6 @@ const openapi = describeRoute(
                                             volume_bought: 62980.97,
                                             volume_sold: 194043.55,
                                             total_volume: 257024.52,
-                                            total_fees: 0,
                                             realized_pnl: 61796.11,
                                             first_trade: '2026-06-12 09:36:14',
                                             last_trade: '2026-06-14 18:15:01',

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -1051,7 +1051,8 @@ export const hyperliquidCoinSchema = z.coerce
 // (Yes/No or custom labels per `state_outcome_meta.side_specs`).
 export const hyperliquidOutcomeCoinSchema = z.coerce
     .string()
-    .min(2)
+    .min(1)
+    .transform((val) => (val.startsWith('#') ? val : `#${val}`))
     .refine(
         (val) => /^#\d+[01]$/.test(val),
         'Invalid outcome coin (must match `#<outcome_id*10 + side_index>` with side_index in {0,1})'
@@ -1059,7 +1060,7 @@ export const hyperliquidOutcomeCoinSchema = z.coerce
     .meta({
         type: 'string',
         description:
-            'Outcome coin (`#<outcome_id*10 + side_index>`). Side index = 0 or 1. Discover via `/v1/hyperliquid/outcomes`.',
+            'Outcome coin (`#<outcome_id*10 + side_index>`). Side index = 0 or 1. Discover via `/v1/hyperliquid/outcomes`. Bare digits are accepted and prefixed with `#` server-side — useful when a browser strips the literal `#` as a URL fragment.',
         example: '#1720',
     });
 


### PR DESCRIPTION
## Summary

Two additional outcome-endpoint improvements on top of v3.22.0:

- **`coin` auto-prefix** — `?coin=3380` is now accepted in addition to `?coin=#3380`; the schema prepends the `#` server-side. Useful when a browser treats the literal `#` as a URL fragment and strips it from the request. `outcome_id` + `side` selectors keep working. Non-breaking.

- **Drop `total_fees`** — removes the field from `/outcomes/ohlc` and `/outcomes/users` responses. HIP-4 markets are fee-free by protocol design and the field carried always-zero values. Breaking response-shape change; minor version bump appropriate.

If Hyperliquid ever enables per-trade fees on HIP-4, the field can be re-added.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)