### PR TITLE
fix(ohlcv): bound pool OHLC queries to recent candles for perf (#582)

### DIFF
--- a/dbs-config.yaml.example
+++ b/dbs-config.yaml.example
@@ -22,7 +22,7 @@ networks:
     transfers: mainnet:evm-transfers@v0.2.2
     balances: mainnet:evm-balances@v0.2.3
     nfts: mainnet:evm-nft-tokens@v0.6.2
-    dexes: mainnet:evm-dex@v0.2.6
+    dexes: mainnet:evm-dex@v0.5.0
     contracts: mainnet:evm-contracts@v0.3.0
 
   # SVM Networks
@@ -33,14 +33,14 @@ networks:
     balances: solana:svm-balances@v0.3.2
     accounts: solana:svm-accounts@v0.3.0
     metadata: solana:svm-metadata@v0.3.1
-    dexes: solana:svm-dex@v0.4.4
+    dexes: solana:svm-dex@v0.5.2
 
   # TVM Networks
   tron:
     type: tvm
     cluster: b
     transfers: tron:evm-transfers@v0.2.3
-    dexes: tron:evm-dex@v0.2.6
+    dexes: tron:evm-dex@v0.5.0
 
   # Polymarket
   polymarket:

--- a/src/routes/ohlcv/evm.sql
+++ b/src/routes/ohlcv/evm.sql
@@ -1,4 +1,29 @@
 WITH
+window_bound AS (
+    /* Find the timestamp cutoff of the most-recent (limit+offset) candles by
+       scanning ONLY the cheap `timestamp` column of the underlying state table.
+       `ohlc_prices` is a GROUP BY view over `state_ohlc_prices`; querying it
+       without a lower time bound forces the merge of the pool's ENTIRE history
+       (multi-GB reads, multi-second, GBs of memory) before ORDER BY ... LIMIT
+       can discard almost all of it. Bounding the view to this cutoff keeps the
+       result identical while reading only the needed tail. The excluded-protocol
+       filter is applied here too so each counted bucket has a surviving row. */
+    SELECT min(bucket) AS min_ts
+    FROM
+    (
+        SELECT toStartOfInterval(timestamp, INTERVAL {interval:UInt64} MINUTE) AS bucket
+        FROM {db_dex:Identifier}.state_ohlc_prices
+        WHERE interval_min = {interval: UInt64}
+            AND pool = {pool: String}
+            AND (isNull({start_time:Nullable(UInt64)}) OR timestamp >= toDateTime({start_time:Nullable(UInt64)}))
+            AND (isNull({end_time:Nullable(UInt64)})   OR timestamp <= toDateTime({end_time:Nullable(UInt64)}))
+            AND toString(protocol) NOT IN {excluded_protocols:Array(String)}
+        GROUP BY bucket
+        ORDER BY bucket DESC
+        LIMIT  {limit:UInt64}
+        OFFSET {offset:UInt64}
+    )
+),
 ohlc_raw AS (
     /* Read the LIMIT'd window of OHLC rows first so the downstream metadata
        lookup is bounded to the tokens that actually appear in the result. */
@@ -20,6 +45,8 @@ ohlc_raw AS (
         AND p.pool = {pool: String}
         AND (isNull({start_time:Nullable(UInt64)}) OR p.timestamp >= toDateTime({start_time:Nullable(UInt64)}))
         AND (isNull({end_time:Nullable(UInt64)})   OR p.timestamp <= toDateTime({end_time:Nullable(UInt64)}))
+        /* Restrict the heavy state-merge view to the most-recent buckets found above. */
+        AND p.timestamp >= (SELECT min_ts FROM window_bound)
 
         /* Protocols whose substreams decoders are known to emit duplicates of another
            protocol. List maintained in EXCLUDED_EVM_PROTOCOLS in src/config.ts. */

--- a/src/routes/ohlcv/svm.sql
+++ b/src/routes/ohlcv/svm.sql
@@ -1,4 +1,32 @@
-WITH ohlc AS
+WITH
+/* Find the timestamp cutoff of the most-recent (limit+offset) candles FIRST.
+   This only reads/aggregates the cheap `timestamp` column to enumerate distinct
+   buckets, so it can use the primary key and stop early — unlike the main query
+   below, whose argMin/quantile/uniq state-merges are expensive to read.
+   Without this bound the main GROUP BY has to merge the pool's ENTIRE history
+   before ORDER BY ... LIMIT can discard it, which is what makes high-activity
+   pools take >10s and time out (500). The cutoff preserves exact semantics:
+   `timestamp >= min_bucket` selects precisely the most-recent buckets, including
+   for sparse pools whose candles span a much wider wall-clock range than
+   interval*limit. */
+window_bound AS
+(
+    SELECT min(bucket) AS min_ts
+    FROM
+    (
+        SELECT toStartOfInterval(timestamp, INTERVAL {interval:UInt64} MINUTE) AS bucket
+        FROM {db_dex:Identifier}.state_ohlc_prices
+        WHERE interval_min = {interval: UInt64}
+        AND amm_pool = {amm_pool: String}
+        AND (isNull({start_time:Nullable(UInt64)}) OR timestamp >= toDateTime({start_time:Nullable(UInt64)}))
+        AND (isNull({end_time:Nullable(UInt64)}) OR timestamp <= toDateTime({end_time:Nullable(UInt64)}))
+        GROUP BY bucket
+        ORDER BY bucket DESC
+        LIMIT {limit: UInt64}
+        OFFSET {offset: UInt64}
+    )
+),
+ohlc AS
 (
     SELECT
         if(
@@ -23,6 +51,8 @@ WITH ohlc AS
     AND amm_pool = {amm_pool: String}
     AND (isNull({start_time:Nullable(UInt64)}) OR timestamp >= toDateTime({start_time:Nullable(UInt64)}))
     AND (isNull({end_time:Nullable(UInt64)}) OR timestamp <= toDateTime({end_time:Nullable(UInt64)}))
+    /* Restrict the heavy state-merge to the most-recent buckets found above. */
+    AND o.timestamp >= (SELECT min_ts FROM window_bound)
     GROUP BY token0, token1, amm, amm_pool, datetime
     ORDER BY datetime DESC
     LIMIT {limit: UInt64}


### PR DESCRIPTION
Fixes the slow pool-OHLC queries and intermittent 500s reported in #582 (customer charting use case).

## Problem

The pool OHLC endpoints aggregate `AggregateFunction` state rows via a **blocking `GROUP BY`**. With no lower time bound, the query merges the pool's **entire history** before `ORDER BY … LIMIT` can discard it. High-activity pools therefore read GBs and take multiple seconds — the cause of the >10s calls and `500 internal_server_error` timeouts in the report (especially under the client's 5× concurrency).

This affects **SVM, EVM, and TVM** (TVM reuses `evm.sql`). EVM was actually the worst: a single hot-pool query read **1.56 GiB / 5.1 GB RAM**.

## Fix

Add a lightweight `window_bound` CTE that finds the timestamp cutoff of the most-recent `(limit+offset)` candles by scanning **only the cheap `timestamp` column** of `state_ohlc_prices`, then constrain the heavy aggregation with `timestamp >= cutoff`.

- **Results are byte-identical** (verified on production across 5 presets/pools), including for **sparse pools** whose candles span a much wider wall-clock range than `interval×limit` — so this is *not* the unsafe "default a time window" approach.
- Same query parameters, no handler/schema/API-contract change.
- The excluded-protocol filter is applied inside `window_bound` (EVM) so every counted bucket has a surviving row.

## Benchmarks (production, `FORMAT Null`, `use_query_cache=0`)

| query | before | after |
|---|---|---|
| SVM 1h · 1m/60 | 830–1240 ms · 210 MiB · **815 MiB RAM** | **120–200 ms · 16 MiB · 42 MiB** |
| SVM 1d · 5m/288 | 980–1450 ms | **160–250 ms** |
| SVM 1m · 4h/180 | 1189 ms | **259 ms** |
| EVM 1m/100 (hot pool) | 3270 ms · 1.56 GiB · **5133 MiB RAM** | **155 ms · 262 MiB · 314 MiB** |

**~7–21× faster, ~6–16× less memory.** The per-query memory collapse is what relieves the concurrency contention producing the 500s.

**Trade-off:** coarse intervals (1h/1w) with little history regress by tens of ms (extra timestamp pass) but stay far under budget. `SETTINGS optimize_aggregation_in_order=1` was tried and rejected — it doesn't prune (bytes unchanged) and made the 1h case slower.

## Also

- Bump `dbs-config.yaml.example` dex versions to match production: `svm-dex@v0.5.2`, `mainnet:evm-dex@v0.5.0`, `tron:evm-dex@v0.5.0`.

## Validation notes

- SQL imports + `normalizeSQL()` clean; parameter sets unchanged.
- Benchmarked directly against production `state_ohlc_prices` (`solana:svm-dex@v0.5.2` 5.8B rows; `mainnet:evm-dex@v0.5.0`), result parity confirmed.
- ⚠️ Not yet covered by an automated perf test — recommend adding a `DB_TESTS=true` assertion pinned to the #582 outlier pools as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)