### PR TITLE
fix(hyperliquid): shorten coin description to fit 300-char schema cap

### DIFF
--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -1060,7 +1060,7 @@ export const hyperliquidOutcomeCoinSchema = z.coerce
     .meta({
         type: 'string',
         description:
-            'Outcome coin (`#<outcome_id*10 + side_index>`). Side index = 0 or 1. Discover via `/v1/hyperliquid/outcomes`. Bare digits are accepted and prefixed with `#` server-side — useful when a browser strips the literal `#` as a URL fragment.',
+            'Outcome coin (`#<outcome_id*10 + side_index>`). Side index = 0 or 1. Bare digits accepted (auto-prefixed). Discover via `/v1/hyperliquid/outcomes`.',
         example: '#1720',
     });
 


### PR DESCRIPTION
v3.23.0 startup hotfix. The bare-digit auto-prefix description shipped in #568 pushed the `coin` schema description past the 300-character hard cap enforced by \`createQuerySchema\` on the post-batching suffix. The check throws at module load — v3.23.0 image CrashLoops on boot before serving any traffic, so stage rollout is stuck on v3.22.0.

This trims the description to fit while preserving the actual signal: format, side-index range, auto-prefix mention, discovery pointer.

Plan after merge: delete + recreate the \`v3.23.0\` tag at the new HEAD (same version, fresh image) — no \`v3.23.1\` bump.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)