### PR TITLE
chore(skill): make SKILL.md OKF-compatible

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,10 +1,15 @@
 ---
 name: pinax-api
+type: skill
+title: Pinax API
 description: >
   Query Pinax API datasets, including Token API for EVM/SVM/TVM token data,
   prediction markets, and perp exchange data. Use when: integrating with Pinax
   API, choosing endpoints, building API requests, handling pagination, or
   discovering supported networks.
+resource: https://api.pinax.network
+tags: [pinax, token-api, evm, svm, tvm, polymarket, hyperliquid, blockchain]
+timestamp: 2026-06-19T00:00:00Z
 ---
 
 # Pinax API


### PR DESCRIPTION
## What

Adds [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) frontmatter to `skills/SKILL.md` so it parses as a conformant OKF concept document, while staying a valid Claude Code skill file.

## Why

OKF (Google Cloud, v0.1) is a vendor-neutral markdown spec for agent-consumable knowledge. A conformant concept document MUST carry a non-empty `type` field and SHOULD carry `title`, `description`, `resource`, `tags`, and `timestamp`. Our `SKILL.md` previously had only the Claude Code `name`/`description` fields.

## Changes

```yaml
name: pinax-api          # retained (Claude Code skill discovery)
type: skill              # OKF-mandatory
title: Pinax API         # OKF recommended
description: >           # retained — serves both formats
  ...
resource: https://api.pinax.network
tags: [pinax, token-api, evm, svm, tvm, polymarket, hyperliquid, blockchain]
timestamp: 2026-06-19T00:00:00Z
```

- Only the YAML frontmatter changed; the document body is untouched.
- OKF consumers must preserve/tolerate unknown keys, so `name` remains for Claude Code skill discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)