### PR TITLE
fix(hyperliquid): nullable funding fields on /markets for spot rows

### DIFF
--- a/src/routes/hyperliquid/markets.sql
+++ b/src/routes/hyperliquid/markets.sql
@@ -90,9 +90,9 @@ FROM (
         cur.sell_volume_24h                                                      AS sell_volume_24h,
         cur.trades_24h                                                           AS trades_24h,
         coalesce(uu.unique_users_24h, 0)                                         AS unique_users_24h,
-        oi.open_interest                                                         AS open_interest,
-        oi.funding_rate                                                          AS funding_rate,
-        oi.funding_snapshot_time                                                 AS funding_snapshot_time
+        if(oi.funding_snapshot_time > toDateTime(0), oi.open_interest, NULL)     AS open_interest,
+        if(oi.funding_snapshot_time > toDateTime(0), oi.funding_rate,   NULL)    AS funding_rate,
+        if(oi.funding_snapshot_time > toDateTime(0), oi.funding_snapshot_time, NULL) AS funding_snapshot_time
     FROM day_cur cur
     LEFT JOIN day_prev prev ON prev.coin = cur.coin
     LEFT JOIN oi_latest oi  ON oi.coin  = cur.coin


### PR DESCRIPTION
## Summary

Spot markets don't produce open_interest / funding_rate rows, so the LEFT JOIN against `state_open_interest` returned ClickHouse type defaults (`0` for numerics, `1970-01-01 00:00:00` for the snapshot time). The Zod response schema already declared all three as nullable; the SQL now matches.

Before:
```json
{ "coin": "@107", "dex": "spot", "open_interest": 0, "funding_rate": 0, "funding_snapshot_time": "1970-01-01 00:00:00" }
```

After:
```json
{ "coin": "@107", "dex": "spot", "open_interest": null, "funding_rate": null, "funding_snapshot_time": null }
```

## Why

Epoch-zero sentinels are misleading to consumers (sorting / charting code mis-handles them). Nullability is the right contract.

`funding_snapshot_time > toDateTime(0)` is used as the row-existence probe — can't `nullIf(funding_rate, 0)` directly because zero IS a valid funding_rate value (perp markets with flat funding) and a valid open_interest value (perp markets with no current positions).

Perp coins verified unchanged: BTC still returns populated `open_interest`, `funding_rate`, `funding_snapshot_time`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)