### PR TITLE
feat(hyperliquid): unify outcome context across /outcomes/* responses

### DIFF
--- a/src/routes/hyperliquid/_outcome_context.ts
+++ b/src/routes/hyperliquid/_outcome_context.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+// Per-row outcome metadata embedded on every /outcomes/* response except
+// /outcomes itself (which carries the canonical full shape — description,
+// side_specs, named_outcome_ids, etc.).
+//
+// Two variants:
+//   - OutcomeContext        — aggregates that collapse legs (e.g. /outcomes/users)
+//   - OutcomeLegContext     — per-leg rows (e.g. /outcomes/ohlc, /outcomes/trades,
+//                             /outcomes/users/positions, /outcomes/users/activity)
+//
+// `settle_fraction` follows HIP-4 verbatim: a value in [0, 1] representing the
+// payout per Yes share at settlement; the No share pays (1 - settle_fraction).
+// Binary outcomes resolve to 0 or 1. Bounded-options-style markets can carry
+// fractional values (per HIP-4 "settle within a fixed range"). Nullable until
+// status='settled'.
+
+export const outcomeContextSchema = z.object({
+    outcome_id: z.number().int(),
+    outcome_name: z
+        .string()
+        .describe(
+            'Outcome leaf label. For multi-outcome questions this is the per-leg name (team, candidate, bucket). For binary single-outcome markets it is the full market title.'
+        ),
+    question_id: z.number().int().nullable().describe('Parent question id; null for binary single-outcome markets.'),
+    question_name: z.string().nullable().describe('Parent question display name; null when `question_id` is null.'),
+    status: z.string().describe('`live` while trading, `settled` after resolution.'),
+    settle_fraction: z
+        .number()
+        .nullable()
+        .describe(
+            'HIP-4 `settleFraction`: payout per Yes share at resolution, in [0, 1]. No share pays `1 - settle_fraction`. Null while live. Binary outcomes resolve to 0 or 1; bounded-options markets can carry fractional values.'
+        ),
+});
+
+export const outcomeLegContextSchema = outcomeContextSchema.extend({
+    coin: z.string().describe('HL-native leg identifier `#<outcome_id*10 + side_index>` (e.g. `#3570`).'),
+    side_index: z.number().int().describe('0 = first sideSpec, 1 = second sideSpec.'),
+    side_label: z
+        .string()
+        .describe('Side display label resolved from `outcomeMeta.sideSpecs[side_index]` (e.g. `Yes`, `Argentina`).'),
+});
+
+export type OutcomeContext = z.infer<typeof outcomeContextSchema>;
+export type OutcomeLegContext = z.infer<typeof outcomeLegContextSchema>;

--- a/src/routes/hyperliquid/outcomes_ohlc.sql
+++ b/src/routes/hyperliquid/outcomes_ohlc.sql
@@ -19,7 +19,10 @@ WITH
         SELECT
             outcome_id,
             name AS outcome_name,
-            side_specs
+            side_specs,
+            status,
+            question_id,
+            settle_fraction
         FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
         WHERE outcome_id IN (
             SELECT intDiv(toUInt64(splitByChar('#', c)[2]), 10)
@@ -28,11 +31,6 @@ WITH
     )
 SELECT
     candles.timestamp                                              AS timestamp,
-    candles.coin                                                   AS coin,
-    candles.outcome_id                                             AS outcome_id,
-    candles.side_index                                             AS side_index,
-    coalesce(m.side_specs[candles.side_index + 1], '')             AS side_label,
-    coalesce(m.outcome_name, '')                                   AS outcome_name,
     candles.interval_min                                           AS interval_min,
     candles.open                                                   AS open,
     greatest(candles.high_quantile, candles.open, candles.close)   AS high,
@@ -42,7 +40,31 @@ SELECT
     candles.sell_volume                                            AS sell_volume,
     candles.gross_volume                                           AS gross_volume,
     candles.net_volume                                             AS net_volume,
-    candles.transactions                                           AS transactions
+    candles.transactions                                           AS transactions,
+    CAST(
+        (
+            candles.outcome_id,
+            coalesce(m.outcome_name, ''),
+            m.question_id,
+            nullIf(coalesce(q.name, ''), ''),
+            coalesce(m.status, ''),
+            m.settle_fraction,
+            candles.coin,
+            candles.side_index,
+            coalesce(m.side_specs[candles.side_index + 1], '')
+        )
+        AS Tuple(
+            outcome_id UInt64,
+            outcome_name String,
+            question_id Nullable(UInt64),
+            question_name Nullable(String),
+            status String,
+            settle_fraction Nullable(Float64),
+            coin String,
+            side_index UInt8,
+            side_label String
+        )
+    )                                                              AS outcome
 FROM (
     SELECT
         t.timestamp                                                AS timestamp,
@@ -68,4 +90,8 @@ FROM (
     SETTINGS optimize_aggregation_in_order = 1
 ) AS candles
 LEFT JOIN meta AS m ON m.outcome_id = candles.outcome_id
+LEFT JOIN (
+    SELECT question_id, name
+    FROM {db_hypercore:Identifier}.state_question_meta FINAL
+) AS q ON q.question_id = m.question_id
 ORDER BY candles.timestamp DESC, candles.coin

--- a/src/routes/hyperliquid/outcomes_ohlc.sql
+++ b/src/routes/hyperliquid/outcomes_ohlc.sql
@@ -93,5 +93,6 @@ LEFT JOIN meta AS m ON m.outcome_id = candles.outcome_id
 LEFT JOIN (
     SELECT question_id, name
     FROM {db_hypercore:Identifier}.state_question_meta FINAL
+    WHERE question_id IN (SELECT question_id FROM meta WHERE question_id IS NOT NULL)
 ) AS q ON q.question_id = m.question_id
 ORDER BY candles.timestamp DESC, candles.coin

--- a/src/routes/hyperliquid/outcomes_ohlc.ts
+++ b/src/routes/hyperliquid/outcomes_ohlc.ts
@@ -14,6 +14,7 @@ import {
     timestampSchema,
 } from '../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../utils.js';
+import { outcomeLegContextSchema } from './_outcome_context.js';
 
 import query from './outcomes_ohlc.sql' with { type: 'text' };
 
@@ -39,11 +40,6 @@ const responseSchema = apiUsageResponseSchema.extend({
     data: z.array(
         z.object({
             timestamp: dateTimeSchema,
-            coin: z.string(),
-            outcome_id: z.number().int(),
-            side_index: z.number().int(),
-            side_label: z.string(),
-            outcome_name: z.string(),
             interval_min: z.number().int(),
             open: z.number(),
             high: z.number(),
@@ -54,6 +50,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             gross_volume: z.number(),
             net_volume: z.number(),
             transactions: z.number().int(),
+            outcome: outcomeLegContextSchema,
         })
     ),
 });
@@ -62,7 +59,7 @@ const openapi = describeRoute(
     withErrorResponses({
         summary: 'Outcome OHLCV',
         description:
-            "Returns OHLCV candles for one or more outcome legs over the requested interval. Provide either `coin` (full Hyperliquid coin identifier, e.g. `#1730`) or `outcome_id` (UInt64); both accept CSV for batched grid views. With `outcome_id`, the `side` selector resolves to side_index 0 (`yes`, default), 1 (`no`), or returns both (`both`).\n\nTrade-side fields (`buy_volume`, `sell_volume`) carry the directional split: `buy_volume` counts taker buys of this leg, `sell_volume` counts taker sells. Composition events (SPLIT_OUTCOME, MERGE_OUTCOME, MERGE_QUESTION, NEGATE_OUTCOME) and SETTLEMENT payouts are excluded from candles by design; query them via `/v1/hyperliquid/outcomes/trades` for the raw stream.\n\nWhen multiple legs are requested, each timestamp bucket is paginated as a unit — the response contains every requested leg's candle for the most recent `limit` distinct timestamps.",
+            "Returns OHLCV candles for one or more outcome legs over the requested interval. Provide either `coin` (full Hyperliquid coin identifier, e.g. `#1730`) or `outcome_id` (UInt64); both accept CSV for batched grid views. With `outcome_id`, the `side` selector resolves to side_index 0 (`yes`, default), 1 (`no`), or returns both (`both`).\n\nTrade-side fields (`buy_volume`, `sell_volume`) carry the directional split: `buy_volume` counts taker buys of this leg, `sell_volume` counts taker sells. Composition events (SPLIT_OUTCOME, MERGE_OUTCOME, MERGE_QUESTION, NEGATE_OUTCOME) and SETTLEMENT payouts are excluded from candles by design; query them via `/v1/hyperliquid/outcomes/trades` for the raw stream.\n\nWhen multiple legs are requested, each timestamp bucket is paginated as a unit — the response contains every requested leg's candle for the most recent `limit` distinct timestamps.\n\nEvery row embeds the compact `outcome` leg context (`outcome_id`, `outcome_name`, `question_id`, `question_name`, `status`, `settle_fraction`, `coin`, `side_index`, `side_label`). For full outcome metadata call `/v1/hyperliquid/outcomes?outcome_id=...`.",
         tags: ['Hyperliquid Outcomes'],
         security: [{ bearerAuth: [] }],
         responses: {
@@ -77,11 +74,6 @@ const openapi = describeRoute(
                                     data: [
                                         {
                                             timestamp: '2026-06-16 15:00:00',
-                                            coin: '#1730',
-                                            outcome_id: 173,
-                                            side_index: 0,
-                                            side_label: 'Yes',
-                                            outcome_name: 'Argentina',
                                             interval_min: 60,
                                             open: 0.09562,
                                             high: 0.09732,
@@ -92,6 +84,17 @@ const openapi = describeRoute(
                                             gross_volume: 7336.03,
                                             net_volume: 1706.61,
                                             transactions: 18,
+                                            outcome: {
+                                                outcome_id: 173,
+                                                outcome_name: 'Argentina',
+                                                question_id: 32,
+                                                question_name: '2026 World Cup Champion',
+                                                status: 'live',
+                                                settle_fraction: null,
+                                                coin: '#1730',
+                                                side_index: 0,
+                                                side_label: 'Yes',
+                                            },
                                         },
                                     ],
                                 },
@@ -102,11 +105,6 @@ const openapi = describeRoute(
                                     data: [
                                         {
                                             timestamp: '2026-06-16 15:00:00',
-                                            coin: '#1730',
-                                            outcome_id: 173,
-                                            side_index: 0,
-                                            side_label: 'Yes',
-                                            outcome_name: 'Argentina',
                                             interval_min: 60,
                                             open: 0.09562,
                                             high: 0.09732,
@@ -117,14 +115,20 @@ const openapi = describeRoute(
                                             gross_volume: 7336.03,
                                             net_volume: 1706.61,
                                             transactions: 18,
+                                            outcome: {
+                                                outcome_id: 173,
+                                                outcome_name: 'Argentina',
+                                                question_id: 32,
+                                                question_name: '2026 World Cup Champion',
+                                                status: 'live',
+                                                settle_fraction: null,
+                                                coin: '#1730',
+                                                side_index: 0,
+                                                side_label: 'Yes',
+                                            },
                                         },
                                         {
                                             timestamp: '2026-06-16 15:00:00',
-                                            coin: '#1731',
-                                            outcome_id: 173,
-                                            side_index: 1,
-                                            side_label: 'No',
-                                            outcome_name: 'Argentina',
                                             interval_min: 60,
                                             open: 0.90438,
                                             high: 0.90475,
@@ -135,6 +139,17 @@ const openapi = describeRoute(
                                             gross_volume: 4925.43,
                                             net_volume: -1284.33,
                                             transactions: 12,
+                                            outcome: {
+                                                outcome_id: 173,
+                                                outcome_name: 'Argentina',
+                                                question_id: 32,
+                                                question_name: '2026 World Cup Champion',
+                                                status: 'live',
+                                                settle_fraction: null,
+                                                coin: '#1731',
+                                                side_index: 1,
+                                                side_label: 'No',
+                                            },
                                         },
                                     ],
                                 },

--- a/src/routes/hyperliquid/outcomes_trades.sql
+++ b/src/routes/hyperliquid/outcomes_trades.sql
@@ -24,11 +24,6 @@ SELECT
     page.transaction_hash                                   AS transaction_hash,
     page.transaction_id                                     AS transaction_id,
     page.event_index                                        AS event_index,
-    page.coin                                               AS coin,
-    page.outcome_id                                         AS outcome_id,
-    page.side_index                                         AS side_index,
-    coalesce(m.side_specs[page.side_index + 1], '')         AS side_label,
-    coalesce(m.outcome_name, '')                            AS outcome_name,
     page.user                                               AS user,
     page.side                                               AS side,
     page.direction                                          AS direction,
@@ -42,7 +37,31 @@ SELECT
     page.order_id                                           AS order_id,
     page.client_order_id                                    AS client_order_id,
     page.twap_id                                            AS twap_id,
-    page.crossed                                            AS crossed
+    page.crossed                                            AS crossed,
+    CAST(
+        (
+            page.outcome_id,
+            coalesce(m.outcome_name, ''),
+            m.question_id,
+            nullIf(coalesce(q.name, ''), ''),
+            coalesce(m.status, ''),
+            m.settle_fraction,
+            page.coin,
+            page.side_index,
+            coalesce(m.side_specs[page.side_index + 1], '')
+        )
+        AS Tuple(
+            outcome_id UInt64,
+            outcome_name String,
+            question_id Nullable(UInt64),
+            question_name Nullable(String),
+            status String,
+            settle_fraction Nullable(Float64),
+            coin String,
+            side_index UInt8,
+            side_label String
+        )
+    )                                                       AS outcome
 FROM (
     SELECT
         timestamp,
@@ -79,7 +98,11 @@ FROM (
     OFFSET {offset:UInt64}
 ) AS page
 LEFT JOIN (
-    SELECT outcome_id, name AS outcome_name, side_specs
+    SELECT outcome_id, name AS outcome_name, side_specs, status, question_id, settle_fraction
     FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
 ) AS m ON m.outcome_id = page.outcome_id
+LEFT JOIN (
+    SELECT question_id, name
+    FROM {db_hypercore:Identifier}.state_question_meta FINAL
+) AS q ON q.question_id = m.question_id
 ORDER BY page.timestamp DESC, page.block_num DESC, page.event_index DESC

--- a/src/routes/hyperliquid/outcomes_trades.sql
+++ b/src/routes/hyperliquid/outcomes_trades.sql
@@ -17,6 +17,46 @@ WITH
         SELECT arrayJoin(arrayConcat(named_outcome_ids, settled_outcome_ids, [fallback_outcome_id])) AS outcome_id
         FROM {db_hypercore:Identifier}.state_question_meta FINAL
         WHERE question_id IN (SELECT toUInt64(arrayJoin({question_id:Array(String)})))
+    ),
+    page AS (
+        SELECT
+            timestamp,
+            coin,
+            outcome_id,
+            side_index,
+            user,
+            side,
+            direction,
+            price,
+            size,
+            size * price          AS notional,
+            start_position,
+            closed_pnl_num        AS closed_pnl,
+            fee,
+            fee_token,
+            order_id,
+            client_order_id,
+            twap_id,
+            crossed,
+            event_hash            AS transaction_hash,
+            transaction_id,
+            block_num,
+            event_index
+        FROM {db_hypercore:Identifier}.outcome_fills
+        WHERE timestamp >= (SELECT t FROM start_ts)
+          AND timestamp <  (SELECT t FROM end_ts)
+          AND (empty({user:Array(String)})        OR user       IN {user:Array(String)})
+          AND (empty({coin:Array(String)})        OR coin       IN {coin:Array(String)})
+          AND (empty({outcome_id:Array(String)})  OR outcome_id IN (SELECT toUInt64(arrayJoin({outcome_id:Array(String)}))))
+          AND (empty({question_id:Array(String)}) OR outcome_id IN (SELECT outcome_id FROM question_outcome_ids))
+        ORDER BY timestamp DESC, block_num DESC, event_index DESC
+        LIMIT {limit:UInt64}
+        OFFSET {offset:UInt64}
+    ),
+    meta AS (
+        SELECT outcome_id, name AS outcome_name, side_specs, status, question_id, settle_fraction
+        FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
+        WHERE outcome_id IN (SELECT outcome_id FROM page)
     )
 SELECT
     page.block_num                                          AS block_num,
@@ -62,47 +102,11 @@ SELECT
             side_label String
         )
     )                                                       AS outcome
-FROM (
-    SELECT
-        timestamp,
-        coin,
-        outcome_id,
-        side_index,
-        user,
-        side,
-        direction,
-        price,
-        size,
-        size * price          AS notional,
-        start_position,
-        closed_pnl_num        AS closed_pnl,
-        fee,
-        fee_token,
-        order_id,
-        client_order_id,
-        twap_id,
-        crossed,
-        event_hash            AS transaction_hash,
-        transaction_id,
-        block_num,
-        event_index
-    FROM {db_hypercore:Identifier}.outcome_fills
-    WHERE timestamp >= (SELECT t FROM start_ts)
-      AND timestamp <  (SELECT t FROM end_ts)
-      AND (empty({user:Array(String)})        OR user       IN {user:Array(String)})
-      AND (empty({coin:Array(String)})        OR coin       IN {coin:Array(String)})
-      AND (empty({outcome_id:Array(String)})  OR outcome_id IN (SELECT toUInt64(arrayJoin({outcome_id:Array(String)}))))
-      AND (empty({question_id:Array(String)}) OR outcome_id IN (SELECT outcome_id FROM question_outcome_ids))
-    ORDER BY timestamp DESC, block_num DESC, event_index DESC
-    LIMIT {limit:UInt64}
-    OFFSET {offset:UInt64}
-) AS page
-LEFT JOIN (
-    SELECT outcome_id, name AS outcome_name, side_specs, status, question_id, settle_fraction
-    FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
-) AS m ON m.outcome_id = page.outcome_id
+FROM page
+LEFT JOIN meta AS m ON m.outcome_id = page.outcome_id
 LEFT JOIN (
     SELECT question_id, name
     FROM {db_hypercore:Identifier}.state_question_meta FINAL
+    WHERE question_id IN (SELECT question_id FROM meta WHERE question_id IS NOT NULL)
 ) AS q ON q.question_id = m.question_id
 ORDER BY page.timestamp DESC, page.block_num DESC, page.event_index DESC

--- a/src/routes/hyperliquid/outcomes_trades.ts
+++ b/src/routes/hyperliquid/outcomes_trades.ts
@@ -15,6 +15,7 @@ import {
     timestampSchema,
 } from '../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../utils.js';
+import { outcomeLegContextSchema } from './_outcome_context.js';
 
 import query from './outcomes_trades.sql' with { type: 'text' };
 
@@ -35,11 +36,6 @@ const responseSchema = apiUsageResponseSchema.extend({
             transaction_hash: z.string(),
             transaction_id: z.number().int(),
             event_index: z.number().int(),
-            coin: z.string(),
-            outcome_id: z.number().int(),
-            side_index: z.number().int(),
-            side_label: z.string(),
-            outcome_name: z.string(),
             user: z.string(),
             side: z
                 .string()
@@ -58,6 +54,7 @@ const responseSchema = apiUsageResponseSchema.extend({
             client_order_id: z.string(),
             twap_id: z.number().int(),
             crossed: z.boolean(),
+            outcome: outcomeLegContextSchema,
         })
     ),
 });
@@ -66,7 +63,7 @@ const openapi = describeRoute(
     withErrorResponses({
         summary: 'Outcome Trades',
         description:
-            'Returns a chronological fill feed for HIP-4 outcome markets. Each row is a single fill carrying price, size, side (`BID` = user bought, `ASK` = user sold), and one of seven directions:\n\n- `BUY`, `SELL`: regular taker matches. These are the only directions that flow into OHLCV candles.\n- `SETTLEMENT`: payout when the outcome resolved. Size = position cleared, price = 1 on the winning leg or 0 on the losing leg.\n- `SPLIT_OUTCOME`: user minted both Yes+No legs by depositing $1 of the quote token.\n- `MERGE_OUTCOME`: user redeemed Yes+No legs back to $1 of the quote token.\n- `MERGE_QUESTION`: user redeemed a full set of question outcomes back to $1 (multi-outcome only).\n- `NEGATE_OUTCOME`: converted a Yes-leg holding into a No-leg holding for the *other* outcomes under the same question (multi-outcome only).\n\nFilters compose additively. At least one of `coin`, `outcome_id`, `question_id`, or `user` is required. Defaults to the last 24 hours when no time range is specified.\n\nFor candle aggregates of the BUY/SELL subset, see `/v1/hyperliquid/outcomes/ohlc`. `fee_token` shows `+<coin_number>` on zero-fee fills (Hyperliquid wire-format quirk).',
+            'Returns a chronological fill feed for HIP-4 outcome markets. Each row is a single fill carrying price, size, side (`BID` = user bought, `ASK` = user sold), and one of seven directions:\n\n- `BUY`, `SELL`: regular taker matches. These are the only directions that flow into OHLCV candles.\n- `SETTLEMENT`: payout when the outcome resolved. Size = position cleared, price = 1 on the winning leg or 0 on the losing leg.\n- `SPLIT_OUTCOME`: user minted both Yes+No legs by depositing $1 of the quote token.\n- `MERGE_OUTCOME`: user redeemed Yes+No legs back to $1 of the quote token.\n- `MERGE_QUESTION`: user redeemed a full set of question outcomes back to $1 (multi-outcome only).\n- `NEGATE_OUTCOME`: converted a Yes-leg holding into a No-leg holding for the *other* outcomes under the same question (multi-outcome only).\n\nFilters compose additively. At least one of `coin`, `outcome_id`, `question_id`, or `user` is required. Defaults to the last 24 hours when no time range is specified.\n\nEvery row embeds the compact `outcome` leg context (`outcome_id`, `outcome_name`, `question_id`, `question_name`, `status`, `settle_fraction`, `coin`, `side_index`, `side_label`). For full outcome metadata call `/v1/hyperliquid/outcomes?outcome_id=...`.\n\nFor candle aggregates of the BUY/SELL subset, see `/v1/hyperliquid/outcomes/ohlc`. `fee_token` shows `+<coin_number>` on zero-fee fills (Hyperliquid wire-format quirk).',
         tags: ['Hyperliquid Outcomes'],
         security: [{ bearerAuth: [] }],
         responses: {
@@ -86,11 +83,6 @@ const openapi = describeRoute(
                                                 '0x40163a5290e2756e418f043dc1871e00005152382be59440e3dee5a54fe64f58',
                                             transaction_id: 218233422822675,
                                             event_index: 347,
-                                            coin: '#3290',
-                                            outcome_id: 329,
-                                            side_index: 0,
-                                            side_label: 'Yes',
-                                            outcome_name: 'Recurring',
                                             user: '0xfc0a9d73b4382348bac7f4f600439bc61bb00271',
                                             side: 'ASK',
                                             direction: 'SETTLEMENT',
@@ -105,6 +97,17 @@ const openapi = describeRoute(
                                             client_order_id: '',
                                             twap_id: 0,
                                             crossed: true,
+                                            outcome: {
+                                                outcome_id: 329,
+                                                outcome_name: 'Recurring',
+                                                question_id: null,
+                                                question_name: null,
+                                                status: 'settled',
+                                                settle_fraction: 1.0,
+                                                coin: '#3290',
+                                                side_index: 0,
+                                                side_label: 'Yes',
+                                            },
                                         },
                                     ],
                                 },

--- a/src/routes/hyperliquid/outcomes_users.sql
+++ b/src/routes/hyperliquid/outcomes_users.sql
@@ -21,6 +21,11 @@ WITH
         WHERE dex = 'outcome'
           AND interval_min = {interval_min:UInt32}
           AND user IN {user:Array(String)}
+    ),
+    meta AS (
+        SELECT outcome_id, name, status, question_id, settle_fraction
+        FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
+        WHERE outcome_id IN (SELECT outcome_id FROM rows)
     )
 SELECT
     r.user                                                   AS user,
@@ -52,13 +57,11 @@ SELECT
         )
     )                                                        AS outcome
 FROM rows AS r
-LEFT JOIN (
-    SELECT outcome_id, name, status, question_id, settle_fraction
-    FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
-) AS m ON m.outcome_id = r.outcome_id
+LEFT JOIN meta AS m ON m.outcome_id = r.outcome_id
 LEFT JOIN (
     SELECT question_id, name
     FROM {db_hypercore:Identifier}.state_question_meta FINAL
+    WHERE question_id IN (SELECT question_id FROM meta WHERE question_id IS NOT NULL)
 ) AS q ON q.question_id = m.question_id
 WHERE (empty({outcome_id:Array(String)})  OR r.outcome_id IN (SELECT toUInt64(arrayJoin({outcome_id:Array(String)}))))
   AND (empty({question_id:Array(String)}) OR r.outcome_id IN (SELECT outcome_id FROM question_outcome_ids))

--- a/src/routes/hyperliquid/outcomes_users.sql
+++ b/src/routes/hyperliquid/outcomes_users.sql
@@ -24,10 +24,6 @@ WITH
     )
 SELECT
     r.user                                                   AS user,
-    r.outcome_id                                             AS outcome_id,
-    coalesce(m.name, '')                                     AS outcome_name,
-    coalesce(m.status, '')                                   AS status,
-    coalesce(m.side_specs, [])                               AS side_specs,
     sum(r.transactions)                                      AS transactions,
     sum(r.buys)                                              AS buys,
     sum(r.sells)                                             AS sells,
@@ -39,28 +35,34 @@ SELECT
     max(r.last_trade)                                        AS last_trade,
     CAST(
         (
+            r.outcome_id,
+            coalesce(m.name, ''),
             m.question_id,
             nullIf(coalesce(q.name, ''), ''),
-            q.fallback_outcome_id
+            coalesce(m.status, ''),
+            m.settle_fraction
         )
         AS Tuple(
+            outcome_id UInt64,
+            outcome_name String,
             question_id Nullable(UInt64),
-            name Nullable(String),
-            fallback_outcome_id Nullable(UInt64)
+            question_name Nullable(String),
+            status String,
+            settle_fraction Nullable(Float64)
         )
-    )                                                        AS question
+    )                                                        AS outcome
 FROM rows AS r
 LEFT JOIN (
-    SELECT outcome_id, name, status, side_specs, question_id
+    SELECT outcome_id, name, status, question_id, settle_fraction
     FROM {db_hypercore:Identifier}.state_outcome_meta FINAL
 ) AS m ON m.outcome_id = r.outcome_id
 LEFT JOIN (
-    SELECT question_id, name, fallback_outcome_id
+    SELECT question_id, name
     FROM {db_hypercore:Identifier}.state_question_meta FINAL
 ) AS q ON q.question_id = m.question_id
 WHERE (empty({outcome_id:Array(String)})  OR r.outcome_id IN (SELECT toUInt64(arrayJoin({outcome_id:Array(String)}))))
   AND (empty({question_id:Array(String)}) OR r.outcome_id IN (SELECT outcome_id FROM question_outcome_ids))
-GROUP BY r.user, r.outcome_id, m.name, m.status, m.side_specs, m.question_id, q.name, q.fallback_outcome_id
+GROUP BY r.user, r.outcome_id, m.name, m.status, m.question_id, m.settle_fraction, q.name
 ORDER BY total_volume DESC
 LIMIT {limit:UInt64}
 OFFSET {offset:UInt64}

--- a/src/routes/hyperliquid/outcomes_users.ts
+++ b/src/routes/hyperliquid/outcomes_users.ts
@@ -14,6 +14,7 @@ import {
     userLookbackIntervalSchema,
 } from '../../types/zod.js';
 import { validatorHook, withErrorResponses } from '../../utils.js';
+import { outcomeContextSchema } from './_outcome_context.js';
 
 import query from './outcomes_users.sql' with { type: 'text' };
 
@@ -24,20 +25,10 @@ const querySchema = createQuerySchema({
     interval: { schema: userLookbackIntervalSchema, optional: true },
 });
 
-const questionSchema = z.object({
-    question_id: z.number().int().nullable(),
-    name: z.string().nullable(),
-    fallback_outcome_id: z.number().int().nullable(),
-});
-
 const responseSchema = apiUsageResponseSchema.extend({
     data: z.array(
         z.object({
             user: z.string(),
-            outcome_id: z.number().int(),
-            outcome_name: z.string(),
-            status: z.string(),
-            side_specs: z.array(z.string()),
             transactions: z.number().int(),
             buys: z.number().int(),
             sells: z.number().int(),
@@ -47,16 +38,16 @@ const responseSchema = apiUsageResponseSchema.extend({
             realized_pnl: z.number(),
             first_trade: dateTimeSchema,
             last_trade: dateTimeSchema,
-            question: questionSchema,
+            outcome: outcomeContextSchema,
         })
     ),
 });
 
 const openapi = describeRoute(
     withErrorResponses({
-        summary: 'Outcome User Activity',
+        summary: 'Outcome User Lookup',
         description:
-            'Returns trading aggregates per outcome for a given user, with both side legs (Yes/No or custom labels) collapsed into one row per outcome. Includes fill count, buys/sells split, volume bought/sold, realized PnL, and first/last trade times across all seven outcome directions (BUY/SELL/SETTLEMENT/SPLIT_OUTCOME/MERGE_OUTCOME/MERGE_QUESTION/NEGATE_OUTCOME).\n\n`user` is required; `outcome_id` and `question_id` narrow further. Sorted by `total_volume` descending. Backed by `state_user_by_coin` (hourly refresh; `interval=1h` lags up to 1h).\n\n`question.question_id IS NULL` indicates a binary single-outcome market (no parent question grouping in HL `outcomeMeta`).',
+            'Returns trading aggregates per outcome for a given user, with both side legs (Yes/No or custom labels) collapsed into one row per outcome. Includes fill count, buys/sells split, volume bought/sold, realized PnL, and first/last trade times.\n\nSETTLEMENT events contribute to `realized_pnl` (the resolution payout is realized P&L for positions held to resolution) but do not count toward `transactions` / `buys` / `sells` / `volume_*` — those reflect actual taker trade activity. SPLIT/MERGE/MERGE_QUESTION/NEGATE composition events are excluded from every aggregate.\n\n`user` is required; `outcome_id` and `question_id` narrow further. Sorted by `total_volume` descending. Backed by `state_user_by_coin` (hourly refresh; `interval=1h` lags up to 1h).\n\nEvery row embeds the compact `outcome` context (`outcome_id`, `outcome_name`, `question_id`, `question_name`, `status`, `settle_fraction`). For full outcome metadata (description, side_specs, named_outcome_ids, etc.) call `/v1/hyperliquid/outcomes?outcome_id=...`.',
         tags: ['Hyperliquid Outcomes'],
         security: [{ bearerAuth: [] }],
         responses: {
@@ -71,10 +62,6 @@ const openapi = describeRoute(
                                     data: [
                                         {
                                             user: '0xfcecc2a54724cf0502eb7c916e2717ef76a510ed',
-                                            outcome_id: 318,
-                                            outcome_name: 'Germany',
-                                            status: 'settled',
-                                            side_specs: ['Yes', 'No'],
                                             transactions: 276,
                                             buys: 30,
                                             sells: 246,
@@ -84,10 +71,13 @@ const openapi = describeRoute(
                                             realized_pnl: 61796.11,
                                             first_trade: '2026-06-12 09:36:14',
                                             last_trade: '2026-06-14 18:15:01',
-                                            question: {
+                                            outcome: {
+                                                outcome_id: 318,
+                                                outcome_name: 'Germany',
                                                 question_id: null,
-                                                name: null,
-                                                fallback_outcome_id: null,
+                                                question_name: null,
+                                                status: 'settled',
+                                                settle_fraction: 1.0,
                                             },
                                         },
                                     ],


### PR DESCRIPTION
## Summary

Refactors `/outcomes/users`, `/outcomes/ohlc`, and `/outcomes/trades` to embed a compact `outcome` context object on every row, mirroring the Polymarket MarketContext pattern. `/outcomes` itself keeps its full canonical shape — single source of truth for descriptions, side_specs, named_outcome_ids, etc.

**Two context variants:**

```ts
OutcomeContext = {
  outcome_id, outcome_name,
  question_id, question_name,
  status, settle_fraction
}

OutcomeLegContext = {
  ...OutcomeContext,
  coin, side_index, side_label
}
```

| Endpoint | Variant | Why |
|---|---|---|
| `/outcomes/users` | `OutcomeContext` | aggregates collapse Yes/No legs into one row per outcome |
| `/outcomes/ohlc` | `OutcomeLegContext` | one row per leg per bucket |
| `/outcomes/trades` | `OutcomeLegContext` | one row per fill on a specific leg |

`settle_fraction` follows HIP-4 verbatim — value in [0, 1] representing the payout per Yes share at resolution; the No share pays `1 - settle_fraction`. Binary outcomes resolve to 0 or 1; bounded-options markets can carry fractional values. Null while `status='live'`.

## Why

Three motivations:
1. **Reduce per-row duplication** — full outcome/question metadata (description, named_outcome_ids, sideSpecs full array) only lives on `/outcomes`. Per-row endpoints carry just enough to display + a pointer back.
2. **SDK ergonomics** — TypeScript consumers get one `OutcomeContext` / `OutcomeLegContext` interface reusable across endpoints. Mirrors what Polymarket already does with `MarketContext`.
3. **Consistency** — `/outcomes/users` used a nested `question` object with 3 fields while `/outcomes` returned 6 fields under the same name. Now collapsed to a `question_id` + `question_name` pointer pair.

## Code references

- `src/routes/hyperliquid/_outcome_context.ts` — shared schema module
- `src/routes/hyperliquid/outcomes_users.{ts,sql}` — OutcomeContext consumer
- `src/routes/hyperliquid/outcomes_ohlc.{ts,sql}` — OutcomeLegContext consumer
- `src/routes/hyperliquid/outcomes_trades.{ts,sql}` — OutcomeLegContext consumer

The new `/outcomes/users/positions` and `/outcomes/users/activity` endpoints (#83/#84) will inherit `OutcomeLegContext` by design.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)