### PR TITLE
fix(hyperliquid): tighten /outcomes/users polish

### DIFF
--- a/src/routes/hyperliquid/outcomes_users.ts
+++ b/src/routes/hyperliquid/outcomes_users.ts
@@ -10,6 +10,7 @@ import {
     dateTimeSchema,
     evmAddressSchema,
     hyperliquidOutcomeIdSchema,
+    hyperliquidOutcomeUserSortBySchema,
     hyperliquidQuestionIdSchema,
     userLookbackIntervalSchema,
 } from '../../types/zod.js';
@@ -23,7 +24,14 @@ const querySchema = createQuerySchema({
     outcome_id: { schema: hyperliquidOutcomeIdSchema, batched: true, optional: true },
     question_id: { schema: hyperliquidQuestionIdSchema, batched: true, optional: true },
     interval: { schema: userLookbackIntervalSchema, optional: true },
+    sort_by: { schema: hyperliquidOutcomeUserSortBySchema, prefault: 'total_volume' },
 });
+
+const SORT_COLUMN_MAP: Record<string, string> = {
+    total_volume: 'total_volume',
+    transactions: 'transactions',
+    realized_pnl: 'realized_pnl',
+};
 
 const responseSchema = apiUsageResponseSchema.extend({
     data: z.array(
@@ -47,7 +55,7 @@ const openapi = describeRoute(
     withErrorResponses({
         summary: 'Outcome User Lookup',
         description:
-            'Returns trading aggregates per outcome with both side legs (Yes/No or custom labels) collapsed into one row per (user, outcome). Includes fill count, buys/sells split, volume bought/sold, realized PnL, and first/last trade times.\n\nFilters compose additively. At least one of `user`, `outcome_id`, or `question_id` must be provided. Sorted by `total_volume` descending — when `user` is omitted the response is a leaderboard for the given outcome / question scope.\n\nSETTLEMENT events contribute to `realized_pnl` (the resolution payout is realized P&L for positions held to resolution) but do not count toward `transactions` / `buys` / `sells` / `volume_*` — those reflect actual taker trade activity. SPLIT/MERGE/MERGE_QUESTION/NEGATE composition events are excluded from every aggregate.\n\n`interval` selects the lookback window applied at MV refresh time: `1h`, `1d`, `1w`, `30d`. Omit for all-time. Each interval is a sliding window of fills whose `fill_time >= now() - interval` at the most recent MV refresh; rows have up to one hour of staleness (and up to six hours for the all-time aggregate). Backed by `state_user_by_coin`.\n\nEvery row embeds the compact `outcome` context (`outcome_id`, `outcome_name`, `question_id`, `question_name`, `status`, `settle_fraction`). For full outcome metadata (description, side_specs, named_outcome_ids, etc.) call `/v1/hyperliquid/outcomes?outcome_id=...`.',
+            '**At least one of `user`, `outcome_id`, or `question_id` is required** — calls without any of these return `400`.\n\nReturns trading aggregates per outcome with both side legs (Yes/No or custom labels) collapsed into one row per (user, outcome). Includes fill count, buys/sells split, volume bought/sold, realized PnL, and first/last trade times.\n\nFilters compose additively. Sorted by `sort_by` descending (default `total_volume`; also `transactions`, `realized_pnl`) — when `user` is omitted the response is a leaderboard for the given outcome / question scope.\n\nSETTLEMENT events contribute to `realized_pnl` (the resolution payout is realized P&L for positions held to resolution) but do not count toward `transactions` / `buys` / `sells` / `volume_*` — those reflect actual taker trade activity. SPLIT/MERGE/MERGE_QUESTION/NEGATE composition events are excluded from every aggregate.\n\n`interval` selects the lookback window applied at MV refresh time: `1h`, `1d`, `1w`, `30d`. Omit for all-time. Each interval is a sliding window of fills whose `fill_time >= now() - interval` at the most recent MV refresh; rows have up to one hour of staleness (and up to six hours for the all-time aggregate). Backed by `state_user_by_coin`.\n\nEvery row embeds the compact `outcome` context (`outcome_id`, `outcome_name`, `question_id`, `question_name`, `status`, `settle_fraction`). For full outcome metadata (description, side_specs, named_outcome_ids, etc.) call `/v1/hyperliquid/outcomes?outcome_id=...`.',
         tags: ['Hyperliquid Outcomes'],
         security: [{ bearerAuth: [] }],
         responses: {
@@ -140,7 +148,10 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
         return c.json({ error: 'Hyperliquid not configured' }, 500);
     }
 
-    const response = await makeUsageQueryJson(c, [query], {
+    const sortColumn = SORT_COLUMN_MAP[params.sort_by] ?? 'total_volume';
+    const sql = query.replace('ORDER BY total_volume DESC', `ORDER BY ${sortColumn} DESC`);
+
+    const response = await makeUsageQueryJson(c, [sql], {
         ...params,
         interval_min: params.interval ?? 0,
         network: 'hyperliquid',

--- a/src/routes/hyperliquid/outcomes_users_activity.ts
+++ b/src/routes/hyperliquid/outcomes_users_activity.ts
@@ -10,7 +10,7 @@ import {
     dateTimeSchema,
     evmAddressSchema,
     hyperliquidOutcomeCoinSchema,
-    hyperliquidOutcomeDirectionSchema,
+    hyperliquidOutcomeCompositionDirectionSchema,
     hyperliquidOutcomeIdSchema,
     hyperliquidQuestionIdSchema,
     timestampSchema,
@@ -25,7 +25,7 @@ const querySchema = createQuerySchema({
     coin: { schema: hyperliquidOutcomeCoinSchema, batched: true, optional: true },
     outcome_id: { schema: hyperliquidOutcomeIdSchema, batched: true, optional: true },
     question_id: { schema: hyperliquidQuestionIdSchema, batched: true, optional: true },
-    direction: { schema: hyperliquidOutcomeDirectionSchema, batched: true, optional: true },
+    direction: { schema: hyperliquidOutcomeCompositionDirectionSchema, batched: true, optional: true },
     start_time: { schema: timestampSchema, optional: true },
     end_time: { schema: timestampSchema, optional: true },
 });
@@ -55,7 +55,7 @@ const openapi = describeRoute(
     withErrorResponses({
         summary: 'Outcome User Activity',
         description:
-            "Returns the chronological composition-event feed for HIP-4 outcome positions — one row per (event, affected leg). Covers `SETTLEMENT` (resolution payouts), `SPLIT_OUTCOME` (mint Yes+No from collateral), `MERGE_OUTCOME` (redeem Yes+No to collateral), `MERGE_QUESTION` (redeem the full Yes-set of a multi-outcome question), and `NEGATE_OUTCOME` (convert a No-A holding into Yes-on-every-other-outcome under the same question).\n\nBUY/SELL taker fills are deliberately excluded — query `/v1/hyperliquid/outcomes/trades` for those. Override the default by passing an explicit `direction` filter.\n\nFilters compose additively. At least one of `user`, `coin`, `outcome_id`, or `question_id` must be provided. Defaults to the last 24 hours when no time range is specified.\n\n`closed_pnl` carries the realized USDC delta for the row's leg (settlement payouts on the winning leg are positive; merge/redeem rows carry the collateral-side delta). For position-level rollups see `/v1/hyperliquid/outcomes/users`; for current open share balances see `/v1/hyperliquid/outcomes/users/positions`.\n\nEvery row embeds the compact `outcome` leg context (`outcome_id`, `outcome_name`, `question_id`, `question_name`, `status`, `settle_fraction`, `coin`, `side_index`, `side_label`). For full outcome metadata call `/v1/hyperliquid/outcomes?outcome_id=...`.",
+            "**At least one of `user`, `coin`, `outcome_id`, or `question_id` is required** — calls without any of these return `400`.\n\nReturns the chronological composition-event feed for HIP-4 outcome positions — one row per (event, affected leg). Covers `SETTLEMENT` (resolution payouts), `SPLIT_OUTCOME` (mint Yes+No from collateral), `MERGE_OUTCOME` (redeem Yes+No to collateral), `MERGE_QUESTION` (redeem the full Yes-set of a multi-outcome question), and `NEGATE_OUTCOME` (convert a No-A holding into Yes-on-every-other-outcome under the same question).\n\nBUY/SELL taker fills are not served by this endpoint — query `/v1/hyperliquid/outcomes/trades` for those. The `direction` enum here is restricted to the five composition tags; passing `BUY`/`SELL` returns `400`.\n\nFilters compose additively. Defaults to the last 24 hours when no time range is specified.\n\n`closed_pnl` carries the realized USDC delta for the row's leg (settlement payouts on the winning leg are positive; merge/redeem rows carry the collateral-side delta). For position-level rollups see `/v1/hyperliquid/outcomes/users`; for current open share balances see `/v1/hyperliquid/outcomes/users/positions`.\n\nEvery row embeds the compact `outcome` leg context (`outcome_id`, `outcome_name`, `question_id`, `question_name`, `status`, `settle_fraction`, `coin`, `side_index`, `side_label`). For full outcome metadata call `/v1/hyperliquid/outcomes?outcome_id=...`.",
         tags: ['Hyperliquid Outcomes'],
         security: [{ bearerAuth: [] }],
         responses: {
@@ -103,7 +103,7 @@ const openapi = describeRoute(
     })
 );
 
-const COMPOSITION_DIRECTIONS = ['SETTLEMENT', 'SPLIT_OUTCOME', 'MERGE_OUTCOME', 'MERGE_QUESTION', 'NEGATE_OUTCOME'];
+const ALL_COMPOSITION_DIRECTIONS = hyperliquidOutcomeCompositionDirectionSchema.options;
 
 const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema> } }>();
 
@@ -126,8 +126,7 @@ route.get('/', openapi, zValidator('query', querySchema, validatorHook), validat
         return c.json({ error: 'Hyperliquid not configured' }, 500);
     }
 
-    // Default direction filter excludes BUY/SELL taker fills — those go through /outcomes/trades
-    const direction = params.direction.length ? params.direction : COMPOSITION_DIRECTIONS;
+    const direction = params.direction.length ? params.direction : ALL_COMPOSITION_DIRECTIONS;
 
     const response = await makeUsageQueryJson(c, [query], {
         ...params,

--- a/src/routes/hyperliquid/outcomes_users_positions.sql
+++ b/src/routes/hyperliquid/outcomes_users_positions.sql
@@ -16,6 +16,7 @@ WITH
         FROM {db_hypercore:Identifier}.state_user_outcome_position FINAL
         WHERE share_balance > 0
           AND (empty({user:Array(String)})        OR user       IN {user:Array(String)})
+          AND (empty({coin:Array(String)})        OR coin       IN {coin:Array(String)})
           AND (empty({outcome_id:Array(String)})  OR outcome_id IN (SELECT toUInt64(arrayJoin({outcome_id:Array(String)}))))
           AND (empty({question_id:Array(String)}) OR outcome_id IN (SELECT outcome_id FROM question_outcome_ids))
     ),

--- a/src/routes/hyperliquid/outcomes_users_positions.ts
+++ b/src/routes/hyperliquid/outcomes_users_positions.ts
@@ -9,6 +9,7 @@ import {
     createQuerySchema,
     dateTimeSchema,
     evmAddressSchema,
+    hyperliquidOutcomeCoinSchema,
     hyperliquidOutcomeIdSchema,
     hyperliquidQuestionIdSchema,
 } from '../../types/zod.js';
@@ -19,6 +20,7 @@ import query from './outcomes_users_positions.sql' with { type: 'text' };
 
 const querySchema = createQuerySchema({
     user: { schema: evmAddressSchema, batched: true, optional: true },
+    coin: { schema: hyperliquidOutcomeCoinSchema, batched: true, optional: true },
     outcome_id: { schema: hyperliquidOutcomeIdSchema, batched: true, optional: true },
     question_id: { schema: hyperliquidQuestionIdSchema, batched: true, optional: true },
 });
@@ -39,7 +41,7 @@ const openapi = describeRoute(
     withErrorResponses({
         summary: 'Outcome User Positions',
         description:
-            "Returns each user's current open share balance per outcome leg, derived from the full history of `outcome_fills`. HIP-4's `side` field encodes share-flow direction (BID = receive, ASK = release); the running sum across BUY/SELL/SETTLEMENT/SPLIT/MERGE/NEGATE composition events yields the user's current share count, in line with HL `spotClearinghouseState.balances[]`.\n\nFilters compose additively. At least one of `user`, `outcome_id`, or `question_id` must be provided. When `user` is omitted the response is a holder list for the requested outcome / question scope, sorted by share_balance descending.\n\nOnly currently-open long positions are returned (`share_balance > 0`). Settled outcomes naturally drop out via SETTLEMENT ASK fills that zero the running sum. Coverage caveat: a sink that has not been backfilled to a block predating the user's earliest activity will under-report by the shares acquired before the backfill horizon. Reconcile against HL `spotClearinghouseState` when authoritative numbers are required.\n\nEvery row embeds the compact `outcome` leg context (`outcome_id`, `outcome_name`, `question_id`, `question_name`, `status`, `settle_fraction`, `coin`, `side_index`, `side_label`). For full outcome metadata call `/v1/hyperliquid/outcomes?outcome_id=...`.",
+            "**At least one of `user`, `coin`, `outcome_id`, or `question_id` is required** — calls without any of these return `400`.\n\nReturns each user's current open share balance per outcome leg, derived from the full history of `outcome_fills`. HIP-4's `side` field encodes share-flow direction (BID = receive, ASK = release); the running sum across BUY/SELL/SETTLEMENT/SPLIT/MERGE/NEGATE composition events yields the user's current share count, in line with HL `spotClearinghouseState.balances[]`.\n\nFilters compose additively. When `user` is omitted the response is a holder list for the requested outcome / question / coin scope, sorted by share_balance descending.\n\nOnly currently-open long positions are returned (`share_balance > 0`). Settled outcomes naturally drop out via SETTLEMENT ASK fills that zero the running sum. Coverage caveat: a sink that has not been backfilled to a block predating the user's earliest activity will under-report by the shares acquired before the backfill horizon. Reconcile against HL `spotClearinghouseState` when authoritative numbers are required.\n\nEvery row embeds the compact `outcome` leg context (`outcome_id`, `outcome_name`, `question_id`, `question_name`, `status`, `settle_fraction`, `coin`, `side_index`, `side_label`). For full outcome metadata call `/v1/hyperliquid/outcomes?outcome_id=...`.",
         tags: ['Hyperliquid Outcomes'],
         security: [{ bearerAuth: [] }],
         responses: {
@@ -110,12 +112,12 @@ const route = new Hono<{ Variables: { validatedData: z.infer<typeof querySchema>
 route.get('/', openapi, zValidator('query', querySchema, validatorHook), validator('query', querySchema), async (c) => {
     const params = c.req.valid('query');
 
-    if (!params.user.length && !params.outcome_id.length && !params.question_id.length) {
+    if (!params.user.length && !params.coin.length && !params.outcome_id.length && !params.question_id.length) {
         return c.json(
             {
                 status: 400,
                 code: 'bad_query_input',
-                message: 'Provide at least one of user, outcome_id, or question_id',
+                message: 'Provide at least one of user, coin, outcome_id, or question_id',
             },
             400
         );

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -1021,6 +1021,15 @@ export const hyperliquidUserSortBySchema = z.enum(hyperliquidUserSortFields).met
     default: 'total_volume',
 });
 
+// Outcome-user sort columns — narrower than the perp/spot set because HIP-4
+// outcomes don't have fees, funding, or liquidation flows.
+const hyperliquidOutcomeUserSortFields = ['total_volume', 'transactions', 'realized_pnl'] as const;
+export const hyperliquidOutcomeUserSortBySchema = z.enum(hyperliquidOutcomeUserSortFields).meta({
+    type: 'string',
+    enum: hyperliquidOutcomeUserSortFields,
+    default: 'total_volume',
+});
+
 export const hyperliquidTokenSchema = z.coerce
     .string()
     .min(1)
@@ -1117,6 +1126,25 @@ export const hyperliquidOutcomeDirectionSchema = z.enum(hyperliquidOutcomeDirect
     description:
         'Restrict by outcome direction tag. `BUY`/`SELL` are taker matches; `SETTLEMENT` is the resolution payout; the four `*_OUTCOME`/`MERGE_QUESTION` tags are HIP-4 collateral reshapes. Omit for all seven.',
     example: 'BUY',
+});
+
+// `direction` filter for `/v1/hyperliquid/outcomes/users/activity`. Strict
+// subset excluding BUY/SELL — that endpoint is the composition-events feed
+// (resolution payouts + collateral reshapes); taker fills belong on
+// `/outcomes/trades`.
+const hyperliquidOutcomeCompositionDirectionValues = [
+    'SETTLEMENT',
+    'SPLIT_OUTCOME',
+    'MERGE_OUTCOME',
+    'MERGE_QUESTION',
+    'NEGATE_OUTCOME',
+] as const;
+export const hyperliquidOutcomeCompositionDirectionSchema = z.enum(hyperliquidOutcomeCompositionDirectionValues).meta({
+    type: 'string',
+    enum: hyperliquidOutcomeCompositionDirectionValues,
+    description:
+        'Composition events only. `SETTLEMENT` is the resolution payout; the four `*_OUTCOME`/`MERGE_QUESTION` tags are HIP-4 collateral reshapes. BUY/SELL not accepted — for taker fills query `/outcomes/trades`.',
+    example: 'SETTLEMENT',
 });
 
 // `direction` filter for `/v1/hyperliquid/markets/activity`. Perp + spot


### PR DESCRIPTION
## Summary

Four follow-up polish items from feedback on the v3.21.0-pre1 staging build, all on the `/outcomes/users` family.

- **`/outcomes/users/activity`** now uses a composition-only direction enum (`SETTLEMENT`, `SPLIT_OUTCOME`, `MERGE_OUTCOME`, `MERGE_QUESTION`, `NEGATE_OUTCOME`). Passing `BUY`/`SELL` returns `400` rather than silently mixing taker fills into the composition-events feed; trade-shaped fills remain on `/outcomes/trades`.
- **`/outcomes/users/positions`** accepts `coin` as a valid scope, in line with `/outcomes/users/activity`. The param was previously silently ignored.
- **`/outcomes/users`** gains a `sort_by` parameter (default `total_volume`; also `transactions`, `realized_pnl`), matching the leaderboard-mode behavior of `/users`. The enum is narrower since outcomes don't have fees, funding, or liquidation flows.
- **All three endpoint descriptions** lead with the at-least-one-of constraint in bold so SDK consumers see it without a failed call.

## Why

The current pre-release on stage lets BUY/SELL filters mix two distinct event semantics on the activity feed, silently drops `coin` on positions even though the data model fully supports it, hardcodes outcome leaderboard sort to `total_volume` with no opt-out, and buries the at-least-one-of constraint at the end of long descriptions. Each is a small but visible inconsistency in the public surface; addressing them tightens the v3.21.0 final.

Code:
- `src/types/zod.ts` — new `hyperliquidOutcomeCompositionDirectionSchema`, new `hyperliquidOutcomeUserSortBySchema`
- `src/routes/hyperliquid/outcomes_users.ts`, `outcomes_users_activity.ts`, `outcomes_users_positions.{ts,sql}`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)