### PR TITLE
chore: drop compress() middleware

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,4 @@
 import { type Context, Hono } from 'hono';
-import { compress } from 'hono/compress';
 import './src/banner.js';
 import { describeRoute, openAPIRouteHandler } from 'hono-openapi';
 import { logServerInit } from './src/banner.js';
@@ -10,12 +9,6 @@ import { APIErrorResponse } from './src/utils.js';
 import { createX402Discovery } from './src/x402/discovery.js';
 
 const app = new Hono();
-
-// Response compression. Uses the runtime's CompressionStream — gzip and
-// deflate negotiated via Accept-Encoding. Most responses on the API are
-// JSON payloads that compress 5-10x; the OpenAPI document alone is
-// ~540KB uncompressed.
-app.use(compress());
 
 // Tracking all incoming requests
 app.use(async (c: Context, next) => {


### PR DESCRIPTION
## Summary

Drops the Hono `compress()` middleware from `index.ts`. Response compression is moving to the Caddy `encode` layer so it applies uniformly across every route — including authenticated paths going through the gateway, which currently strip `Accept-Encoding` before forwarding upstream and therefore receive identity from Hono regardless.

Keeping the app-side encoder alongside Caddy-side `encode` would either double-encode or be silently bypassed depending on directive order. Cleaner to drop it.

No external surface change — Caddy will handle compression negotiation downstream once the encode directive is in place.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)